### PR TITLE
RULEAPI-616: Stabilize the link validation CI check by preserving the probing results between runs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,6 +45,11 @@ validate_links_task:
     dockerfile: Dockerfile
     cpu: 1
     memory: 2G
+  env:
+    LINK_CACHE_NAME: link-probing-status
+    LINK_CACHE_PATH: /root/link-probing-history.cache
   tests_script:
-    - ./validate_links.sh
+    - bash ci/cirrus-cache.sh download ${LINK_CACHE_NAME} ${LINK_CACHE_PATH}
+    - ./validate_links.sh ${LINK_CACHE_PATH}
+    - bash ci/cirrus-cache.sh upload ${LINK_CACHE_NAME} ${LINK_CACHE_PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim-buster
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor pipenv git
+    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor pipenv git curl
    
 CMD ["bash"]

--- a/ci/cirrus-cache.sh
+++ b/ci/cirrus-cache.sh
@@ -6,15 +6,10 @@ ACTION=${1}
 CACHE_NAME=${2}
 PATH_TO_CACHE=${3}
 
-# replacing / with ___ feature/xyz becomes feature___xyz
-DEFAULT_NAME=${CIRRUS_DEFAULT_BRANCH//\//___}
-CURRENT_NAME=${CIRRUS_BRANCH//\//___}
-
-CACHE_KEY=${CACHE_NAME}-${CURRENT_NAME}
-DEFAULT_CACHE_KEY=${CACHE_NAME}-${DEFAULT_NAME}
+CACHE_KEY=${CACHE_NAME}
+DEFAULT_CACHE_KEY=${CACHE_NAME}
 
 CACHE_URL=http://${CIRRUS_HTTP_CACHE_HOST}/${CACHE_KEY}
-CACHE_DEFAULT_URL=http://${CIRRUS_HTTP_CACHE_HOST}/${DEFAULT_CACHE_KEY}
 
 TMP_PATH=/tmp/tmp-cache.tgz
 
@@ -24,12 +19,9 @@ download)
   echo "Download cache with key ${CACHE_KEY}"
 
   echo "  -> try ${CACHE_URL}"
-  curl -sfSL -o ${TMP_PATH} ${CACHE_URL} || {
-    echo "  -> try default branch cache ${CACHE_DEFAULT_URL}"
-    curl -sfSL -o ${TMP_PATH} ${CACHE_DEFAULT_URL} || {
-      echo "Cache download failed";
-      exit 0;
-    }
+  curl -sfSL -o ${TMP_PATH} ${CACHE_URL} {
+    echo "Cache download failed";
+    exit 0;
   }
   du -hs ${TMP_PATH}
   tar -Pxzf ${TMP_PATH}

--- a/ci/cirrus-cache.sh
+++ b/ci/cirrus-cache.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+set -euo pipefail
+
+ACTION=${1}
+CACHE_NAME=${2}
+PATH_TO_CACHE=${3}
+
+# replacing / with ___ feature/xyz becomes feature___xyz
+DEFAULT_NAME=${CIRRUS_DEFAULT_BRANCH//\//___}
+CURRENT_NAME=${CIRRUS_BRANCH//\//___}
+
+CACHE_KEY=${CACHE_NAME}-${CURRENT_NAME}
+DEFAULT_CACHE_KEY=${CACHE_NAME}-${DEFAULT_NAME}
+
+CACHE_URL=http://${CIRRUS_HTTP_CACHE_HOST}/${CACHE_KEY}
+CACHE_DEFAULT_URL=http://${CIRRUS_HTTP_CACHE_HOST}/${DEFAULT_CACHE_KEY}
+
+TMP_PATH=/tmp/tmp-cache.tgz
+
+case "${ACTION}" in
+
+download)
+  echo "Download cache with key ${CACHE_KEY}"
+
+  echo "  -> try ${CACHE_URL}"
+  curl -sfSL -o ${TMP_PATH} ${CACHE_URL} || {
+    echo "  -> try default branch cache ${CACHE_DEFAULT_URL}"
+    curl -sfSL -o ${TMP_PATH} ${CACHE_DEFAULT_URL} || {
+      echo "Cache download failed";
+      exit 0;
+    }
+  }
+  du -hs ${TMP_PATH}
+  tar -Pxzf ${TMP_PATH}
+  rm ${TMP_PATH}
+  ;;
+
+upload)
+  echo "Upload cache to ${CACHE_URL}"
+  tar -Pczf ${TMP_PATH} ${PATH_TO_CACHE}
+  du -hs ${TMP_PATH}
+  curl -s -X POST --data-binary @${TMP_PATH} ${CACHE_URL}
+  ;;
+
+*)
+  echo "Unexpected cache ACTION: ${ACTION}"
+  exit 1
+  ;;
+
+esac

--- a/ci/cirrus-cache.sh
+++ b/ci/cirrus-cache.sh
@@ -19,7 +19,7 @@ download)
   echo "Download cache with key ${CACHE_KEY}"
 
   echo "  -> try ${CACHE_URL}"
-  curl -sfSL -o ${TMP_PATH} ${CACHE_URL} {
+  curl -sfSL -o ${TMP_PATH} ${CACHE_URL} || {
     echo "Cache download failed";
     exit 0;
   }

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -63,8 +63,6 @@ def url_was_reached_recently(url: str):
 def live_url(url: str, timeout=5):
   if url.startswith('#'):
     return True
-  if url in EXCEPTIONS:
-    return True
   try:
     req = requests.Request('GET', url, headers = {'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90"',
                                                   'sec-ch-ua-mobile': '?0',
@@ -152,7 +150,11 @@ def check_html_links(dir):
   print("Testing links")
   for url in urls:
     print(f"{url} in {len(urls[url])} files")
-    if url_was_reached_recently(url):
+    if url in EXCEPTIONS:
+      global link_probes_history
+      link_probes_history.pop(url)
+      print("skip as an exception")
+    elif url_was_reached_recently(url):
       print("skip probing because it was reached recently")
     elif live_url(url, timeout=5):
       rejuvenate_url(url)

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 import pathlib
 
 TOLERABLE_LINK_DOWNTIME = timedelta(days=7)
-LINK_PROBES_HISTORY_FILE = 'link_probes.history'
+LINK_PROBES_HISTORY_FILE = './link_probes.history'
 PROBING_COOLDOWN = timedelta(days=1)
 PROBING_SPREAD = 100 # minutes
 link_probes_history = {}
@@ -25,20 +25,22 @@ def show_files(filenames):
     print(filename)
 
 def load_url_probing_history():
-    global link_probes_history
-    try:
-        with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
-            print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
-            link_probes_history = eval(link_probes_history_stream.read())
-            print(link_probes_history)
-    except Exception:
-        # If the history file is not present, ignore, will create one in the end.
-        pass
+  global link_probes_history
+  print('Trying to load probing history from ' + LINK_PROBES_HISTORY_FILE)
+  print(os.listdir('.'))
+  try:
+    with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
+      print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
+      link_probes_history = eval(link_probes_history_stream.read())
+      print(link_probes_history)
+  except Exception:
+    # If the history file is not present, ignore, will create one in the end.
+    pass
 
 def save_url_probing_history():
-    global link_probes_history
-    with open(LINK_PROBES_HISTORY_FILE, 'w') as link_probes_history_stream:
-        link_probes_history_stream.write(str(link_probes_history))
+  global link_probes_history
+  with open(LINK_PROBES_HISTORY_FILE, 'w') as link_probes_history_stream:
+    link_probes_history_stream.write(str(link_probes_history))
 
 def rejuvenate_url(url: str):
   global link_probes_history

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,9 +16,7 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
-              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
-              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall'']
 
 def show_files(filenames):
   for filename in filenames:
@@ -26,17 +24,13 @@ def show_files(filenames):
 
 def load_url_probing_history():
   global link_probes_history
-  print('Trying to load probing history from ' + LINK_PROBES_HISTORY_FILE)
-  print(os.listdir('.'))
   try:
     with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
-      print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
-      blob = link_probes_history_stream.read()
-      link_probes_history = eval(blob)
-      print(link_probes_history)
+      print('Using the historical url-probe results from ' + LINK_PROBES_HISTORY_FILE)
+      link_probes_history = eval(link_probes_history_stream.read())
   except Exception as e:
-    print(e)
     # If the history file is not present, ignore, will create one in the end.
+    print(f"Failed to load historical url-probe results: {e}")
     pass
 
 def save_url_probing_history():
@@ -64,7 +58,6 @@ def url_was_reached_recently(url: str):
   spread = random.randrange(PROBING_SPREAD)
   probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
   diff = (datetime.datetime.now() - last_time_up)
-  print(f"comparing {probing_cooldown} with the difference: {diff}")
   return (datetime.datetime.now() - last_time_up) < probing_cooldown
 
 def live_url(url: str, timeout=5):

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -33,8 +33,8 @@ def load_url_probing_history():
       print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
       link_probes_history = eval(link_probes_history_stream.read())
       print(link_probes_history)
-  except Exception:
-    print(Exception)
+  except Exception as e:
+    print(e)
     # If the history file is not present, ignore, will create one in the end.
     pass
 

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -57,7 +57,7 @@ def url_was_reached_recently(url: str):
     return False
   last_time_up = link_probes_history[url]
   spread = random.randrange(PROBING_SPREAD)
-  probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
+  probing_cooldown = PROBING_COOLDOWN + timedelta(minutes=spread)
   diff = (datetime.now() - last_time_up)
   print(f"comparing {probing_cooldown} with the difference: {diff}")
   return (datetime.now() - last_time_up) < probing_cooldown

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -134,6 +134,7 @@ def is_active(metadata_fname, generic_metadata_fname):
 def check_html_links(dir):  
   urls={}
   errors=[]
+  load_url_probing_history()
   print("Finding links in html files")
   tot_files = 0
   for rulepath in pathlib.Path(dir).iterdir():
@@ -174,4 +175,5 @@ def check_html_links(dir):
       print(f"{len(confirmed_errors)}/{len(urls)} links are dead, see the list and related files before")
       exit(1)
   print(f"All {len(urls)} links are good")
+  save_url_probing_history()
 

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -31,7 +31,9 @@ def load_url_probing_history():
   try:
     with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
       print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
-      link_probes_history = eval(link_probes_history_stream.read())
+      blob = link_probes_history_stream.read()
+      print(blob)
+      link_probes_history = eval(blob)
       print(link_probes_history)
   except Exception as e:
     print(e)

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -55,10 +55,8 @@ def url_was_reached_recently(url: str):
   if url not in link_probes_history:
     return False
   last_time_up = link_probes_history[url]
-  print(f"{url} was reached most recently on {last_time_up}")
   spread = random.randrange(PROBING_SPREAD)
   probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
-  diff = (datetime.datetime.now() - last_time_up)
   return (datetime.datetime.now() - last_time_up) < probing_cooldown
 
 def live_url(url: str, timeout=5):

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,10 +16,7 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
-
-              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
-              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
 ]
 
 def show_files(filenames):
@@ -156,8 +153,6 @@ def check_html_links(dir):
   for url in urls:
     print(f"{url} in {len(urls[url])} files")
     if url in EXCEPTIONS:
-      global link_probes_history
-      link_probes_history.pop(url, None)
       print("skip as an exception")
     elif url_was_reached_recently(url):
       print("skip probing because it was reached recently")

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -30,6 +30,7 @@ def load_url_probing_history():
         with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
             print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
             link_probes_history = eval(link_probes_history_stream.read())
+            print(link_probes_history)
     except Exception:
         # If the history file is not present, ignore, will create one in the end.
         pass

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -17,7 +17,6 @@ link_probes_history = {}
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
               'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
-]
 
 def show_files(filenames):
   for filename in filenames:

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,7 +16,11 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
+
+              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
+              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
+]
 
 def show_files(filenames):
   for filename in filenames:
