### PR TITLE
Create rule S6288[java]: Authorizing non-authenticated users to use keys in the Android KeyStore is security-sensitive

### DIFF
--- a/rules/S6288/java/rule.adoc
+++ b/rules/S6288/java/rule.adoc
@@ -1,4 +1,43 @@
-include::../rule.adoc[]
+include::../description.adoc[]
+
+include::../ask-yourself.adoc[]
+
+include::../recommended.adoc[]
+
+== Noncompliant Code Example
+
+Any users can use the key: 
+
+----
+KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
+
+KeyGenParameterSpec builder = new KeyGenParameterSpec.Builder("test_secret_key_noncompliant",KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT) // Noncompliant (s6288)
+    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+    .build();
+
+keyGenerator.init(builder);
+----
+
+== Compliant Solution
+
+The use of the key is limited to authenticated users (for a duration of time defined to 60 seconds):
+
+----
+KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
+
+KeyGenParameterSpec builder = new KeyGenParameterSpec.Builder("test_secret_key", KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+    .setUserAuthenticationRequired(true) // Compliant
+    .setUserAuthenticationParameters (60, KeyProperties.AUTH_DEVICE_CREDENTIAL)
+    .build();
+
+keyGenerator.init(builder)
+----
+
+include::../see.adoc[]
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S6288/java/rule.adoc
+++ b/rules/S6288/java/rule.adoc
@@ -6,12 +6,12 @@ include::../recommended.adoc[]
 
 == Noncompliant Code Example
 
-Any users can use the key: 
+Any user can use the key: 
 
 ----
 KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
 
-KeyGenParameterSpec builder = new KeyGenParameterSpec.Builder("test_secret_key_noncompliant",KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT) // Noncompliant (s6288)
+KeyGenParameterSpec builder = new KeyGenParameterSpec.Builder("test_secret_key_noncompliant", KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT) // Noncompliant
     .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
     .build();
@@ -29,7 +29,7 @@ KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM
 KeyGenParameterSpec builder = new KeyGenParameterSpec.Builder("test_secret_key", KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
     .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-    .setUserAuthenticationRequired(true) // Compliant
+    .setUserAuthenticationRequired(true) 
     .setUserAuthenticationParameters (60, KeyProperties.AUTH_DEVICE_CREDENTIAL)
     .build();
 


### PR DESCRIPTION
https://jira.sonarsource.com/browse/SONARJAVA-3868