### PR TITLE
Correct typo

### DIFF
--- a/rules/S6032/cfamily/rule.adoc
+++ b/rules/S6032/cfamily/rule.adoc
@@ -1,7 +1,7 @@
 Unintentional expensive copy should be avoided when using ``++auto++`` as a placeholder type.
 
 
-When using ``++const auto++`` as a placeholder type, you might unintentionally forget to add an ampersand(``++&++``) in front of the ``++auto++`` keyword. This can silently create a pointless copy and possibly have a bad impact on the performance of your code depending on the size of the created object and its context.
+When using ``++const auto++`` as a placeholder type, you might unintentionally forget to add an ampersand(``++&++``) after the ``++auto++`` keyword. This can silently create a pointless copy and possibly have a bad impact on the performance of your code depending on the size of the created object and its context.
 
 For example, if it happens in a range-based for loop context, it is going to lead to creating as many useless objects as the size of the range.
 


### PR DESCRIPTION
The text mentioned `&auto a = f()` instead of `auto &a = f()`