### PR TITLE
RULEAPI-664: Revert "RULEAPI-609 Support superseded rules" (quickfix)

### DIFF
--- a/rules/S1145/abap/rule.adoc
+++ b/rules/S1145/abap/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/apex/rule.adoc
+++ b/rules/S1145/apex/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/cfamily/rule.adoc
+++ b/rules/S1145/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/csharp/rule.adoc
+++ b/rules/S1145/csharp/rule.adoc
@@ -1,25 +1,23 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
 
 ----
-if (true)
-{
-  DoSomething();
+if (true) 
+{  
+  DoSomething(); 
 }
 ...
-if (false)
+if (false) 
 {
-  DoSomethingElse();
+  DoSomethingElse(); 
 }
 ----
 
 == Compliant Solution
 
 ----
-DoSomething();
+DoSomething(); 
 ...
 ----
 

--- a/rules/S1145/flex/rule.adoc
+++ b/rules/S1145/flex/rule.adoc
@@ -1,16 +1,14 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
 
 ----
-if (true) {
-  doSomething();
+if (true) {  
+  doSomething(); 
 }
 ...
-if (false) {
-  doSomethingElse();
+if (false) {  
+  doSomethingElse(); 
 }
 ----
 

--- a/rules/S1145/go/rule.adoc
+++ b/rules/S1145/go/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/java/rule.adoc
+++ b/rules/S1145/java/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/javascript/rule.adoc
+++ b/rules/S1145/javascript/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/kotlin/rule.adoc
+++ b/rules/S1145/kotlin/rule.adoc
@@ -1,15 +1,13 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
 
 ----
-if (true) {
+if (true) {  
   doSomething()
 }
 ...
-if (false) {
+if (false) {  
   doSomethingElse()
 }
 ----

--- a/rules/S1145/php/rule.adoc
+++ b/rules/S1145/php/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/pli/rule.adoc
+++ b/rules/S1145/pli/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/plsql/rule.adoc
+++ b/rules/S1145/plsql/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 ``++IF++`` statements with conditions that are always false have the effect of making blocks of code non-functional. This can be useful during debugging, but should not be checked in. ``++IF++`` statements with conditions that are always true are completely redundant, and make the code less readable. In either case, unconditional ``++IF++`` statements should be removed.
 
 == Noncompliant Code Example

--- a/rules/S1145/python/rule.adoc
+++ b/rules/S1145/python/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/rpg/rule.adoc
+++ b/rules/S1145/rpg/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/ruby/rule.adoc
+++ b/rules/S1145/ruby/rule.adoc
@@ -1,15 +1,13 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
 
 ----
-if true
+if true 
   doSomething()
 end
 ...
-if false
+if false 
   doSomethingElse()
 end
 ----

--- a/rules/S1145/rule.adoc
+++ b/rules/S1145/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::description.adoc[]
 
 include::noncompliant.adoc[]

--- a/rules/S1145/scala/rule.adoc
+++ b/rules/S1145/scala/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/swift/rule.adoc
+++ b/rules/S1145/swift/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1145/vb6/rule.adoc
+++ b/rules/S1145/vb6/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1145/vbnet/rule.adoc
+++ b/rules/S1145/vbnet/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
@@ -17,7 +15,7 @@ include::../description.adoc[]
 == Compliant Solution
 
 ----
-DoSomething();
+DoSomething(); 
 ' ...
 ----
 

--- a/rules/S1154/javascript/rule.adoc
+++ b/rules/S1154/javascript/rule.adoc
@@ -1,6 +1,4 @@
-//// This rule is superseded by RSPEC-2201
-//// Please consider implementing this latter instead.
-Doing an operation on a string without using the result of the operation is useless and is certainly due to a misunderstanding.
+Doing an operation on a string without using the result of the operation is useless and is certainly due to a misunderstanding. 
 
 
 == Noncompliant Code Example

--- a/rules/S1697/csharp/rule.adoc
+++ b/rules/S1697/csharp/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2259
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1697/java/rule.adoc
+++ b/rules/S1697/java/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2259
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1697/javascript/rule.adoc
+++ b/rules/S1697/javascript/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2259
-//// Please consider implementing this latter instead.
 When either the equality operator in a test for ``++null++`` or ``++undefined++``, or the logical operator that follows it is reversed, the code has the appearance of safely null-testing the object before dereferencing it. Unfortunately the effect is just the opposite - the object is null-tested and then dereferenced only if it is ``++null++``/``++undefined++``, leading to a guaranteed ``++TypeError++``.
 
 == Noncompliant Code Example

--- a/rules/S1697/php/rule.adoc
+++ b/rules/S1697/php/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2259
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S1697/rule.adoc
+++ b/rules/S1697/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2259
-//// Please consider implementing this latter instead.
 include::description.adoc[]
 
 include::noncompliant.adoc[]

--- a/rules/S1768/cfamily/rule.adoc
+++ b/rules/S1768/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 Because the value in a variable of an unsigned type or ``++enum++`` can never be less than zero, testing to see if it is negative or checking its absolute value is a useless operation which can only confuse future readers of the code.
 
 

--- a/rules/S2277/java/rule.adoc
+++ b/rules/S2277/java/rule.adoc
@@ -1,6 +1,4 @@
-//// This rule is superseded by RSPEC-5542
-//// Please consider implementing this latter instead.
-Without OAEP in RSA encryption, it takes less work for an attacker to decrypt the data or infer patterns from the ciphertext. This rule logs an issue as soon as a literal value starts with ``++RSA/NONE++``.
+Without OAEP in RSA encryption, it takes less work for an attacker to decrypt the data or infer patterns from the ciphertext. This rule logs an issue as soon as a literal value starts with ``++RSA/NONE++``. 
 
 == Noncompliant Code Example
 

--- a/rules/S2277/php/rule.adoc
+++ b/rules/S2277/php/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5542
-//// Please consider implementing this latter instead.
 Without OAEP in RSA encryption, it takes less work for an attacker to decrypt the data or infer patterns from the ciphertext. This rule logs an issue when ``++openssl_public_encrypt++`` is used with one the following padding constants: ``++OPENSSL_NO_PADDING++`` or ``++OPENSSL_PKCS1_PADDING++`` or ``++OPENSSL_SSLV23_PADDING++``.
 
 == Noncompliant Code Example

--- a/rules/S2278/cfamily/rule.adoc
+++ b/rules/S2278/cfamily/rule.adoc
@@ -1,19 +1,17 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example
 
 ----
-CCCryptorStatus cryptStatus = CCCrypt(kCCEncrypt,
+CCCryptorStatus cryptStatus = CCCrypt(kCCEncrypt, 
                                       kCCAlgorithmDES, // Noncompliant
                                       kCCOptionPKCS7Padding | kCCOptionECBMode,
-                                      keyPtr,
+                                      keyPtr, 
                                       kCCKeySizeDES,
-                                      NULL,
-                                      [self bytes],
+                                      NULL, 
+                                      [self bytes], 
                                       dataLength,
-                                      buffer,
+                                      buffer, 
                                       bufferSize
                                       &numBytesEncrypted);
 ----

--- a/rules/S2278/csharp/rule.adoc
+++ b/rules/S2278/csharp/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S2278/java/rule.adoc
+++ b/rules/S2278/java/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2278/php/rule.adoc
+++ b/rules/S2278/php/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S2278/plsql/rule.adoc
+++ b/rules/S2278/plsql/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S2278/python/rule.adoc
+++ b/rules/S2278/python/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S2278/rule.adoc
+++ b/rules/S2278/rule.adoc
@@ -1,6 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
-
 include::description.adoc[]
 
 include::noncompliant.adoc[]

--- a/rules/S2278/swift/rule.adoc
+++ b/rules/S2278/swift/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-5547
-//// Please consider implementing this latter instead.
 include::../description.adoc[]
 
 == Noncompliant Code Example

--- a/rules/S2608/cfamily/rule.adoc
+++ b/rules/S2608/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/csharp/rule.adoc
+++ b/rules/S2608/csharp/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/flex/rule.adoc
+++ b/rules/S2608/flex/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/html/rule.adoc
+++ b/rules/S2608/html/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/java/rule.adoc
+++ b/rules/S2608/java/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/php/rule.adoc
+++ b/rules/S2608/php/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/python/rule.adoc
+++ b/rules/S2608/python/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/rule.adoc
+++ b/rules/S2608/rule.adoc
@@ -1,6 +1,4 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
-Cookie values and the contents of form fields - both visible _and_ hidden - can easily be manipulated by attackers. Therefore, security decisions should not be made based on these inputs.
+Cookie values and the contents of form fields - both visible _and_ hidden - can easily be manipulated by attackers. Therefore, security decisions should not be made based on these inputs. 
 
 
 This rule logs an issue whenever form fields and cookie values are accessed.

--- a/rules/S2608/swift/rule.adoc
+++ b/rules/S2608/swift/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/vb6/rule.adoc
+++ b/rules/S2608/vb6/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2608/vbnet/rule.adoc
+++ b/rules/S2608/vbnet/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2255
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2734/python/rule.adoc
+++ b/rules/S2734/python/rule.adoc
@@ -1,6 +1,4 @@
-//// This rule is superseded by RSPEC-935
-//// Please consider implementing this latter instead.
-By contract, every Python function returns something, even if it's the ``++None++`` value, which can be returned implicitly by omitting the ``++return++`` statement, or explicitly.
+By contract, every Python function returns something, even if it's the ``++None++`` value, which can be returned implicitly by omitting the ``++return++`` statement, or explicitly. 
 
 
 The ``++__init__++`` method is required to return ``++None++``. A ``++TypeError++`` will be raised if the ``++__init__++`` method either ``++yield++``s or ``++return++``s any expression other than ``++None++``. Returning some expression that evaluates to ``++None++`` will not raise an error, but is considered bad practice.

--- a/rules/S2815/cfamily/rule.adoc
+++ b/rules/S2815/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2815/csharp/rule.adoc
+++ b/rules/S2815/csharp/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2815/java/rule.adoc
+++ b/rules/S2815/java/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 include::../rule.adoc[]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2815/rule.adoc
+++ b/rules/S2815/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-2583
-//// Please consider implementing this latter instead.
 According to the {cpp} standard, ``++this++`` can never be null, so comparisons of the two are pointless at best. At worst, because of compiler optimizations, such comparisons could lead to null pointer dereferences or obscure, difficult-to-diagnose errors in production.
 
 

--- a/rules/S3833/javascript/rule.adoc
+++ b/rules/S3833/javascript/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-3854
-//// Please consider implementing this latter instead.
 In the constructor of a derived class, accessing ``++this++`` or ``++super++`` before ``++super()++`` is called raises a reference error. ``++super()++`` should always be called first.
 
 

--- a/rules/S879/cfamily/rule.adoc
+++ b/rules/S879/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-//// This rule is superseded by RSPEC-3949
-//// Please consider implementing this latter instead.
 Unsigned integer expressions do not strictly overflow, but instead wrap around in a modular way.
 
 


### PR DESCRIPTION
This reverts commit 56f3b1b19dbf7230cb3bf219292a0decb12fb356.
The deprecation comments were intended to be hidden from the end-users, yet they show. Reverting until we find a better syntax