### PR TITLE
Modify rule S5854: Fix noncompliant example

### DIFF
--- a/rules/S5854/java/rule.adoc
+++ b/rules/S5854/java/rule.adoc
@@ -6,7 +6,7 @@ Characters like ``++'é'++`` can be expressed either as a single code point or 
 ----
 String s = "e\u0300";
 Pattern p = Pattern.compile("é|ë|è"); // Noncompliant
-System.out.println(p.matcher(s).replaceAll("e")); // print 'é'
+System.out.println(p.matcher(s).replaceAll("e")); // print 'è'
 ----
 
 


### PR DESCRIPTION
The comment showing the output used the wrong accent.