### PR TITLE
Modify rule S6045: Cover heterogenous lookup for unordered containers in C++20

### DIFF
--- a/rules/S6045/cfamily/metadata.json
+++ b/rules/S6045/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Transparent comparator should be used with associative \"std::string\"containers",
+  "title": "Transparent comparator should be used with associative \"std::string\" containers",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -73,7 +73,7 @@ void g() {
   std::unordered_set<std::string, StringHash, std::equal_to<>> m = { "Dory", "Marlin", "Nemo", "Emo"}; // Compliant
   m.find("Nemo"); // std::string_view is created out of raw C-string literal
   std::string_view n{"Nemo"};
-  m.find(n); // No need to create the std::string
+  m.find(n); // No need to create a std::string
 }
 ----
 

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -4,10 +4,25 @@
 Invoking a lookup function (such as ``++find++``, ``++count++``, or ``++lower_bound++``) with a non-``++std::string++`` argument, i.e., a raw C-string literal (``++s.find("Nemo")++``), or a temporary ``++std::string++`` created of an ``++std::string_view++``, on a container of ``++std::string++`` with non-transparent comparator, leads to a temporary ``++std::string++`` object, because the lookup function will support only an argument of the ``++key_type++``.
 
 
+{cpp}20 extended support for heterogeneous lookup to unordered associative containers: ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``, 
+that provide additional overloads, are enabled if used equality functor and the hasher are both transparent. 
+The standard provides transparent equality functor in form ``++std::equal_to<>++``, however there is no corresponding transparent hasher object, and one needs to be defined in program.
+For ``++std::string++`` such hasher may be provided by converting each supplied object to `++std::string_view++` and hashing it using ``++std::hash<std::string_view>++``:
+---
+struct StringHash {
+  using is_transparent = void; // enables heterogeneous lookup
+
+  std::size_t operator()(std::string_view sv) const {
+    std::hash<std::string_view> hasher;
+    return hasher(sv);
+  }
+};
+---
+
 Always prefer using a transparent comparator with associative "std::string" containers to avoid creating the temporary. Note that transparent comparators are strongly discouraged if used with types that are not directly comparable as it will lead to the creation of ``++O(log(container.size())))++`` temporaries with lookup functions such as ``++find++``, ``++count++``, and ``++lower_bound++``.
 
 
