### PR TITLE
Fix "pipenv install" invocation to avoid update of Pipfile.lock

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ tooling_tests_task:
     PYTHONPATH: .
   install_dependencies_script:
     - cd rspec-tools
-    - pipenv install -e .
+    - pipenv install
     - pipenv run pip install pytest
   tests_script:
     - cd rspec-tools

--- a/.github/workflows/add_language.yml
+++ b/.github/workflows/add_language.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: 'Install rspec-tools'
       working-directory: 'rspec/rspec-tools'
-      run: pipenv install -e .
+      run: pipenv install
 
     - name: 'Add Language'
       working-directory: 'rspec/rspec-tools'

--- a/.github/workflows/create_new_rspec.yml
+++ b/.github/workflows/create_new_rspec.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: 'Install rspec-tools'
       working-directory: 'rspec/rspec-tools'
-      run: pipenv install -e .
+      run: pipenv install
 
     - name: 'Create Rule'
       working-directory: 'rspec/rspec-tools'

--- a/ci/validate_links.sh
+++ b/ci/validate_links.sh
@@ -12,7 +12,7 @@ ls -al $CACHE_PATH
 
 #validate links in asciidoc
 cd rspec-tools
-pipenv install -e .
+pipenv install
 pipenv run rspec-tools check-links --d ../out
 cd ..
 


### PR DESCRIPTION
When python scripts executing on Cirrus Ci run`pipenv install -e .`, it triggers an update of `Pipfile.lock` which then fails to resolve dependency.
As `pipenv install` doesn't trigger an update of `Pipfile.lock` I removed the `-e` argument from install commands.