### PR TITLE
Drop 'Sonar way recommended' profile from all rules

### DIFF
--- a/rules/S113/javascript/metadata.json
+++ b/rules/S113/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S117/javascript/metadata.json
+++ b/rules/S117/javascript/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Variable, property and parameter names should comply with a naming convention",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1192/javascript/metadata.json
+++ b/rules/S1192/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S121/javascript/metadata.json
+++ b/rules/S121/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S122/javascript/metadata.json
+++ b/rules/S122/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S138/javascript/metadata.json
+++ b/rules/S138/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1440/javascript/metadata.json
+++ b/rules/S1440/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1477/javascript/metadata.json
+++ b/rules/S1477/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1526/javascript/metadata.json
+++ b/rules/S1526/javascript/metadata.json
@@ -23,6 +23,6 @@
   "sqKey": "S1526",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1528/javascript/metadata.json
+++ b/rules/S1528/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S1528",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S1821/javascript/metadata.json
+++ b/rules/S1821/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2376/javascript/metadata.json
+++ b/rules/S2376/javascript/metadata.json
@@ -5,6 +5,6 @@
     "constantCost": "5min"
   },
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2392/javascript/metadata.json
+++ b/rules/S2392/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S2392",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2424/javascript/metadata.json
+++ b/rules/S2424/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S2424",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2428/javascript/metadata.json
+++ b/rules/S2428/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S2428",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2933/javascript/metadata.json
+++ b/rules/S2933/javascript/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Private properties that are only assigned in the constructor or at declaration should be \"readonly\"",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S2966/javascript/metadata.json
+++ b/rules/S2966/javascript/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Non-null assertions should not be used",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3003/javascript/metadata.json
+++ b/rules/S3003/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S3003",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3257/javascript/metadata.json
+++ b/rules/S3257/javascript/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Primitive types should be omitted from initialized or defaulted declarations",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3353/javascript/metadata.json
+++ b/rules/S3353/javascript/metadata.json
@@ -4,6 +4,6 @@
     "es2015"
   ],
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3512/javascript/metadata.json
+++ b/rules/S3512/javascript/metadata.json
@@ -24,6 +24,6 @@
   "sqKey": "S3512",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3757/javascript/metadata.json
+++ b/rules/S3757/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S3757",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3758/javascript/metadata.json
+++ b/rules/S3758/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S3758",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3760/javascript/metadata.json
+++ b/rules/S3760/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S3760",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3786/javascript/metadata.json
+++ b/rules/S3786/javascript/metadata.json
@@ -23,6 +23,6 @@
   "sqKey": "S3786",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S3801/metadata.json
+++ b/rules/S3801/metadata.json
@@ -25,6 +25,6 @@
   "sqKey": "S3801",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4023/javascript/metadata.json
+++ b/rules/S4023/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4136/metadata.json
+++ b/rules/S4136/metadata.json
@@ -25,6 +25,6 @@
   "sqKey": "S4136",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4137/javascript/metadata.json
+++ b/rules/S4137/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4137",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4139/javascript/metadata.json
+++ b/rules/S4139/javascript/metadata.json
@@ -23,6 +23,6 @@
   "sqKey": "S4139",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4157/javascript/metadata.json
+++ b/rules/S4157/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4157",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4324/javascript/metadata.json
+++ b/rules/S4324/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4324",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4327/javascript/metadata.json
+++ b/rules/S4327/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4327",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4328/javascript/metadata.json
+++ b/rules/S4328/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4328",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4622/javascript/metadata.json
+++ b/rules/S4622/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4622",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S4798/javascript/metadata.json
+++ b/rules/S4798/javascript/metadata.json
@@ -22,6 +22,6 @@
   "sqKey": "S4798",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S881/javascript/metadata.json
+++ b/rules/S881/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }

--- a/rules/S935/javascript/metadata.json
+++ b/rules/S935/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way recommended"
+
   ]
 }


### PR DESCRIPTION
By mistake I didn't drop all appearances of 'Sonar way recommended' in #148, so finishing it here