### PR TITLE
Modify Rule S1001: Revert changes introduced by CPP-1307

### DIFF
--- a/rules/S1001/cfamily/metadata.json
+++ b/rules/S1001/cfamily/metadata.json
@@ -1,6 +1,6 @@
 {
-  "title": "\"using-directives\" should not introduce identifiers with the same name from different namespaces",
-  "type": "BUG",
+  "title": "\"using-directives\" should not be used",
+  "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/rules/S1001/cfamily/rule.adoc
+++ b/rules/S1001/cfamily/rule.adoc
@@ -1,22 +1,42 @@
-"using-directives" add additional scopes to the set of scopes searched during name lookup. All identifiers in these scopes become visible. If two different namespaces contain some identifiers with same names then it can quickly become error-prone as it increases the possibility that the identifier found by the compiler does not meet developer expectations. This rule raises an issue as soon a "using" directive leads to introduce an ambiguity.
+`using` directives add additional scopes to the set of scopes searched during name lookup. All identifiers in these scopes become visible, increasing the possibility that the identifier found by the compiler does not meet developer expectations.
+
+Using-declarations or fully-qualified names restricts the set of names considered to only the name explicitly specified, and so these are safer options.
 
 
 == Noncompliant Code Example
 
 ----
 namespace NS1 {
-  int foo;
-  int bar;
+  int f();
 }
 
-using namespace NS1; // OK
+using namespace NS1; // Noncompliant
 
-namespace NS2 {
-  int foo;
-  int somethingElse;
+void g() {
+  f();
+}
+----
+
+== Compliant Solution
+
+----
+namespace NS1 {
+  int f();
 }
 
-using namespace NS2; // Noncompliant as there might be an ambiguity between NS1::foo and NS2::foo
+void g() {
+  NS1::f();
+}
+
+// Or
+
+using NS1::f; // Compliant, this is a using declaration
+
+void g() {
+  f();
+}
+
+
 ----
 
 


### PR DESCRIPTION
The changes in the RSPEC were never implemented. They will be put in another PR.

Also rewrite the examples.
