### PR TITLE
RULEAPI-684: Restore the section skipped during import from Jira

### DIFF
--- a/rules/S6227/cfamily/rule.adoc
+++ b/rules/S6227/cfamily/rule.adoc
@@ -9,6 +9,22 @@ However, one of the reasons for using private inheritance instead of composition
 
 This rule reports an issue on classes that has private bases class that can be replaced with a member.
 
+== Noncompliant Code Example
+
+----
+struct Thingy {
+  /* .... */
+};
+
+struct Widget : private Thingy { // Noncompliant
+   /* .... */
+};
+
+template<typename Value, typename Alloc>
+class Vector :  Alloc { // Noncompliant
+   /* .... */
+};
+----
 
 == Compliant Solution
 


### PR DESCRIPTION
The issue that caused the section skipping: non-canonical section names. These were mostly fixed before the export point. A few freshly created rules, days before the transition had non-canonical sections. They are mentioned in the log during export (but were missed or ignored during export). The affected rules are (all c-family): S6223, S6227, S6229, S6231

S6223, and S6231 were fixed earlier
S6229 is fixed by https://github.com/SonarSource/rspec/pull/363
This PR fixes the remaining S6227