### PR TITLE
CPP-2968: Rule S6221: Concept names should comply with a naming convention

### DIFF
--- a/rules/S6221/cfamily/rule.adoc
+++ b/rules/S6221/cfamily/rule.adoc
@@ -7,7 +7,7 @@ With default provided regular expression ``++^[A-Z][a-zA-Z0-9]*$++``:
 
 ----
 template <class T>
-concept integral = std::is_integral<T>_v; // Noncompliant
+concept integral = std::is_integral_v<T>; // Noncompliant
 ----
 
 
@@ -15,7 +15,7 @@ concept integral = std::is_integral<T>_v; // Noncompliant
 
 ----
 template <class T>
-concept Integral = std::is_integral<T>_v; // Compliant
+concept Integral = std::is_integral_v<T>; // Compliant
 ----
 
 


### PR DESCRIPTION
Correct typo in code examples