### PR TITLE
Fix coverage update: the phantom of the old rule_coverage directory

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -25,13 +25,13 @@ jobs:
       run: pip install pipenv
 
     - name: 'Install coverage script dependencies'
-      working-directory: 'rspec/rule_coverage'
+      working-directory: 'rspec/rspec-tools'
       run: |
         pipenv --python python3.9 install
 
     - name: 'Regenerate coverage information'
       id: gen-coverage
-      working-directory: 'rspec/rule_coverage'
+      working-directory: 'rspec/rspec-tools'
       run: |
         pipenv run rspec-tools update-coverage
         mv ./covered_rules.json ../frontend/public/covered_rules.json


### PR DESCRIPTION
This is a rebase artefact: forgotten to use the `rspec-tools` directory where the coverage script was moved to.