### PR TITLE
RULEAPI-624 Fix the RSPEC index in the presense of PRs with noncompliant file structure.

### DIFF
--- a/frontend/src/deployment/index.ts
+++ b/frontend/src/deployment/index.ts
@@ -12,6 +12,8 @@ import { process_incomplete_rspecs, PullRequest } from './pullRequestIndexing';
 
 import { PR_DIRECTORY, RULE_SRC_DIRECTORY, RULE_DST_DIRECTORY } from './paths';
 
+process.on('unhandledRejection', up => { throw up })
+
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs(process.argv.slice(2))
 

--- a/frontend/src/deployment/pullRequestIndexing.ts
+++ b/frontend/src/deployment/pullRequestIndexing.ts
@@ -44,6 +44,9 @@ export async function process_incomplete_rspecs(tmpRepoDir: string,
   for (const pull of pulls) {
     const ref = await repo.getBranch('refs/remotes/origin/pr/' + pull.pull_id);
     await repo.checkoutRef(ref);
-    process(path.join(tmpRepoDir, 'rules', pull.rspec_id), pull);
+    const ruleDir = path.join(tmpRepoDir, 'rules', pull.rspec_id);
+    if (fs.existsSync(ruleDir)) {
+      process(ruleDir, pull);
+    }
   }
 }

--- a/frontend/src/deployment/pullRequestIndexing.ts
+++ b/frontend/src/deployment/pullRequestIndexing.ts
@@ -2,6 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import { Octokit } from '@octokit/rest';
 import Git from 'nodegit';
+import { logger as rootLogger } from './deploymentLogger';
+
+const logger = rootLogger.child({ source: path.basename(__filename) })
 
 export interface PullRequest {
   rspec_id: string,
@@ -47,6 +50,8 @@ export async function process_incomplete_rspecs(tmpRepoDir: string,
     const ruleDir = path.join(tmpRepoDir, 'rules', pull.rspec_id);
     if (fs.existsSync(ruleDir)) {
       process(ruleDir, pull);
+    } else {
+      logger.error(`No rule dir rules/${pull.rspec_id} is found for the PR#${pull.pull_id}: ${pull.url}`);
     }
   }
 }


### PR DESCRIPTION
1. Force the deployment to fail for any unexpected failure in the indexing of the un-merged open PRs (for the non implemented rules).
2. Ignore the PRs that promise to create a certain rule (i.e. "Create rule S1234") and fail to deliver on that promise: have no folder `rules/S1234`.