### PR TITLE
Correct the meaning of a PR link for a rule (under specification)

### DIFF
--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
   tabScroller: {
     flexGrow: 0
   },
-  unimplemented: {
+  underspecified: {
     color: 'red'
   },
 
@@ -239,8 +239,7 @@ export function RulePage(props: any) {
   }
 
   if (coverage !== "Not Covered") {
-    prUrl = undefined;
-    branch = 'master'; 
+    branch = 'master';
   }
 
   let editOnGithubUrl = 'https://github.com/SonarSource/rspec/blob/' +
@@ -258,7 +257,7 @@ export function RulePage(props: any) {
   }
   let prLink = <></>;
   if (prUrl) {
-      prLink = <div><span className={classes.unimplemented}>Not implemented (see <a href={prUrl}>PR</a>)</span></div>
+      prLink = <div><span className={classes.underspecified}>Under specification (see <a href={prUrl}>PR</a>)</span></div>
   }
   const ruleNumber = ruleid.substring(1);
 


### PR DESCRIPTION
Existence of a PR link means the rule specification is not merged to master yet,
and might still be undergoing specification.
It should not be hidden if the rule is already covered by an analyzer.

If the rule is still in the PR it means it's specification is not complete,
and might change before the PR is merged.

The original meaning of "Not implemented" stems from the deprecated policy of
merging the rspec to the master before merging the implementation of the rule
in an analyzer (which itself was caused by the technical limitation of rule-api,
since removed).