### PR TITLE
add missing and future security standards

### DIFF
--- a/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
+++ b/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
@@ -117,6 +117,13 @@
           "uniqueItems": true,
           "pattern": "A([0-9]|10)"
         },
+        "OWASP Mobile": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "M([0-9]|10)"
+        },
         "PCI DSS": {
           "type": "array",
           "minItems": 0,

--- a/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
+++ b/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
@@ -117,12 +117,40 @@
           "uniqueItems": true,
           "pattern": "A([0-9]|10)"
         },
-        "OWASP Mobile": {
+        "PCI DSS": {
           "type": "array",
           "minItems": 0,
           "items": { "type": "string" },
           "uniqueItems": true,
-          "pattern": "M([0-9]|10)"
+          "pattern": "([0-9]{1,3}\\.?){1,3}"
+        },
+        "CIS": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "([0-9]{1,3}\\.?){1,3}"
+        },
+        "HIPAA": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "([0-9]{1,3}\\.?){2}"
+        },
+        "CERT": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "[A-Z0-9]+-[A-Z]+\\."
+        },
+        "MASVS": {
+          "type": "array",
+          "minItems": 0,
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "pattern": "MSTG-[A-Z]+-[0-9]+"
         }
       }
     }


### PR DESCRIPTION
* PCI DSS:  https://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard, three numbers maximum separated by dots: `4.1.2`, `6.1.2`
* CIS: https://www.cisecurity.org/controls/cis-controls-list/, three numbers maximum separated by dots: `4.1.2`, `6.1.2`
* HIPAA: https://hipaaone.com/wp-content/uploads/2019/06/HIPAA-Security-Checklist.pdf, two numbers maximum separated by a dot, examples: `164.312`, `164.314`
* CERT: https://resources.sei.cmu.edu/downloads/secure-coding/assets/sei-cert-c-coding-standard-2016-v01.pdf, two alphanumerical strings separated by a dash and ending by a dot, examples: `PRE30-C.`, `FIO30-C.`
* MASVS: https://mobile-security.gitbook.io/masvs/security-requirements/0x06-v1-architecture_design_and_threat_modelling_requireme, `MSTG` followed  by a dash then alphabetical string, followed by a dash then a number, examples: `MSTG-ARCH-1`, `MSTG-CRYPTO-1`