### PR TITLE
Fix metadata schema to allow an empty coveredLanguages array

### DIFF
--- a/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
+++ b/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
@@ -22,6 +22,7 @@
         "additionalProperties": false,
         "coveredLanguages": {
           "type": "array",
+          "minItems": 0,
           "items": {
             "type": "string",
             "uniqueItems": true


### PR DESCRIPTION
Should fix this error:
* https://github.com/SonarSource/rspec/pull/153
* https://cirrus-ci.com/task/5842259590512640?logs=metadata_tests#L30