### PR TITLE
RULEAPI-680: Remove the mention of [label]

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -258,8 +258,11 @@ This way, your comment will only be visible in GitHub preview and on the Search 
 
 == Untriaged Pull Requests
 
-Untriaged PRs are the ones without any label. You can easily see all of them with the filter https://github.com/SonarSource/rspec/pulls?q=is%3Aopen+is%3Apr+no%3Alabel[`Label > Unlabeled`]. +
-All triaged PRs should have at least one label that corresponds to the bubble(s) the PR is related to. This allows bubbles to easily filter out the PRs they are interested in.
+Untriaged PRs are the ones without any GitHub label assigned to them.
+You can easily see all of them with the filter https://github.com/SonarSource/rspec/pulls?q=is%3Aopen+is%3Apr+no%3Alabel[`no:label`].
+
+All triaged PRs should have at least one label that corresponds to the bubble(s) the PR is related to.
+This allows bubbles to easily filter the PRs they are interested in.
 
 == Tooling
 https://github.com/SonarSource/rspec/tree/master/rspec-tools[rspec-tools]::

--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,8 @@ include::supported_languages.adoc[]
 
 image::img/new-rule-workflow.png[]
 
-You should see https://github.com/pulls/assigned[a new pull request assigned to you]. It might take up to a few minutes to appear.
+You should see https://github.com/pulls/assigned[a new pull request assigned to you] with the appropriate language labels.
+It might take up to a few minutes to appear.
 It contains a scaffolding of files for the new rule. Feel free to modify it as you please.
 
 The title of the PR for a new rule will say only "Create rule Sxxxx", which is not very informative. +
@@ -98,7 +99,7 @@ Otherwise, you can use https://asciidoclive.com/[AsciiDocLIVE] and this https://
 Similar to adding a new rule, if the rule exists on the main branch, trigger the "Add language to a rule" GitHub action.
 
 . go to the https://github.com/SonarSource/rspec/actions/workflows/add_language.yml[Add language to a rule] GitHub action
-. click on the grey _Run wokflow_ button (on the right).
+. click on the grey _Run workflow_ button (on the right).
 . in the field _"ID of an existing rule"_ write the ID of the existing rule you want to add language to.
 It must be in a form `Sxxxx` where `xxxx` is the number of the rule.
 For example: `S100`, `S1234`, or `S6000`.
@@ -109,16 +110,16 @@ include::supported_languages.adoc[]
 
 image::img/add-language-workflow.png[]
 
-You should see https://github.com/pulls/assigned[a new pull request assigned to you].
+You should see https://github.com/pulls/assigned[a new pull request assigned to you] with the appropriate language label.
 It might take up to a few minutes to appear.
 It contains a scaffolding of files for the new rule. Feel free to modify it as you please.
 
-The title of the PR for a new rule will say only "Create rule Sxxxx[lang]", which is not very informative. +
+The title of the PR for a new rule will say only "Create rule Sxxxx", which is not very informative. +
 Modify the title to better summarize the nature or the rule, so that it is easier to find when searching through unimplemented rules.
-Do preserve the "Create rule Sxxxx[lang]" prefix, as it is used by our tooling.
+Do preserve the "Create rule Sxxxx" prefix, as it is used by our tooling.
 For example:
 ----
-Create rule S100[java]: Method names should comply with a naming convention
+Create rule S100: Method names should comply with a naming convention
 ----
 
 Otherwise, if the rule has not been merged yet (i.e. the rule has not been implemented by any plugin), you can use the already existing PR corresponding to this rule. +

--- a/rspec-tools/rspec_tools/create_rule.py
+++ b/rspec-tools/rspec_tools/create_rule.py
@@ -198,7 +198,7 @@ class RuleCreator:
     return self._create_pull_request(
       github_api,
       branch_name,
-      f'Create rule S{rule_number}[{language}]',
+      f'Create rule S{rule_number}',
       f'You can preview this rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{language}) (updated a few minutes after each push).',
       [label],
       user

--- a/rspec-tools/tests/test_create_rule.py
+++ b/rspec-tools/tests/test_create_rule.py
@@ -288,7 +288,7 @@ def test_add_language_new_pr(rule_creator: RuleCreator):
   rule_creator.add_language_pull_request(mockGithub, rule_number, language, 'mylab', user='testuser')
 
   ghRepoMock.create_pull.assert_called_once();
-  assert ghRepoMock.create_pull.call_args.kwargs['title'].startswith(f'Create rule S{rule_number}[{language}]')
+  assert ghRepoMock.create_pull.call_args.kwargs['title'].startswith(f'Create rule S{rule_number}')
   ghRepoMock.create_pull.call_args.kwargs['head'].startswith('rule/')
   pullMock.add_to_assignees.assert_called_with('testuser');
   pullMock.add_to_labels.assert_called_with('mylab');


### PR DESCRIPTION
Update documentation and script.

---

FWIW, the doc already contains (~L260):

> == Untriaged Pull Requests
Untriaged PRs are the ones without any label. You can easily see all of them with the filter Label > Unlabeled.
All triaged PRs should have at least one label that corresponds to the bubble(s) the PR is related to. This allows bubbles to easily filter out the PRs they are interested in.

So the requirement to have labels is already there. Let me know if this should be reworded to have more visibility.

---

I also didn't document how to use `git` commands to extract the history for a given language. _If_ it should be included, I'm not exactly sure where this should go. It also feels out of scope somehow, but I don't have a strong opinion on this point.