@@ -55,6 +59,7 @@ def url_was_reached_recently(url: str):
   if url not in link_probes_history:
     return False
   last_time_up = link_probes_history[url]
+  print(f"{url} was reached most recently on {last_time_up}")
   spread = random.randrange(PROBING_SPREAD)
   probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
   diff = (datetime.datetime.now() - last_time_up)
@@ -105,7 +110,7 @@ def live_url(url: str, timeout=5):
     print(f"ERROR: ", e)
     return False
 
-def findurl_in_html(filename,urls):    
+def findurl_in_html(filename,urls):
   with open(filename, 'r', encoding="utf8") as file:
     soup = BeautifulSoup(file,features="html.parser")
     for link in soup.findAll('a'):
@@ -152,7 +157,7 @@ def check_html_links(dir):
     print(f"{url} in {len(urls[url])} files")
     if url in EXCEPTIONS:
       global link_probes_history
-      link_probes_history.pop(url)
+      link_probes_history.pop(url, None)
       print("skip as an exception")
     elif url_was_reached_recently(url):
       print("skip probing because it was reached recently")

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,7 +16,9 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
+              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
+              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
 
 def show_files(filenames):
   for filename in filenames:

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -11,6 +11,12 @@ TOLERABLE_LINK_DOWNTIME = timedelta(days=7)
 LINK_PROBES_HISTORY_FILE = 'link_probes.history'
 link_probes_history = {}
 
