### PR TITLE
Modify rule S6178[cfamily]: add quick fix

### DIFF
--- a/rules/S6178/cfamily/metadata.json
+++ b/rules/S6178/cfamily/metadata.json
@@ -25,5 +25,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "partial"
 }


### PR DESCRIPTION
partial because no quick fixes are generated when char types mismatch.