### PR TITLE
Fix the mistakingly deleted 'See' sections in #362

### DIFF
--- a/rules/S1134/rule.adoc
+++ b/rules/S1134/rule.adoc
@@ -2,3 +2,5 @@ include::description.adoc[]
 
 include::noncompliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S1135/rule.adoc
+++ b/rules/S1135/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S1493/rule.adoc
+++ b/rules/S1493/rule.adoc
@@ -8,3 +8,5 @@ include::sensitive.adoc[]
 
 include::compliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S1523/rule.adoc
+++ b/rules/S1523/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2070/rule.adoc
+++ b/rules/S2070/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2076/rule.adoc
+++ b/rules/S2076/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2087/rule.adoc
+++ b/rules/S2087/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2222/rule.adoc
+++ b/rules/S2222/rule.adoc
@@ -4,3 +4,5 @@ include::noncompliant.adoc[]
 
 include::compliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2631/rule.adoc
+++ b/rules/S2631/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S2647/rule.adoc
+++ b/rules/S2647/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S3904/rule.adoc
+++ b/rules/S3904/rule.adoc
@@ -4,3 +4,5 @@ include::noncompliant.adoc[]
 
 include::compliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S4274/rule.adoc
+++ b/rules/S4274/rule.adoc
@@ -4,3 +4,5 @@ include::noncompliant.adoc[]
 
 include::compliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S4830/rule.adoc
+++ b/rules/S4830/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5147/rule.adoc
+++ b/rules/S5147/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5344/rule.adoc
+++ b/rules/S5344/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5659/rule.adoc
+++ b/rules/S5659/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5691/rule.adoc
+++ b/rules/S5691/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5730/rule.adoc
+++ b/rules/S5730/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5732/rule.adoc
+++ b/rules/S5732/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5734/rule.adoc
+++ b/rules/S5734/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5736/rule.adoc
+++ b/rules/S5736/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5742/rule.adoc
+++ b/rules/S5742/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5743/rule.adoc
+++ b/rules/S5743/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5753/rule.adoc
+++ b/rules/S5753/rule.adoc
@@ -8,3 +8,5 @@ include::sensitive.adoc[]
 
 include::compliant.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5757/rule.adoc
+++ b/rules/S5757/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5773/rule.adoc
+++ b/rules/S5773/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5804/rule.adoc
+++ b/rules/S5804/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5852/rule.adoc
+++ b/rules/S5852/rule.adoc
@@ -4,3 +4,5 @@ include::ask-yourself.adoc[]
 
 include::recommended.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S5883/rule.adoc
+++ b/rules/S5883/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+

--- a/rules/S6273/rule.adoc
+++ b/rules/S6273/rule.adoc
@@ -1,2 +1,4 @@
 include::description.adoc[]
 
+include::see.adoc[]
+


### PR DESCRIPTION
committed the squased commit f6331f7fdca7fe36e52439b927312fd5d5a455c0 of the PR #362 

The mistake was caused by the uninitialized variable "hasSeeSection" in the
automatic removal script. Fixed here:
https://github.com/SonarSource/languages-experimental-tooling/commit/f6331f7fdca7fe36e52439b927312fd5d5a455c0