### PR TITLE
add owasp mobile security standard to schema validation

### DIFF
--- a/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
+++ b/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
@@ -116,6 +116,13 @@
           "items": { "type": "string" },
           "uniqueItems": true,
           "pattern": "A([0-9]|10)"
+        },
+        "OWASP Mobile": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "M([0-9]|10)"
         }
       }
     }


### PR DESCRIPTION
New security standard "OWASP Mobile": https://owasp.org/www-project-mobile-top-10/

Always starts with a `M`, eg: `M1`, `M2` ... `M10`

Is was used in Jira for some current RSPECs: https://jira.sonarsource.com/browse/RSPEC-5605
but metadata standards on subtask/languages [were not migrated](https://github.com/SonarSource/rspec/blob/master/rules/S5604/xml/metadata.json)