### PR TITLE
Modify rule S6287: Remove tainted key from samples

### DIFF
--- a/rules/S6287/csharp/rule.adoc
+++ b/rules/S6287/csharp/rule.adoc
@@ -7,10 +7,10 @@ using System.Web;
 using System.Web.Mvc;
 
 [HttpGet]
-public ActionResult index(string key, string val)
+public ActionResult index(string val)
 {
-    Response.AddHeader(key, val);  // Noncompliant
-    HttpCookie cookie = new HttpCookie(key, val);  // Noncompliant
+    Response.AddHeader("Set-Cookie", val);  // Noncompliant
+    HttpCookie cookie = new HttpCookie("ASP.NET_SessionId", val);  // Noncompliant
     Response.AppendCookie(cookie);
     return View("");
 }

--- a/rules/S6287/java/rule.adoc
+++ b/rules/S6287/java/rule.adoc
@@ -8,9 +8,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping(value = "/")
-public void index(HttpServletResponse res, String key, String value) {
-    res.setHeader(key, value);  // Noncompliant
-    Cookie cookie = new Cookie(key, value);  // Noncompliant
+public void index(HttpServletResponse res, String value) {
+    res.setHeader("Set-Cookie", value);  // Noncompliant
+    Cookie cookie = new Cookie("jsessionid", value);  // Noncompliant
     res.addCookie(cookie);
 }
 ----

--- a/rules/S6287/javascript/rule.adoc
+++ b/rules/S6287/javascript/rule.adoc
@@ -4,11 +4,10 @@ include::../description.adoc[]
 
 ----
 module.exports.index = async function (req, res) {
-  const key = req.query.key;
   const value = req.query.value;
 
-  res.setHeader(key, value);  // Noncompliant
-  res.cookie(key, value);  // Noncompliant
+  res.setHeader("Set-Cookie", value);  // Noncompliant
+  res.cookie("connect.sid", value);  // Noncompliant
 };
 ----
 

--- a/rules/S6287/php/rule.adoc
+++ b/rules/S6287/php/rule.adoc
@@ -9,12 +9,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 public function index(Request $request)
 {
-    $key = $request->query->get('k');
     $value = $request->query->get('v');
 
     $response = new Response('');
-    $response->headers->set($key, $value);  // Noncompliant
-    $cookie = Cookie::create($key, $value);  // Noncompliant
+    $response->headers->set('Set-Cookie', $value);  // Noncompliant
+    $cookie = Cookie::create('PHPSESSID', $value);  // Noncompliant
     $response->headers->setCookie($cookie);
 
     return $response;

--- a/rules/S6287/python/rule.adoc
+++ b/rules/S6287/python/rule.adoc
@@ -6,11 +6,10 @@ include::../description.adoc[]
 from django.http import HttpResponse
 
 def index(request):
-    key = request.GET.get("key")
     value = request.GET.get("value")
     response = HttpResponse("")
-    response[key] = value  # Noncompliant
-    response.set_cookie(key, value)  # Noncompliant
+    response["Set-Cookie"] = value  # Noncompliant
+    response.set_cookie("sessionid", value)  # Noncompliant
     return response
 ----
 


### PR DESCRIPTION
The specification of the rule changed after the RSPEC was created and I forgot to update the code samples in RSPEC.

For now an issue is only raised if the header is explicitly "Set-Cookie" but not if it is tainted. In the future this should change but for now we will not detect an issue if the key is tainted. Thus, it does not make sense to show it in the code samples.