### PR TITLE
S1226: CPP-2006 Align RSPEC description with current rule implementation

### DIFF
--- a/rules/S1226/cfamily/rule.adoc
+++ b/rules/S1226/cfamily/rule.adoc
@@ -1,14 +1,14 @@
-While it is technically correct to assign to parameters from within function bodies, doing so before the parameter value is read is likely a bug. Instead, initial values of parameters should be, if not treated as ``++final++``, then at least read before reassignment.
+While it is technically correct to assign to parameters from within function bodies, it is better to use temporary variables to store intermediate results.
+
+Allowing parameters to be assigned to also reduces the code readability as developers will not be able to know whether the original parameter or some temporary variable is being accessed without going through the whole function.
 
 == Noncompliant Code Example
 
 ----
 int glob = 0;
-void function (int a, bool b) {
-  if (b) {
-    a = glob; // Noncompliant
-  }
-  otherFunction(a);
+void function (int a) {
+  a = glob; // Noncompliant
+  ...
 }
 ----
 
@@ -16,15 +16,11 @@ void function (int a, bool b) {
 
 ----
 int glob = 0;
-void function (int a bool b) {
-  int c = b ? a : glob;
-  otherFunction(c);
+void function (int a) {
+  int b = glob;
+  ...
 }
 ----
-
-== Exceptions
-
-In {cpp}, pass-by-reference can sometimes be used for "out" parameters (even if using the return value of the function is most of the time a better alternative). Therefore, parameters passed by reference will be ignored by this rule.
 
 == See
 


### PR DESCRIPTION
The RSPEC was changed, but not the implementation. This PR re-establishes the previous RSPEC. The change will be available in another RSPEC that will only be merged together with the implementation.