+# These links consistently fail in CI, but work-on-my-machine
+EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
+              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
+              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
+
 def show_files(filenames):
   for filename in filenames:
     print(filename)
@@ -29,10 +35,6 @@ def save_url_probing_history():
     global link_probes_history
     with open(LINK_PROBES_HISTORY_FILE, 'w') as link_probes_history_stream:
         link_probes_history_stream.write(str(link_probes_history))
-
-# These links consistently fail in CI, but work-on-my-machine
-EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
 
 def rejuvenate_url(url: str):
   global link_probes_history

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -3,14 +3,14 @@ import re
 import requests
 import json
 import random
+import datetime
 from bs4 import BeautifulSoup
 from socket import timeout
-from datetime import datetime, timedelta
 import pathlib
 
-TOLERABLE_LINK_DOWNTIME = timedelta(days=7)
+TOLERABLE_LINK_DOWNTIME = datetime.timedelta(days=7)
 LINK_PROBES_HISTORY_FILE = './link_probes.history'
-PROBING_COOLDOWN = timedelta(days=1)
+PROBING_COOLDOWN = datetime.timedelta(days=1)
 PROBING_SPREAD = 100 # minutes
 link_probes_history = {}
 
@@ -32,7 +32,6 @@ def load_url_probing_history():
     with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
       print('Using the historical url probe results from ' + LINK_PROBES_HISTORY_FILE)
       blob = link_probes_history_stream.read()
