### PR TITLE
Modify rule S2057: Add an exception for Records

### DIFF
--- a/rules/S2057/java/rule.adoc
+++ b/rules/S2057/java/rule.adoc
@@ -39,10 +39,11 @@ public class Raspberry extends Fruit
 
 == Exceptions
 
-Swing and AWT classes, ``++abstract++`` classes, ``++Throwable++`` and its subclasses (``++Exception++``s and ``++Error++``s), and classes marked with ``++@SuppressWarnings("serial")++`` are ignored.
+Records, Swing and AWT classes, ``++abstract++`` classes, ``++Throwable++`` and its subclasses (``++Exception++``s and ``++Error++``s), and classes marked with ``++@SuppressWarnings("serial")++`` are ignored.
 
 
 == See
 
 * https://wiki.sei.cmu.edu/confluence/x/ajdGBQ[CERT, SER00-J.] - Enable serialization compatibility during class evolution
+* https://docs.oracle.com/en/java/javase/15/docs/specs/records-serialization.html#serialization-of-records[Record Serialization] - Serialization of Records
 


### PR DESCRIPTION
Add an exception to the rule as the constraint of validation on the serialUID is waived for Records.

SONARJAVA-3755 