### PR TITLE
RULEAPI-700: fix odd highlighting for selected segment of metadata

### DIFF
--- a/frontend/src/hljs-humanoid-light.css
+++ b/frontend/src/hljs-humanoid-light.css
@@ -16,9 +16,6 @@ code.hljs {
  color:#232629;
  background:#f8f8f2
 }
-.hljs ::selection {
- color:#deded8
-}
 .hljs-comment {
  color:#c0c0bd
 }


### PR DESCRIPTION
Before the fix:
![Screenshot from 2021-10-01 08-49-24](https://user-images.githubusercontent.com/70532144/135577634-ab7d7bf5-42be-4b04-8698-a4b7de5bc499.png)
after the fix:
![Screenshot from 2021-10-01 08-50-06](https://user-images.githubusercontent.com/70532144/135577700-db8c995f-589f-41aa-a318-3179b40d7454.png)
