### PR TITLE
Fix UI warnings: <div> nested in <p> and list items lacking keys

### DIFF
--- a/frontend/src/SearchHit.tsx
+++ b/frontend/src/SearchHit.tsx
@@ -101,7 +101,7 @@ export function SearchHit(props: SearchHitProps) {
     }
   });
   const titles = props.data.titles.map(title => (
-    <Typography key="title" variant="body1" component="p" gutterBottom>
+    <Typography key={title} variant="body1" component="p" gutterBottom>
       {title}
     </Typography>
   ));

--- a/frontend/src/SearchHit.tsx
+++ b/frontend/src/SearchHit.tsx
@@ -83,12 +83,13 @@ export function SearchHit(props: SearchHitProps) {
   const actualLanguages = props.data.languages.filter(language => language !== 'default');
   actualLanguages.forEach(lang => {
     const ruleState = ruleStateInAnalyzer(lang, props.data.all_keys);
-    const chip = <Link component={RouterLink} to={`/${props.data.id}/${lang}`} style={{ textDecoration: 'none' }}>
+    const chip = <Link key={lang} component={RouterLink} to={`/${props.data.id}/${lang}`} style={{ textDecoration: 'none' }}>
       <Chip
         classes={{root: (classes as any)[ruleState + 'LanguageChip']}}
         label={lang}
         color="primary"
         clickable
+        key="{lang}"
       />
     </Link>;
     if (ruleState === 'covered') {
@@ -100,25 +101,25 @@ export function SearchHit(props: SearchHitProps) {
     }
   });
   const titles = props.data.titles.map(title => (
-    <Typography variant="body1" component="p" gutterBottom>
+    <Typography key="title" variant="body1" component="p" gutterBottom>
       {title}
     </Typography>
   ));
 
   const coveredBlock = coveredLanguages.length === 0 ? <></> 
-    : <Typography variant="body2" component="p" classes={{root: classes.language}}>
+    : <Typography key="covered-marker" variant="body2" component="div" classes={{root: classes.language}}>
       <Chip classes={{root: classes.coveredMarker}} label="Covered" color="primary" variant="outlined" />
       {coveredLanguages}
     </Typography>;
 
   const targetedBlock = targetedLanguages.length === 0 ? <></> 
-    :<Typography variant="body2" component="p" classes={{root: classes.language}}>
+    : <Typography key="targeted-marker" variant="body2" component="div" classes={{root: classes.language}}>
       <Chip classes={{root: classes.targetedMarker}} label="Targeted" color="secondary" variant="outlined" />
       {targetedLanguages}
     </Typography>;
 
   const removedBlock = removedLanguages.length === 0 ? <></> 
-    :<Typography variant="body2" component="p" classes={{root: classes.language}}>
+    : <Typography key="removed-marker" variant="body2" component="div" classes={{root: classes.language}}>
       <Chip classes={{root: classes.removedMarker}} label="Removed" color="secondary" variant="outlined" />
       {removedLanguages}
     </Typography>;
@@ -126,7 +127,7 @@ export function SearchHit(props: SearchHitProps) {
   return (
     <Card variant="outlined" classes={{root: classes.searchHit}}>
       <CardContent>
-        <Typography classes={{root: classes.ruleid}} variant="h5" component="h5" gutterBottom>
+        <Typography key="rule-id" classes={{root: classes.ruleid}} variant="h5" component="h5" gutterBottom>
           <Link component={RouterLink} to={`/${props.data.id}`}>
             <div> Rule {props.data.id} </div>
           </Link>

--- a/frontend/src/SearchHit.tsx
+++ b/frontend/src/SearchHit.tsx
@@ -83,7 +83,8 @@ export function SearchHit(props: SearchHitProps) {
   const actualLanguages = props.data.languages.filter(language => language !== 'default');
   actualLanguages.forEach(lang => {
     const ruleState = ruleStateInAnalyzer(lang, props.data.all_keys);
-    const chip = <Link key={lang} component={RouterLink} to={`/${props.data.id}/${lang}`} style={{ textDecoration: 'none' }}>
+    const chip = <Link key={lang} component={RouterLink} to={`/${props.data.id}/${lang}`}
+                       style={{ textDecoration: 'none' }}>
       <Chip
         classes={{root: (classes as any)[ruleState + 'LanguageChip']}}
         label={lang}

--- a/frontend/src/SearchPage.tsx
+++ b/frontend/src/SearchPage.tsx
@@ -72,7 +72,7 @@ export const SearchPage = () => {
 
     // making the exact match to appear first in the search results
     results.forEach(indexedRule => {
-      const box = <Box className={classes.searchHitBox}>
+      const box = <Box key={indexedRule.id} className={classes.searchHitBox}>
         <SearchHit key={indexedRule.id} data={indexedRule}/>
       </Box>;
       if(indexedRule.all_keys.some(key => key === upperCaseQuery)) {
@@ -223,7 +223,7 @@ export const SearchPage = () => {
     <Container maxWidth="md">
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <Box className={classes.topRow}>
+          <Box key="total-num" className={classes.topRow}>
             <Box className={classes.resultsCount}>
               <Typography variant="subtitle1">Number of rules found: {numberOfHits}</Typography>
             </Box>


### PR DESCRIPTION
Fix the two warnings observed when testing the SearchPage component:

- Each child in an array should have a unique "key" prop.
  -> add a key prop to list items
- `<div>` cannot be nested in `<p>` (or sth to that effect)
  -> change the relevant Typography components from "p" to "div"