### PR TITLE
RULEAPI-678: Escape """ in search strings embedded into the rule pages rendered in frontend

### DIFF
--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -111,6 +111,7 @@ function ticketsAndImplementationPRsLinks(ruleNumber: string, title: string, lan
     const upperCaseLanguage = language.toUpperCase();
     const jiraProject = languageToJiraProject.get(upperCaseLanguage);
     const githubProject = languageToGithubProject.get(upperCaseLanguage);
+    const titleWihoutQuotes = title.replaceAll('"','');
 
     const implementationPRsLink = (
       <Link href={`https://github.com/SonarSource/${githubProject}/pulls?q=is%3Apr+"S${ruleNumber}"+OR+"RSPEC-${ruleNumber}"`}>
@@ -120,7 +121,7 @@ function ticketsAndImplementationPRsLinks(ruleNumber: string, title: string, lan
 
     if (jiraProject !== undefined) {
       const ticketsLink = (
-        <Link href={`https://jira.sonarsource.com/issues/?jql=project%20%3D%20${jiraProject}%20AND%20(text%20~%20%22S${ruleNumber}%22%20OR%20text%20~%20%22RSPEC-${ruleNumber}%22%20OR%20text%20~%20"${title}")`}>
+        <Link href={`https://jira.sonarsource.com/issues/?jql=project%20%3D%20${jiraProject}%20AND%20(text%20~%20%22S${ruleNumber}%22%20OR%20text%20~%20%22RSPEC-${ruleNumber}%22%20OR%20text%20~%20"${titleWihoutQuotes}")`}>
           Implementation tickets on Jira
         </Link>
       );


### PR DESCRIPTION
Implementation based on 

> Special characters aren’t stored in the index, which means you can’t search for them. The index only keeps text and numbers, so searching for "\\[Jira Software\\]" and "Jira Software" will have the same effect — escaped special characters ([]) won’t be included in the search. `

from https://confluence.atlassian.com/jirasoftwareserver0813/search-syntax-for-text-fields-1027135330.html