### PR TITLE
Modify rule S6193: mark quick fix as infeasible

### DIFF
--- a/rules/S6193/cfamily/metadata.json
+++ b/rules/S6193/cfamily/metadata.json
@@ -17,5 +17,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }


### PR DESCRIPTION
Since the rule is based on a regex, it won't be possible to implement quick fixes.