### PR TITLE
Modify rule S1238[cfamily]: exception for coroutines (CPP-3317)

### DIFF
--- a/rules/S1238/cfamily/rule.adoc
+++ b/rules/S1238/cfamily/rule.adoc
@@ -35,6 +35,11 @@ void registerStudent(School &school, Student const & p); // Compliant, avoids us
 void dump(ostream &out, XmlNode const &node); // Compliant, no slicing
 ----
 
+== Exceptions
+
+This rule does not flag large objects passed by value to coroutines
+because passing arguments by reference to a coroutine often leads to dangling references, e.g., after suspension and resumpion of the coroutine.
+
 == See
 
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const[{cpp} Core Guidelines F.16] - For “in” parameters, pass cheaply-copied types by value and others by reference to ``++const++``


### PR DESCRIPTION
Implementation ticket: CPP-3317