### PR TITLE
Modify Rule S4423[cfamily]: add missing nullptr check for libcurl examples

### DIFF
--- a/rules/S4423/cfamily/rule.adoc
+++ b/rules/S4423/cfamily/rule.adoc
@@ -13,10 +13,12 @@ curl_global_init(CURL_GLOBAL_DEFAULT);
 // CURL_SSLVERSION_DEFAULT is the default option for CURLOPT_SSLVERSION
 // It means legacy version TLSv1 and TLSv1.1 are enabled
 curl = curl_easy_init(); // Noncompliant
-curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+if (curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
-// Perform the request
-curl_easy_perform(curl);
+  // Perform the request
+  curl_easy_perform(curl);
+}
 ----
 
 ----
@@ -26,12 +28,14 @@ CURL *curl;
 curl_global_init(CURL_GLOBAL_DEFAULT);
 
 curl = curl_easy_init();
-curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+if (curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
-curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1); // Noncompliant;  legacy version TLSv1 and TLSv1.1 are enabled
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1); // Noncompliant;  legacy version TLSv1 and TLSv1.1 are enabled
 
-//Perform the request
-curl_easy_perform(curl);
+  //Perform the request
+  curl_easy_perform(curl);
+}
 ----
 
 https://github.com/openssl/openssl[OpenSSL]
@@ -93,12 +97,14 @@ CURL *curl;
 curl_global_init(CURL_GLOBAL_DEFAULT);
 
 curl = curl_easy_init();
-curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+if (curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
-curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // Compliant; enables TLSv1.2 / TLSv1.3 version only
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // Compliant; enables TLSv1.2 / TLSv1.3 version only
 
-// Perform the request
-curl_easy_perform(curl);
+  // Perform the request
+  curl_easy_perform(curl);
+}
 ----
 
 https://github.com/openssl/openssl[OpenSSL]


### PR DESCRIPTION
Do not merge before the FP is fixed