### PR TITLE
Clean-up C++ tags

### DIFF
--- a/rules/S1034/cfamily/metadata.json
+++ b/rules/S1034/cfamily/metadata.json
@@ -1,3 +1,6 @@
 {
-  
+  "tags": [
+    "based-on-misra",
+    "clumsy"
+  ]
 }

--- a/rules/S1034/metadata.json
+++ b/rules/S1034/metadata.json
@@ -7,7 +7,6 @@
     "constantCost": "20min"
   },
   "tags": [
-    "based-on-misra",
     "clumsy"
   ],
   "extra": {

--- a/rules/S1181/java/metadata.json
+++ b/rules/S1181/java/metadata.json
@@ -1,6 +1,5 @@
 {
   "tags": [
-    "cppcoreguidelines",
     "cwe",
     "error-handling",
     "bad-practice",

--- a/rules/S1181/metadata.json
+++ b/rules/S1181/metadata.json
@@ -6,8 +6,7 @@
     "func": "Constant\/Issue",
     "constantCost": "20min"
   },
-  "tags": [
-    "cppcoreguidelines",
+  "tags": [    
     "cwe",
     "error-handling",
     "bad-practice"

--- a/rules/S1238/cfamily/metadata.json
+++ b/rules/S1238/cfamily/metadata.json
@@ -1,5 +1,9 @@
 {
   "title": "Pass by reference to const should be used for large input parameters",
+  "tags": [
+    "cppcoreguidelines",
+    "performance"
+  ],
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"

--- a/rules/S1238/metadata.json
+++ b/rules/S1238/metadata.json
@@ -7,7 +7,6 @@
     "constantCost": "5min"
   },
   "tags": [
-    "cppcoreguidelines",
     "performance"
   ],
   "extra": {

--- a/rules/S1270/cfamily/metadata.json
+++ b/rules/S1270/cfamily/metadata.json
@@ -1,3 +1,6 @@
 {
-  
+  "tags": [
+    "convention",
+    "cppcoreguidelines"
+  ]
 }

--- a/rules/S1270/metadata.json
+++ b/rules/S1270/metadata.json
@@ -7,8 +7,7 @@
     "constantCost": "2min"
   },
   "tags": [
-    "convention",
-    "cppcoreguidelines"
+    "convention"
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S1987/java/metadata.json
+++ b/rules/S1987/java/metadata.json
@@ -1,6 +1,5 @@
 {
   "tags": [
-    "based-on-misra",
     "cert"
   ]
 }

--- a/rules/S1987/metadata.json
+++ b/rules/S1987/metadata.json
@@ -6,8 +6,7 @@
     "func": "Constant\/Issue",
     "constantCost": "15min"
   },
-  "tags": [
-    "based-on-misra"
+  "tags": [    
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S3630/cfamily/metadata.json
+++ b/rules/S3630/cfamily/metadata.json
@@ -1,3 +1,6 @@
 {
-  
+  "tags": [
+    "cppcoreguidelines",
+    "pitfall"
+  ]
 }

--- a/rules/S3630/metadata.json
+++ b/rules/S3630/metadata.json
@@ -7,7 +7,6 @@
     "constantCost": "20min"
   },
   "tags": [
-    "cppcoreguidelines",
     "pitfall"
   ],
   "extra": {

--- a/rules/S3949/java/metadata.json
+++ b/rules/S3949/java/metadata.json
@@ -1,7 +1,6 @@
 {
   "tags": [
-    "overflow",
-    "based-on-misra",
+    "overflow"
     "cert"
   ]
 }

--- a/rules/S3949/java/metadata.json
+++ b/rules/S3949/java/metadata.json
@@ -1,6 +1,6 @@
 {
   "tags": [
-    "overflow"
+    "overflow",
     "cert"
   ]
 }

--- a/rules/S3949/metadata.json
+++ b/rules/S3949/metadata.json
@@ -7,8 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [
-    "overflow",
-    "based-on-misra"
+    "overflow"    
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S787/cfamily/metadata.json
+++ b/rules/S787/cfamily/metadata.json
@@ -1,3 +1,7 @@
 {
-  "sqKey": "C99CommentUsage"
+  "tags": [      
+    "convention",
+    "based-on-misra"
+  ],
+  "sqKey": "C99CommentUsage"  
 }

--- a/rules/S787/metadata.json
+++ b/rules/S787/metadata.json
@@ -6,9 +6,8 @@
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "convention",
-    "based-on-misra"
+  "tags": [      
+    "convention"
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S800/java/metadata.json
+++ b/rules/S800/java/metadata.json
@@ -1,6 +1,5 @@
 {
   "tags": [
-    "based-on-misra",
     "cert",
     "pitfall"
   ]

--- a/rules/S800/metadata.json
+++ b/rules/S800/metadata.json
@@ -6,8 +6,7 @@
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "based-on-misra",
+  "tags": [    
     "pitfall"
   ],
   "extra": {

--- a/rules/S867/metadata.json
+++ b/rules/S867/metadata.json
@@ -7,8 +7,7 @@
     "constantCost": "10min"
   },
   "tags": [
-    "cppcoreguidelines",
-    "based-on-misra"
+    "cppcoreguidelines"
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S867/metadata.json
+++ b/rules/S867/metadata.json
@@ -7,7 +7,7 @@
     "constantCost": "10min"
   },
   "tags": [
-    "cppcoreguidelines"
+  
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S930/metadata.json
+++ b/rules/S930/metadata.json
@@ -7,8 +7,7 @@
     "constantCost": "10min"
   },
   "tags": [
-    "cwe",
-    "based-on-misra"
+    "cwe"
   ],
   "extra": {
     "coveredLanguages": [

--- a/rules/S979/java/metadata.json
+++ b/rules/S979/java/metadata.json
@@ -1,6 +1,5 @@
 {
   "tags": [
-    "based-on-misra",
     "cert",
     "pitfall"
   ]

--- a/rules/S979/metadata.json
+++ b/rules/S979/metadata.json
@@ -6,8 +6,7 @@
     "func": "Constant\/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-    "based-on-misra",
+  "tags": [    
     "pitfall"
   ],
   "extra": {


### PR DESCRIPTION
I got confirmation from the bubbles (other than CFamily) that used "based-on-misra" and "cppcoreguidelines" tags that it was not intentional.