-      print(blob)
       link_probes_history = eval(blob)
       print(link_probes_history)
   except Exception as e:
@@ -47,7 +46,7 @@ def save_url_probing_history():
 
 def rejuvenate_url(url: str):
   global link_probes_history
-  link_probes_history[url] = datetime.now()
+  link_probes_history[url] = datetime.datetime.now()
 
 def url_is_long_dead(url: str):
   global link_probes_history
@@ -55,7 +54,7 @@ def url_is_long_dead(url: str):
     return True
   last_time_up = link_probes_history[url]
   print(f"{url} was reached most recently on {last_time_up}")
-  return TOLERABLE_LINK_DOWNTIME < (datetime.now() - last_time_up)
+  return TOLERABLE_LINK_DOWNTIME < (datetime.datetime.now() - last_time_up)
 
 def url_was_reached_recently(url: str):
   global link_probes_history
@@ -63,10 +62,10 @@ def url_was_reached_recently(url: str):
     return False
   last_time_up = link_probes_history[url]
   spread = random.randrange(PROBING_SPREAD)
-  probing_cooldown = PROBING_COOLDOWN + timedelta(minutes=spread)
-  diff = (datetime.now() - last_time_up)
+  probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
+  diff = (datetime.datetime.now() - last_time_up)
   print(f"comparing {probing_cooldown} with the difference: {diff}")
