### PR TITLE
S1768 Revert changes to the RSPEC that are not in sync with the code

### DIFF
--- a/rules/S1768/cfamily/rule.adoc
+++ b/rules/S1768/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Because the value in a variable of an unsigned type or ``++enum++`` can never be less than zero, testing to see if it is negative or checking its absolute value is a useless operation which can only confuse future readers of the code.
+Because the value in a variable of an unsigned type can never be less than zero, testing to see if it is negative is a useless operation which can only confuse future readers of the code.
 
 
 == Noncompliant Code Example
@@ -9,8 +9,6 @@ unsigned int i = 0; // the lowest value this var can have
 if (i >= 0) { // Noncompliant
   do_x(i);
 }
-unsigned int j = abs(i); // Noncompliant
-...
 ----
 
 
@@ -20,8 +18,6 @@ unsigned int j = abs(i); // Noncompliant
 unsigned int i = 0;
 ...
 do_x(i);
-unsigned int j = i;
-...
 ----
 
 


### PR DESCRIPTION
* One change was wrong: Enums can have negative values
* The other one is of little value, especially for a deprecated rule.
