### PR TITLE
Modify Rule S5131: Message clarity

### DIFF
--- a/rules/S5131/message.adoc
+++ b/rules/S5131/message.adoc
@@ -1,4 +1,3 @@
 === Message
 
-Change this code to not reflect user-controlled data.
-
+Sanitize this user-controlled data before reflecting it.

--- a/rules/S5131/message.adoc
+++ b/rules/S5131/message.adoc
@@ -1,3 +1,3 @@
 === Message
 
-Sanitize this user-controlled data before reflecting it.
+Change this code to not reflect unsanitized user-controlled data.


### PR DESCRIPTION
This RSpec message has been misunderstood by multiple Sonar* users claiming that "reflecting user-controlled data" was exactly their goal. This message aims to clarify our point when we detect XSS in code and advise users to make a fix.