### PR TITLE
Modify rule S6193: Fix typo & update metadata

### DIFF
--- a/rules/S6193/cfamily/metadata.json
+++ b/rules/S6193/cfamily/metadata.json
@@ -9,14 +9,6 @@
   "tags": [
     "convention"
   ],
-  "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-      "MethodName"
-    ]
-  },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-6193",
   "sqKey": "S6193",

--- a/rules/S6193/cfamily/rule.adoc
+++ b/rules/S6193/cfamily/rule.adoc
@@ -9,8 +9,7 @@ With default provided regular expression: ``++^[a-z][a-zA-Z0-9]*$++``:
 generator<int> Iota(int n = 0) {
   while(true)
     co_yield n++;
-}{code}
-
+}
 ----
 
 == Compliant Solution
@@ -19,7 +18,7 @@ generator<int> Iota(int n = 0) {
 generator<int> iota(int n = 0) {
   while(true)
     co_yield n++;
-}{code}
+}
 ----
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
I've removed part of the metadata as it felt incorrect for a new rule to have a legacy key. Let me know if there is something I'm missing though.