### PR TITLE
Modify rule S1763[cfamily]: cover co_return and [[noreturn]]

### DIFF
--- a/rules/S1763/cfamily/rule.adoc
+++ b/rules/S1763/cfamily/rule.adoc
@@ -1,4 +1,6 @@
-include::../description.adoc[]
+Some statements (`return`, `break`, `continue`, `goto`, `switch`, `co_return`) and `throw` expressions move control flow out of the current code block. Furthermore, some function do not return control flow (e.g. `abort()`, `std::terminate()`, functions with the ``++[[noreturn]]++`` attribute).
+
+Any unlabeled statements that come after such a jump or function call are unreachable, and either this dead code should be removed, or the logic should be corrected.
 
 include::../noncompliant.adoc[]
 

--- a/rules/S1763/cfamily/rule.adoc
+++ b/rules/S1763/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Some statements (`return`, `break`, `continue`, `goto`, `switch`, `co_return`) and `throw` expressions move control flow out of the current code block. Furthermore, some function do not return control flow (e.g. `abort()`, `std::terminate()`, functions with the ``++[[noreturn]]++`` attribute).
+Some statements (`return`, `break`, `continue`, `goto`, `co_return`) and `throw` expressions move control flow out of the current code block. Furthermore, some function do not return control flow (e.g. `abort()`, `std::terminate()`, functions with the ``++[[noreturn]]++`` attribute).
 
 Any unlabeled statements that come after such a jump or function call are unreachable, and either this dead code should be removed, or the logic should be corrected.
 


### PR DESCRIPTION
This effectively takes the content of `../description.adoc` and adds mentions to `co_return` and `[[noreturn]]` functions (`abort`, `std::terminate`).

---

No implementation changes are required.