-  return (datetime.now() - last_time_up) < probing_cooldown
+  return (datetime.datetime.now() - last_time_up) < probing_cooldown
 
 def live_url(url: str, timeout=5):
   if url.startswith('#'):

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,9 +16,7 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall',
-              'https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/',
-              'https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
 
 def show_files(filenames):
   for filename in filenames:

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -16,7 +16,7 @@ link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTIONS = ['https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https',
-              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall'']
+              'https://blogs.oracle.com/oraclemagazine/oracle-10g-adds-more-to-forall']
 
 def show_files(filenames):
   for filename in filenames:

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -58,6 +58,8 @@ def url_was_reached_recently(url: str):
   last_time_up = link_probes_history[url]
   spread = random.randrange(PROBING_SPREAD)
   probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
+  diff = (datetime.now() - last_time_up)
+  print(f"comparing {probing_cooldown} with the difference: {diff}")
   return (datetime.now() - last_time_up) < probing_cooldown
 
 def live_url(url: str, timeout=5):
@@ -153,7 +155,7 @@ def check_html_links(dir):
   for url in urls:
     print(f"{url} in {len(urls[url])} files")
     if url_was_reached_recently(url):
-      printf("skip probing because it was reached recently")
+      print("skip probing because it was reached recently")
     elif live_url(url, timeout=5):
       rejuvenate_url(url)
     elif url_is_long_dead(url):

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -34,6 +34,7 @@ def load_url_probing_history():
       link_probes_history = eval(link_probes_history_stream.read())
       print(link_probes_history)
   except Exception:
+    print(Exception)
     # If the history file is not present, ignore, will create one in the end.
     pass
 

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -4,10 +4,10 @@ import requests
 import json
 from bs4 import BeautifulSoup
 from socket import timeout
-from datetime import datetime
+from datetime import datetime, timedelta
 import pathlib
 
-TOLERABLE_LINK_DOWNTIME = datetime.timedelta(days=7)
+TOLERABLE_LINK_DOWNTIME = timedelta(days=7)
 LINK_PROBES_HISTORY_FILE = 'link_probes.history'
 link_probes_history = {}
 

--- a/validate_links.sh
+++ b/validate_links.sh
@@ -6,7 +6,7 @@ echo "CACHE_PATH: $CACHE_PATH"
 [ ! -d $CACHE_PATH ] && mkdir $CACHE_PATH
 ls -al $CACHE_PATH
 
-[ -f "$CACHE_PATH/link_probes.history" ] && cp "$CACHE_PATH/link_probes.history" ./
+[ -f "$CACHE_PATH/link_probes.history" ] && cp "$CACHE_PATH/link_probes.history" ./rspec-tools/
 
 ./generate_html.sh
 
@@ -14,5 +14,6 @@ ls -al $CACHE_PATH
 cd rspec-tools
 pipenv install -e .
 pipenv run rspec-tools check-links --d ../out
+cd ..
 
-cp ./link_probes.history "$CACHE_PATH/"
+cp ./rspec-tools/link_probes.history "$CACHE_PATH/"

--- a/validate_links.sh
+++ b/validate_links.sh
@@ -13,7 +13,6 @@ ls -al $CACHE_PATH
 #validate links in asciidoc
 cd rspec-tools
 pipenv install -e .
-ls -al .
 pipenv run rspec-tools check-links --d ../out
 cd ..
 

--- a/validate_links.sh
+++ b/validate_links.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+CACHE_PATH=$1
+echo "CACHE_PATH: $CACHE_PATH"
+[ ! -d $CACHE_PATH ] && mkdir $CACHE_PATH
+ls -al $CACHE_PATH
+
+[ -f "$CACHE_PATH/link_probes.history" ] && cp "$CACHE_PATH/link_probes.history" ./
+
 ./generate_html.sh
 
 #validate links in asciidoc
 cd rspec-tools
 pipenv install -e .
 pipenv run rspec-tools check-links --d ../out
+
+cp ./link_probes.history "$CACHE_PATH/"

--- a/validate_links.sh
+++ b/validate_links.sh
@@ -13,6 +13,7 @@ ls -al $CACHE_PATH
 #validate links in asciidoc
 cd rspec-tools
 pipenv install -e .
+ls -al .
 pipenv run rspec-tools check-links --d ../out
 cd ..
 


### PR DESCRIPTION
two fluentcpp links (in S5402 and S5419) that are down now are injected into the url-probing history, so they will not fail the link validation for the following 7 days. If fluentcpp.com is still down by then, I suppose, we will have to remove or replace them.