-This rule will detect ``++std::set++``, ``++std::multiset++``, ``++std::map++``, and ``++std::multimap++`` types with a non-transparent comparator.
+This rule will detect ``++std::set++``, ``++std::multiset++``, ``++std::map++``, ``++std::multimap++``, and since {cpp}20 ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++`  types, that uses `++std::string` as key and do not enable heterogeneous lookup.
 
 
 == Noncompliant Code Example
@@ -20,8 +35,15 @@ void f() {
   std::string_view n{"Nemo"};
   m.find(std::string(n)); // extra temporary std::string
 }
-----
 
+void g() {
+  // the default std::equal_to<std::string> and std::hash<std::string> are not transparent
+  std::unordered_set<std::string> m = { "Dory", "Marlin", "Nemo", "Emo"}; // Noncompliant
+  m.find("Nemo"); // This leads to a temporary std::string{"Nemo"}.
+  std::string_view n{"Nemo"};
+  m.find(std::string(n)); // extra temporary std::string
+}
+----
 
 == Compliant Solution
 
@@ -34,6 +56,24 @@ void f() {
                   // is compared directly with std::string elements
   std::string_view n{"Nemo"};
   m.find(n); // No need to create the std::string 
+}
+
+struct StringHash {
+  using is_transparent = void; // enables heterogenous lookup
+
+  std::size_t operator()(std::string_view sv) const {
+    std::hash<std::string_view> hasher;
+    return hasher(sv);
+  }
+};
+
+
+void g() {
+  // std::equal_to<> and StringHash are both transparent
+  std::unordered_set<std::string, StringHash, std::equal_to<>> m = { "Dory", "Marlin", "Nemo", "Emo"}; // Noncompliant
+  m.find("Nemo"); // std::string_view is created out of raw C-string literal
+  std::string_view n{"Nemo"};
+  m.find(n); // No need to create the std::string
 }
 ----
 

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -6,7 +6,7 @@ Invoking a lookup function (such as ``++find++``, ``++count++``, or ``++lower_bo
 
 {cpp}20 extended support for heterogeneous lookup to unordered associative containers: ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``, 
 that provide additional overloads, are enabled if used equality functor and the hasher are both transparent. 
-The standard provides transparent equality functor in form ``++std::equal_to<>++``, however there is no corresponding transparent hasher object, and one needs to be defined in program.
+The standard provides transparent equality functors in the form ``++std::equal_to<>++``. However, there is no standard transparent hasher object and one needs to be defined in the program.
 For ``++std::string++`` such hasher may be provided by converting each supplied object to ``++std::string_view++`` and hashing it using ``++std::hash<std::string_view>++``:
 ----
 struct StringHash {

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -8,7 +8,7 @@ Invoking a lookup function (such as ``++find++``, ``++count++``, or ``++lower_bo
 that provide additional overloads, are enabled if used equality functor and the hasher are both transparent. 
 The standard provides transparent equality functor in form ``++std::equal_to<>++``, however there is no corresponding transparent hasher object, and one needs to be defined in program.
 For ``++std::string++`` such hasher may be provided by converting each supplied object to `++std::string_view++` and hashing it using ``++std::hash<std::string_view>++``:
----
+----
 struct StringHash {
   using is_transparent = void; // enables heterogeneous lookup
 

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -70,7 +70,7 @@ struct StringHash {
 
 void g() {
   // std::equal_to<> and StringHash are both transparent
-  std::unordered_set<std::string, StringHash, std::equal_to<>> m = { "Dory", "Marlin", "Nemo", "Emo"}; // Noncompliant
+  std::unordered_set<std::string, StringHash, std::equal_to<>> m = { "Dory", "Marlin", "Nemo", "Emo"}; // Compliant
   m.find("Nemo"); // std::string_view is created out of raw C-string literal
   std::string_view n{"Nemo"};
   m.find(n); // No need to create the std::string

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -22,7 +22,7 @@ struct StringHash {
 Always prefer using a transparent comparator with associative "std::string" containers to avoid creating the temporary. Note that transparent comparators are strongly discouraged if used with types that are not directly comparable as it will lead to the creation of ``++O(log(container.size())))++`` temporaries with lookup functions such as ``++find++``, ``++count++``, and ``++lower_bound++``.
 
 
-This rule will detect ``++std::set++``, ``++std::multiset++``, ``++std::map++``, ``++std::multimap++``, and since {cpp}20 ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++`  types, that uses `++std::string` as key and do not enable heterogeneous lookup.
+This rule will detect ``++std::set++``, ``++std::multiset++``, ``++std::map++``, ``++std::multimap++``, and since {cpp}20 ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``  types, that use ``++std::string++`` as key and do not enable heterogeneous lookup.
 
 
 == Noncompliant Code Example

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -7,7 +7,7 @@ Invoking a lookup function (such as ``++find++``, ``++count++``, or ``++lower_bo
 {cpp}20 extended support for heterogeneous lookup to unordered associative containers: ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``, 
 that provide additional overloads, are enabled if used equality functor and the hasher are both transparent. 
 The standard provides transparent equality functor in form ``++std::equal_to<>++``, however there is no corresponding transparent hasher object, and one needs to be defined in program.
-For ``++std::string++`` such hasher may be provided by converting each supplied object to `++std::string_view++` and hashing it using ``++std::hash<std::string_view>++``:
+For ``++std::string++`` such hasher may be provided by converting each supplied object to ``++std::string_view++`` and hashing it using ``++std::hash<std::string_view>++``:
 ----
 struct StringHash {
   using is_transparent = void; // enables heterogeneous lookup

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -4,8 +4,7 @@
 Invoking a lookup function (such as ``++find++``, ``++count++``, or ``++lower_bound++``) with a non-``++std::string++`` argument, i.e., a raw C-string literal (``++s.find("Nemo")++``), or a temporary ``++std::string++`` created of an ``++std::string_view++``, on a container of ``++std::string++`` with non-transparent comparator, leads to a temporary ``++std::string++`` object, because the lookup function will support only an argument of the ``++key_type++``.
 
 
-{cpp}20 extended support for heterogeneous lookup to unordered associative containers: ``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``, 
-that provide additional overloads, are enabled if used equality functor and the hasher are both transparent. 
+{cpp}20 extends support for heterogeneous lookup to unordered associative containers (``++std::unordered_set++``, ``++std::unordered_multiset++``, ``++std::unordered_map++``, and ``++std::unordered_multimap++``) that provide additional overloads when the equality functor and the hasher are both transparent. 
 The standard provides transparent equality functors in the form ``++std::equal_to<>++``. However, there is no standard transparent hasher object and one needs to be defined in the program.
 For ``++std::string++`` such hasher may be provided by converting each supplied object to ``++std::string_view++`` and hashing it using ``++std::hash<std::string_view>++``:
 ----

--- a/rules/S6045/cfamily/rule.adoc
+++ b/rules/S6045/cfamily/rule.adoc
@@ -17,7 +17,7 @@ struct StringHash {
     return hasher(sv);
   }
 };
----
+----
 
 Always prefer using a transparent comparator with associative "std::string" containers to avoid creating the temporary. Note that transparent comparators are strongly discouraged if used with types that are not directly comparable as it will lead to the creation of ``++O(log(container.size())))++`` temporaries with lookup functions such as ``++find++``, ``++count++``, and ``++lower_bound++``.
 


### PR DESCRIPTION
…