### PR TITLE
Modify rule S2479: Remove tabs exception for Java text blocks

### DIFF
--- a/rules/S2479/java/rule.adoc
+++ b/rules/S2479/java/rule.adoc
@@ -16,10 +16,6 @@ String zeroWidthSpaceInside = "foo\u200Bbar";  // Compliant, uses escaped value
 char tab = '\t';
 ----
 
-== Exceptions
-
-Text Blocks string literals (java 13 three double-quote marks) can contain tabulations to allow indentation using tabulations.
-
 ifdef::env-github,rspecator-view[]
 '''
 == Comments And Links


### PR DESCRIPTION
The tabs exception is now configurable is now using a parameter and disabled by default.