### PR TITLE
RULEAPI-673: Stop displaying "Not implemented" for languages that do implement the rule

### DIFF
--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -189,6 +189,11 @@ export function RulePage(props: any) {
     }
   }
 
+  if (coverage != "Not Covered") {
+    prUrl = undefined;
+    branch = 'master'; 
+  }
+
   let editOnGithubUrl = 'https://github.com/SonarSource/rspec/blob/' +
                         branch + '/rules/' + ruleid + (language ? '/' + language : '');
 

--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -189,7 +189,7 @@ export function RulePage(props: any) {
     }
   }
 
-  if (coverage != "Not Covered") {
+  if (coverage !== "Not Covered") {
     prUrl = undefined;
     branch = 'master'; 
   }


### PR DESCRIPTION
This PR also changes the behaviour of the Edit on Github link. Before if there was a PR in progress for any language it always opened the folder in the branch from which the PR was created. Now the behaviour remains the same for not implemented languages, however it targets the master branch for languages that already have an implementation.