### PR TITLE
RULEAPI-722: Always cleanup temprary branch for coverage

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -46,6 +46,7 @@ jobs:
       uses: andymckay/cancel-action@0.2
 
     - name: 'Push the updated coverage file to a new branch'
+      id: create-temp-branch
       if: steps.gen-coverage.outputs.new_coverage == 'true'
       working-directory: 'rspec'
       run: |
@@ -78,7 +79,7 @@ jobs:
         git push origin master
 
     - name: 'Delete the temporary branch'
-      if: steps.gen-coverage.outputs.new_coverage == 'true'
+      if: always() && steps.create-temp-branch.conclusion == 'success'
       uses: dawidd6/action-delete-branch@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Unless `always()` or `failure()` is configured `step.if` behave as if `success() &&` was included. 