### PR TITLE
Update pipenv in docker image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9-slim-buster
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor pipenv git curl
+RUN pip install pipenv && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor git curl
 
 CMD ["bash"]


### PR DESCRIPTION
When python scripts executing on Cirrus Ci run`pipenv install -e .`, it triggers an update of `Pipfile.lock` which then fails to resolve dependency.
I don't reproduce this behavior with the latest version of `pipenv`, only with the version from the docker environment installed using `apt-get` (11.9.0).
Using `pip` to install `pipenv` will get the latest version (2021.5.29).