### PR TITLE
Accept local links without checking them.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,7 +44,7 @@ validate_links_task:
     <<: *CONTAINER_DEFINITION   
     dockerfile: Dockerfile
     cpu: 1
-    memory: 1G
+    memory: 2G
   tests_script:
     - ./validate_links.sh
 

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -11,7 +11,10 @@ def show_files(filenames):
   for filename in filenames:
     print(filename)
 
-def live_url(url):
+def live_url(url: str):
+  if url.startswith('#'):
+    return True
+
   code=None
   req = Request(
     url, 

--- a/validate_links.sh
+++ b/validate_links.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 #validate links in asciidoc
 mkdir -p out
-asciidoctor -R rules -D out '**/*.adoc' 
+asciidoctor -R rules -D out 'rules/**/*.adoc'
 cd rspec-tools
 pipenv install -e .
 pipenv run rspec-tools check-links --d ../out


### PR DESCRIPTION
The validation fails because of a local link we have in the project's README.adoc.