### PR TITLE
Remove fluentcpp dead links

### DIFF
--- a/rules/S5402/cfamily/rule.adoc
+++ b/rules/S5402/cfamily/rule.adoc
@@ -98,7 +98,6 @@ Exceptions classes must be copyable. Hence, this rule does not apply to exceptio
 
 == See
 
-* https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/[Make polymorphic copy modern]
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c67-a-polymorphic-class-should-suppress-copying[{cpp} Core Guidelines C.67] - A polymorphic class should suppress copying
 
 

--- a/rules/S5419/cfamily/rule.adoc
+++ b/rules/S5419/cfamily/rule.adoc
@@ -50,7 +50,6 @@ double f() {
 
 == See
 
-* Strong types: https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#i4-make-interfaces-precisely-and-strongly-typed[{cpp} Core Guidelines I.4] - Make interfaces precisely and strongly typed
 
 


### PR DESCRIPTION
These links are dead for a long time now, and there are already links to C++ Core Guidelines