### PR TITLE
Fix the erroneous undeprecation of a deprecated rule without replacement rules

### DIFF
--- a/rules/S4784/vbnet/metadata.json
+++ b/rules/S4784/vbnet/metadata.json
@@ -1,2 +1,7 @@
 {
+  "extra": {
+    "replacementRules": [
+      
+    ]
+  }
 }


### PR DESCRIPTION
this entry overrides the entry in the parent metadata.json (rules/S4784/metadata.json), and sets the replacement rules to an empty list thereby unconditionally deprecating the rule.