### PR TITLE
S1451 Remove the <br> tags from inside <pre>

### DIFF
--- a/rules/S1451/csharp/rule.adoc
+++ b/rules/S1451/csharp/rule.adoc
@@ -19,7 +19,6 @@ then the ``++headerFormat++`` parameter should end with an empty line like this
 
 ----	
 // Copyright (c) SonarSource. All Rights Reserved. Licensed under the LGPL License.  See License.txt in the project root for license information.   
-​
 ---- 
 
 include::../compliant.adoc[]

--- a/rules/S1451/csharp/rule.adoc
+++ b/rules/S1451/csharp/rule.adoc
@@ -17,10 +17,9 @@ namespace Foo
 ----
 then the ``++headerFormat++`` parameter should end with an empty line like this
 
-[subs=normal]
 ----	
 // Copyright (c) SonarSource. All Rights Reserved. Licensed under the LGPL License.  See License.txt in the project root for license information.   
-{empty} +
+​
 ---- 
 
 include::../compliant.adoc[]

--- a/rules/S1451/vbnet/rule.adoc
+++ b/rules/S1451/vbnet/rule.adoc
@@ -17,10 +17,9 @@ namespace Foo
 ----
 then the ``++headerFormat++`` parameter should end with an empty line like this
 
-[subs=normal]
 ----	
 ' Copyright (c) SonarSource. All Rights Reserved. Licensed under the LGPL License.  See License.txt in the project root for license information.   
-{empty} +
+​
 ---- 
 
 include::../compliant.adoc[]

--- a/rules/S1451/vbnet/rule.adoc
+++ b/rules/S1451/vbnet/rule.adoc
@@ -19,7 +19,6 @@ then the ``++headerFormat++`` parameter should end with an empty line like this
 
 ----	
 ' Copyright (c) SonarSource. All Rights Reserved. Licensed under the LGPL License.  See License.txt in the project root for license information.   
-​
 ---- 
 
 include::../compliant.adoc[]


### PR DESCRIPTION
See https://github.com/asciidoctor/asciidoctor/issues/724 for the details on the empty-line stripping in the end of code blocks,
and the [long-standing issue](https://github.com/asciidoctor/asciidoctor/issues/754) about disabling this behavior.