### PR TITLE
Modify rule S3551: Fix mismatch in CERT references between text documentation and metadata

### DIFF
--- a/rules/S3551/java/metadata.json
+++ b/rules/S3551/java/metadata.json
@@ -24,7 +24,7 @@
   "scope": "Main",
   "securityStandards": {
     "CERT": [
-      "MET04-J."
+      "TSM00-J."
     ]
   },
   "defaultQualityProfiles": [


### PR DESCRIPTION
The reference to MET04-J has been removed from the metadata and replaced with TSM00-J which is more specific and thus relevant to the issue.