### PR TITLE
RULEAPI-571: test the UI components

### DIFF
--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -223,7 +223,7 @@ export function RulePage(props: any) {
     const coverageMapper = (key: any, range: any) => {
       if (typeof range === "string") {
         return (
-          <li >{key}: {range}</li>
+          <li key={key} >{key}: {range}</li>
         );
       } else {
         return (

--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -149,7 +149,7 @@ function ticketsAndImplementationPRsLinks(ruleNumber: string, title: string, lan
     const upperCaseLanguage = language.toUpperCase();
     const jiraProject = languageToJiraProject.get(upperCaseLanguage);
     const githubProject = languageToGithubProject.get(upperCaseLanguage);
-    const titleWihoutQuotes = title.replaceAll('"','');
+    const titleWihoutQuotes = title.replace(/"/g, "'");
 
     const implementationPRsLink = (
       <Link href={`https://github.com/SonarSource/${githubProject}/pulls?q=is%3Apr+"S${ruleNumber}"+OR+"RSPEC-${ruleNumber}"`}>

--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -216,7 +216,7 @@ export function RulePage(props: any) {
     languagesTabs = metadataJSON.all_languages.map(lang => { 
       const ruleState = ruleStateInAnalyzer(lang, metadataJSON!.allKeys);
       const classNames = classes.tab + ' ' + (classes as any)[ruleState + 'Tab'];
-      return <Tab label={lang} value={lang} className={classNames} />;
+      return <Tab key={lang} label={lang} value={lang} className={classNames} />;
     });
     metadataJSONString = JSON.stringify(metadataJSON, null, 2);
 

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
+import { render, screen } from '@testing-library/react';
+import App from '../App';
 
 beforeEach(() => {
     window.history.pushState({}, 'RSPEC Search Page', '/rspec/#/rspec/');

--- a/frontend/src/__tests__/RulePage.test.tsx
+++ b/frontend/src/__tests__/RulePage.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import fs from 'fs';
+import path from 'path';
+import { render } from '@testing-library/react';
+import { RulePage } from '../RulePage';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+beforeEach(() => {
+    const rulesPath = path.join(__dirname, '..', 'deployment', '__tests__', 'resources', 'plugin_rules');
+    const specS1000 = fs.readFileSync(path.join(rulesPath, 'S1000', 'cfamily-description.html')).toString();
+    const metadataS1000 = fs.readFileSync(path.join(rulesPath, 'S1000', 'cfamily-metadata.json')).toString();
+    const specS3457 = fs.readFileSync(path.join(rulesPath, 'S3457', 'csharp-description.html')).toString();
+    const metadataS3457 = fs.readFileSync(path.join(rulesPath, 'S3457', 'csharp-metadata.json')).toString();
+    function fetchMock(url, opts) {
+        const coveredRulesUrl = `${process.env.PUBLIC_URL}/covered_rules.json`;
+        const specUrlS1000 = `${process.env.PUBLIC_URL}/rules/S1000/cfamily-description.html`;
+        const metadataUrlS1000 = `${process.env.PUBLIC_URL}/rules/S1000/cfamily-metadata.json`;
+        const specUrlS3457 = `${process.env.PUBLIC_URL}/rules/S3457/csharp-description.html`;
+        const metadataUrlS3457 = `${process.env.PUBLIC_URL}/rules/S3457/csharp-metadata.json`;
+        const specUrlS3457Generic = `${process.env.PUBLIC_URL}/rules/S3457/default-description.html`;
+        const metadataUrlS3457Generic = `${process.env.PUBLIC_URL}/rules/S3457/default-metadata.json`;
+        if (url === specUrlS1000) {
+            return Promise.resolve({text: () => Promise.resolve(specS1000)});
+        } else if (url === metadataUrlS1000) {
+            return Promise.resolve({json: () => Promise.resolve(JSON.parse(metadataS1000))});
+        } if (url === specUrlS3457) {
+            return Promise.resolve({text: () => Promise.resolve(specS3457)});
+        } else if (url === metadataUrlS3457) {
+            return Promise.resolve({json: () => Promise.resolve(JSON.parse(metadataS3457))});
+        } if (url === specUrlS3457Generic) {
+            return Promise.resolve({text: () => Promise.resolve(specS3457)});
+        } else if (url === metadataUrlS3457Generic) {
+            return Promise.resolve({json: () => Promise.resolve(JSON.parse(metadataS3457))});
+        } else if (url === coveredRulesUrl) {
+            return Promise.resolve({json: () => Promise.resolve({'ABAP': {'S100': 'ver1', 'S200': 'ver2'},
+                                                                 'CSH' : {'S3457': 'c#1'},
+                                                                 'C': {'S100': 'c1', 'S234': {'since': 'c2',
+                                                                                              'until': 'c3'}}})});
+        } else {
+            return Promise.reject('unexpected url ' + url);
+        }
+    }
+    jest.spyOn(global, 'fetch').mockImplementation(fetchMock);
+});
+
+afterEach(() => {
+    global.fetch.mockClear();
+});
+
+test('renders cfamily version of S1000', async () => {
+    const history = createMemoryHistory();
+    history.push('/rspec/#/rspec/S1000/cfamily');
+    const match = {params: {ruleid: "S1000", language: "cfamily"}};
+    const { findByText, asFragment } = render(<Router history={history}>
+        <RulePage match={match} />
+    </Router>);
+    await findByText(/S1000/);
+    await findByText(/Implementation tickets on Jira/);
+    // some random phrase from the rule specification
+    await findByText(/7-3-3 - There shall be no unnamed namespaces in header files./);
+    expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders C# version of S3457 (using GH for issues instead of Jira)', async () => {
+    const history = createMemoryHistory();
+    history.push('/rspec/#/rspec/S3457/csharp');
+    const match = {params: {ruleid: "S3457", language: "csharp"}};
+    const { findByText, asFragment } = render(<Router history={history}>
+        <RulePage match={match} />
+    </Router>);
+    await findByText(/S3457/);
+    await findByText(/Implementation issues on GitHub/);
+    expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders generic version of S3457', async () => {
+    const history = createMemoryHistory();
+    history.push('/rspec/#/rspec/S3457');
+    const match = {params: {ruleid: "S3457"}};
+    const { findAllByText, asFragment } = render(<Router history={history}>
+        <RulePage match={match} />
+    </Router>);
+    await findAllByText(/S3457/);
+    await findAllByText(/cfamily/);
+    await findAllByText(/csharp/);
+    expect(asFragment()).toMatchSnapshot();
+});

--- a/frontend/src/__tests__/SearchPage.test.tsx
+++ b/frontend/src/__tests__/SearchPage.test.tsx
@@ -33,8 +33,6 @@ beforeEach(() => {
             }
         })
     }
-
-    window.history.pushState({}, 'RSPEC Search Page', '/rspec/#/rspec/');
     jest.spyOn(global, 'fetch').mockImplementation(fetchMock);
 });
 

--- a/frontend/src/__tests__/SearchPage.test.tsx
+++ b/frontend/src/__tests__/SearchPage.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import path from 'path';
+import { render } from '@testing-library/react';
+import { SearchPage } from '../SearchPage';
+import { buildIndexStore, buildSearchIndex } from '../deployment/searchIndex';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+beforeEach(() => {
+    const rulePath = path.join(__dirname, '..', 'deployment', '__tests__', 'resources', 'plugin_rules');
+    const [indexStore, indexAggregates] = buildIndexStore(rulePath);
+    const searchIndex = buildSearchIndex(indexStore);
+    function fetchMock(url, opts) {
+        const indexUrl = `${process.env.PUBLIC_URL}/rules/rule-index.json`;
+        const storeDataUrl = `${process.env.PUBLIC_URL}/rules/rule-index-store.json`;
+        const aggregatesUrl = `${process.env.PUBLIC_URL}/rules/rule-index-aggregates.json`;
+        const coveredRulesUrl = `${process.env.PUBLIC_URL}/covered_rules.json`;
+        return Promise.resolve({
+            json: () => {
+                if (url === indexUrl) {
+                    return Promise.resolve(JSON.parse(JSON.stringify(searchIndex)));
+                } else if (url === storeDataUrl) {
+                    return Promise.resolve(JSON.parse(JSON.stringify(indexStore)));
+                } else if (url === aggregatesUrl) {
+                    return Promise.resolve(JSON.parse(JSON.stringify(indexAggregates)));
+                } else if (url === coveredRulesUrl) {
+                    return Promise.resolve({'ABAP': {'S100': 'ver1', 'S200': 'ver2'},
+                                            'C': {'S100': 'c1', 'S234': {'since': 'c2',
+                                                                         'until': 'c3'}}});
+                } else {
+                    return Promise.reject('unexpected url ' + url);
+                }
+            }
+        })
+    }
+
+    window.history.pushState({}, 'RSPEC Search Page', '/rspec/#/rspec/');
+    jest.spyOn(global, 'fetch').mockImplementation(fetchMock);
+});
+
+afterEach(() => {
+    global.fetch.mockClear();
+});
+
+test('renders the list of all rules', async () => {
+    const history = createMemoryHistory();
+    history.push('/rspec/#/rspec/');
+    const { findByText, asFragment } = render(<Router history={history}><SearchPage /></Router>);
+    await findByText(/rules found/i);
+    expect(asFragment()).toMatchSnapshot();
+});
+

--- a/frontend/src/__tests__/SearchPage.test.tsx
+++ b/frontend/src/__tests__/SearchPage.test.tsx
@@ -5,35 +5,31 @@ import { SearchPage } from '../SearchPage';
 import { buildIndexStore, buildSearchIndex } from '../deployment/searchIndex';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
+import { fetchMock } from '../testutils';
+
+function normalize(obj) {
+    // Lunr (the search engine) expects its objects to have been
+    // serialized and deserialized when it is queried.
+    // This is not a no-op, because, for example, it translates function references to
+    // simple labels on the serialization step, and then uses these labels to
+    // restore the function references when loading.
+    return JSON.parse(JSON.stringify(obj));
+}
 
 beforeEach(() => {
     const rulePath = path.join(__dirname, '..', 'deployment', '__tests__', 'resources', 'plugin_rules');
     const [indexStore, indexAggregates] = buildIndexStore(rulePath);
     const searchIndex = buildSearchIndex(indexStore);
-    function fetchMock(url, opts) {
-        const indexUrl = `${process.env.PUBLIC_URL}/rules/rule-index.json`;
-        const storeDataUrl = `${process.env.PUBLIC_URL}/rules/rule-index-store.json`;
-        const aggregatesUrl = `${process.env.PUBLIC_URL}/rules/rule-index-aggregates.json`;
-        const coveredRulesUrl = `${process.env.PUBLIC_URL}/covered_rules.json`;
-        return Promise.resolve({
-            json: () => {
-                if (url === indexUrl) {
-                    return Promise.resolve(JSON.parse(JSON.stringify(searchIndex)));
-                } else if (url === storeDataUrl) {
-                    return Promise.resolve(JSON.parse(JSON.stringify(indexStore)));
-                } else if (url === aggregatesUrl) {
-                    return Promise.resolve(JSON.parse(JSON.stringify(indexAggregates)));
-                } else if (url === coveredRulesUrl) {
-                    return Promise.resolve({'ABAP': {'S100': 'ver1', 'S200': 'ver2'},
-                                            'C': {'S100': 'c1', 'S234': {'since': 'c2',
-                                                                         'until': 'c3'}}});
-                } else {
-                    return Promise.reject('unexpected url ' + url);
-                }
-            }
-        })
-    }
-    jest.spyOn(global, 'fetch').mockImplementation(fetchMock);
+    const rootUrl = process.env.PUBLIC_URL;
+    let mockUrls = {};
+    mockUrls[`${rootUrl}/rules/rule-index.json`] = {json: normalize(searchIndex)};
+    mockUrls[`${rootUrl}/rules/rule-index-store.json`] = {json: normalize(indexStore)};
+    mockUrls[`${rootUrl}/rules/rule-index-aggregates.json`] = {json: normalize(indexAggregates)};
+    mockUrls[`${rootUrl}/covered_rules.json`] = {json:
+        {'ABAP': {'S100': 'ver1', 'S200': 'ver2'},
+         'C': {'S100': 'c1', 'S234': {'since': 'c2', 'until': 'c3'}}}
+    };
+    jest.spyOn(global, 'fetch').mockImplementation(fetchMock(mockUrls));
 });
 
 afterEach(() => {

--- a/frontend/src/__tests__/__snapshots__/RulePage.test.tsx.snap
+++ b/frontend/src/__tests__/__snapshots__/RulePage.test.tsx.snap
@@ -1,0 +1,2591 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders C# version of S3457 (using GH for issues instead of Jira) 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="makeStyles-ruleBar-21"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg"
+      >
+        <h2
+          class="MuiTypography-root makeStyles-ruleid-22 MuiTypography-h2"
+        >
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineNone makeStyles-ruleidLink-23 MuiTypography-colorPrimary"
+            href="/S3457"
+          >
+            S3457
+          </a>
+        </h2>
+        <h4
+          class="MuiTypography-root makeStyles-ruleid-22 MuiTypography-h4"
+        />
+        <div
+          class="MuiTabs-root makeStyles-tabRoot-27"
+        >
+          <div
+            class="MuiTabs-scrollable"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller makeStyles-tabScroller-28 MuiTabs-scrollable"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              class="MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-30 makeStyles-targetedTab-32"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  cfamily
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-30 makeStyles-coveredTab-31 Mui-selected"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  csharp
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-30 makeStyles-targetedTab-32"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  java
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-30 makeStyles-targetedTab-32"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  python
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="PrivateTabIndicator-root-37 PrivateTabIndicator-colorPrimary-38 MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthMd"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-24 MuiTypography-h3"
+      >
+        Composite format strings should be used correctly
+      </h3>
+      <div
+        class="MuiBox-root MuiBox-root-34 makeStyles-coverage-25"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Covered Since
+        </h4>
+        <ul>
+          <li>
+            CSH: c#1
+          </li>
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-35 makeStyles-coverage-25"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Related Tickets and Pull Requests
+        </h4>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/rspec/pulls?q=is%3Apr+\\"S3457\\"+OR+\\"RSPEC-3457\\""
+          >
+            Specification Pull Requests
+          </a>
+        </ul>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/sonar-dotnet/pulls?q=is%3Apr+\\"S3457\\"+OR+\\"RSPEC-3457\\""
+          >
+            Implementation Pull Requests
+          </a>
+        </ul>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/sonar-dotnet/issues?q=is%3Aissue+\\"S3457\\"+OR+\\"RSPEC-3457\\""
+          >
+            Implementation issues on GitHub
+          </a>
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-36"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Description
+        </h4>
+        <span
+          class="MuiTypography-root makeStyles-description-26 MuiTypography-body1"
+        >
+          <div>
+            <div>
+              <p>
+                Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected
+behaviors or runtime errors. This rule statically validates the good behavior of composite formats when calling the methods of
+
+                <code>
+                  String.Format
+                </code>
+                , 
+                <code>
+                  StringBuilder.AppendFormat
+                </code>
+                , 
+                <code>
+                  Console.Write
+                </code>
+                , 
+                <code>
+                  Console.WriteLine
+                </code>
+                ,
+
+                <code>
+                  TextWriter.Write
+                </code>
+                , 
+                <code>
+                  TextWriter.WriteLine
+                </code>
+                , 
+                <code>
+                  Debug.WriteLine(String, Object[])
+                </code>
+                ,
+
+                <code>
+                  Trace.TraceError(String, Object[])
+                </code>
+                , 
+                <code>
+                  Trace.TraceInformation(String, Object[])
+                </code>
+                ,
+
+                <code>
+                  Trace.TraceWarning(String, Object[])
+                </code>
+                 and 
+                <code>
+                  TraceSource.TraceInformation(String, Object[])
+                </code>
+                . 
+              </p>
+              
+
+              <h2>
+                Noncompliant Code Example
+              </h2>
+              
+
+              <pre>
+                s = string.Format("{0}", arg0, arg1); // Noncompliant, arg1 is declared but not used.
+s = string.Format("{0} {2}", arg0, arg1, arg2); // Noncompliant, the format item with index 1 is missing so arg1 will not be used.
+s = string.Format("foo"); // Noncompliant, there is no need to use string.Format here.
+
+              </pre>
+              
+
+              <h2>
+                Compliant Solution
+              </h2>
+              
+
+              <pre>
+                s = string.Format("{0}", arg0);
+s = string.Format("{0} {1}", arg0, arg2);
+s = "foo";
+
+              </pre>
+              
+
+              <h2>
+                Exceptions
+              </h2>
+              
+
+              <ul>
+                
+  
+                <li>
+                   No issue is raised if the format string is not a 
+                  <code>
+                    const
+                  </code>
+                  . 
+                </li>
+                
+
+              </ul>
+              
+
+              <pre>
+                var pattern = "{0} {1} {2}";
+var res = string.Format(pattern, 1, 2); // Compliant, not const string are not recognized
+
+              </pre>
+              
+
+              <ul>
+                
+  
+                <li>
+                   No issue is raised if the argument is not an inline creation array. 
+                </li>
+                
+
+              </ul>
+              
+
+              <pre>
+                var array = new int[] {};
+var res = string.Format("{0} {1}", array); // Compliant we don't know the size of the array
+
+              </pre>
+              
+
+              <ul>
+                
+  
+                <li>
+                   This rule doesn't check whether the format specifier (defined after the 
+                  <code>
+                    :
+                  </code>
+                  ) is actually valid. 
+                </li>
+                
+
+              </ul>
+              
+
+              <h2>
+                See
+              </h2>
+              
+
+              <ul>
+                
+  
+                <li>
+                   
+                  <a
+                    href="https://wiki.sei.cmu.edu/confluence/x/J9YxBQ"
+                  >
+                    CERT, FIO47-C.
+                  </a>
+                   - Use valid format strings 
+                </li>
+                
+
+              </ul>
+              
+
+
+            </div>
+            <hr />
+            <a
+              href="https://github.com/SonarSource/rspec/blob/master/rules/S3457/csharp"
+            >
+              Edit on Github
+            </a>
+            <br />
+            <hr />
+            <pre>
+              <code
+                class="json hljs"
+              >
+                {
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "title"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Composite format strings should be used correctly"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "type"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "CODE_SMELL"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "status"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "ready"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "remediation"
+                    </span>
+                  </span>
+                </span>
+                : {
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "func"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Constant/Issue"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "constantCost"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "10min"
+                    </span>
+                  </span>
+                </span>
+                
+  },
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "tags"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "confusing"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultQualityProfiles"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Sonar way"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultSeverity"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Major"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "ruleSpecification"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "RSPEC-3457"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "sqKey"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "S3457"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "scope"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "All"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "all_languages"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "cfamily"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "csharp"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "java"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "python"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "allKeys"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "S3457"
+                    </span>
+                  </span>
+                </span>
+                
+  ]
+}
+              </code>
+            </pre>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`renders cfamily version of S1000 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="makeStyles-ruleBar-1"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg"
+      >
+        <h2
+          class="MuiTypography-root makeStyles-ruleid-2 MuiTypography-h2"
+        >
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineNone makeStyles-ruleidLink-3 MuiTypography-colorPrimary"
+            href="/S1000"
+          >
+            S1000
+          </a>
+        </h2>
+        <h4
+          class="MuiTypography-root makeStyles-ruleid-2 MuiTypography-h4"
+        />
+        <div
+          class="MuiTabs-root makeStyles-tabRoot-7"
+        >
+          <div
+            class="MuiTabs-scrollable"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller makeStyles-tabScroller-8 MuiTabs-scrollable"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              class="MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-10 makeStyles-targetedTab-12 Mui-selected"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  cfamily
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="PrivateTabIndicator-root-17 PrivateTabIndicator-colorPrimary-18 MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthMd"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-4 MuiTypography-h3"
+      >
+        Header files should not contain unnamed namespaces
+      </h3>
+      <div
+        class="MuiBox-root MuiBox-root-14 makeStyles-coverage-5"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Covered Since
+        </h4>
+        <ul>
+          Not Covered
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-15 makeStyles-coverage-5"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Related Tickets and Pull Requests
+        </h4>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/rspec/pulls?q=is%3Apr+\\"S1000\\"+OR+\\"RSPEC-1000\\""
+          >
+            Specification Pull Requests
+          </a>
+        </ul>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/sonar-cpp/pulls?q=is%3Apr+\\"S1000\\"+OR+\\"RSPEC-1000\\""
+          >
+            Implementation Pull Requests
+          </a>
+        </ul>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://jira.sonarsource.com/issues/?jql=project%20%3D%20CPP%20AND%20(text%20~%20%22S1000%22%20OR%20text%20~%20%22RSPEC-1000%22%20OR%20text%20~%20\\"Header files should not contain unnamed namespaces\\")"
+          >
+            Implementation tickets on Jira
+          </a>
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-16"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Description
+        </h4>
+        <span
+          class="MuiTypography-root makeStyles-description-6 MuiTypography-body1"
+        >
+          <div>
+            <div>
+              <div
+                class="paragraph"
+              >
+                
+
+                <p>
+                  An unnamed namespace will be unique within each translation unit. Any declarations appearing in an unnamed namespace in a header will refer to a different entity in each translation unit, which is probably not the expected behavior.
+                </p>
+                
+
+              </div>
+              
+
+              <div
+                class="sect1"
+              >
+                
+
+                <h2
+                  id="_noncompliant_code_example"
+                >
+                  Noncompliant Code Example
+                </h2>
+                
+
+                <div
+                  class="sectionbody"
+                >
+                  
+
+                  <div
+                    class="listingblock"
+                  >
+                    
+
+                    <div
+                      class="content"
+                    >
+                      
+
+                      <pre>
+                        // Header.hpp
+namespace                  // Noncompliant
+{
+  extern int32_t x;
+}
+                      </pre>
+                      
+
+                    </div>
+                    
+
+                  </div>
+                  
+
+                  <div
+                    class="listingblock"
+                  >
+                    
+
+                    <div
+                      class="content"
+                    >
+                      
+
+                      <pre>
+                        // File1.cpp
+#include "Header.hpp"
+
+namespace
+{
+  int32_t x;
+}
+
+void fn_a(void)
+{
+  x = 42;
+}
+                      </pre>
+                      
+
+                    </div>
+                    
+
+                  </div>
+                  
+
+                  <div
+                    class="listingblock"
+                  >
+                    
+
+                    <div
+                      class="content"
+                    >
+                      
+
+                      <pre>
+                        // File2.cpp
+#include "Header.hpp"
+
+namespace
+{
+  int32_t x;  // this is a different x than in File1.cpp
+}
+
+void fn_b(void)
+{
+  fn_a();                  // Is expected to initialize "x" to 42
+  if (x == 42)             // But does not, as there are 2 distinct "x" variables
+  {
+  }
+}
+                      </pre>
+                      
+
+                    </div>
+                    
+
+                  </div>
+                  
+
+                </div>
+                
+
+              </div>
+              
+
+              <div
+                class="sect1"
+              >
+                
+
+                <h2
+                  id="_see"
+                >
+                  See
+                </h2>
+                
+
+                <div
+                  class="sectionbody"
+                >
+                  
+
+                  <div
+                    class="ulist"
+                  >
+                    
+
+                    <ul>
+                      
+
+                      <li>
+                        
+
+                        <p>
+                          MISRA C++:2008, 7-3-3 - There shall be no unnamed namespaces in header files.
+                        </p>
+                        
+
+                      </li>
+                      
+
+                      <li>
+                        
+
+                        <p>
+                          <a
+                            href="https://wiki.sei.cmu.edu/confluence/x/VXs-BQ"
+                          >
+                            CERT, DCL59-CPP.
+                          </a>
+                           - Do not define an unnamed namespace in a header file
+                        </p>
+                        
+
+                      </li>
+                      
+
+                    </ul>
+                    
+
+                  </div>
+                  
+
+                </div>
+                
+
+              </div>
+              
+
+              <div
+                class="sect1"
+              >
+                
+
+                <h2
+                  id="_comments_and_links"
+                >
+                  Comments And Links
+                </h2>
+                
+
+                <div
+                  class="sectionbody"
+                >
+                  
+
+                  <div
+                    class="paragraph"
+                  >
+                    
+
+                    <p>
+                      (visible only on this page)
+                    </p>
+                    
+
+                  </div>
+                  
+
+                  <div
+                    class="sect2"
+                  >
+                    
+
+                    <h3
+                      id="_on_8_feb_2018_004304_thomas_epperson_wrote"
+                    >
+                      on 8 Feb 2018, 00:43:04 Thomas Epperson wrote:
+                    </h3>
+                    
+
+                    <div
+                      class="paragraph"
+                    >
+                      
+
+                      <p>
+                        The implementation incorrectly flags unnamed namespaces in source files. The specs only refer to unnamed namespaces in HEADER files.
+                      </p>
+                      
+
+                    </div>
+                    
+
+                    <div
+                      class="paragraph"
+                    >
+                      
+
+                      <p>
+                        See reported bugs in https://sonarcloud.io/dashboard?id=uglyoldbob_decompiler%3Arestructure
+                      </p>
+                      
+
+                    </div>
+                    
+
+                  </div>
+                  
+
+                </div>
+                
+
+              </div>
+            </div>
+            <hr />
+            <a
+              href="https://github.com/SonarSource/rspec/blob/master/rules/S1000/cfamily"
+            >
+              Edit on Github
+            </a>
+            <br />
+            <hr />
+            <pre>
+              <code
+                class="json hljs"
+              >
+                {
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "title"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Header files should not contain unnamed namespaces"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "type"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "CODE_SMELL"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "status"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "ready"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "remediation"
+                    </span>
+                  </span>
+                </span>
+                : {
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "func"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Constant/Issue"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "constantCost"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "1h"
+                    </span>
+                  </span>
+                </span>
+                
+  },
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "tags"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "cert"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "misra-c++2008"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "pitfall"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "extra"
+                    </span>
+                  </span>
+                </span>
+                : {
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "coveredLanguages"
+                    </span>
+                  </span>
+                </span>
+                : [
+      
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "C++"
+                    </span>
+                  </span>
+                </span>
+                ,
+      
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "C"
+                    </span>
+                  </span>
+                </span>
+                
+    ],
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "replacementRules"
+                    </span>
+                  </span>
+                </span>
+                : []
+  },
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultSeverity"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Major"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "ruleSpecification"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "RSPEC-1000"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "sqKey"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "UnnamedNamespaceInHeader"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "scope"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Main"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultQualityProfiles"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Sonar way"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "MISRA C++ 2008 recommended"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "all_languages"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "cfamily"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "allKeys"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "UnnamedNamespaceInHeader"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "branch"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "master"
+                    </span>
+                  </span>
+                </span>
+                
+}
+              </code>
+            </pre>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`renders generic version of S3457 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="makeStyles-ruleBar-41"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg"
+      >
+        <h2
+          class="MuiTypography-root makeStyles-ruleid-42 MuiTypography-h2"
+        >
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineNone makeStyles-ruleidLink-43 MuiTypography-colorPrimary"
+            href="/S3457"
+          >
+            S3457
+          </a>
+        </h2>
+        <h4
+          class="MuiTypography-root makeStyles-ruleid-42 MuiTypography-h4"
+        />
+        <div
+          class="MuiTabs-root makeStyles-tabRoot-47"
+        >
+          <div
+            class="MuiTabs-scrollable"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller makeStyles-tabScroller-48 MuiTabs-scrollable"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              class="MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-50 makeStyles-targetedTab-52"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  cfamily
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-50 makeStyles-coveredTab-51"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  csharp
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-50 makeStyles-targetedTab-52"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  java
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary makeStyles-tab-50 makeStyles-targetedTab-52"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="MuiTab-wrapper"
+                >
+                  python
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="PrivateTabIndicator-root-57 PrivateTabIndicator-colorPrimary-58 MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthMd"
+    >
+      <h3
+        class="MuiTypography-root makeStyles-title-44 MuiTypography-h3"
+      >
+        Composite format strings should be used correctly
+      </h3>
+      <div
+        class="MuiBox-root MuiBox-root-54 makeStyles-coverage-45"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Covered Since
+        </h4>
+        <ul>
+          <li>
+            CSH: c#1
+          </li>
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-55 makeStyles-coverage-45"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Related Tickets and Pull Requests
+        </h4>
+        <ul>
+          <a
+            class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+            href="https://github.com/SonarSource/rspec/pulls?q=is%3Apr+\\"S3457\\"+OR+\\"RSPEC-3457\\""
+          >
+            Specification Pull Requests
+          </a>
+        </ul>
+        <ul>
+          <div>
+            Select a language to see the implementation pull requests
+          </div>
+        </ul>
+        <ul>
+          <div>
+            Select a language to see the implementation tickets
+          </div>
+        </ul>
+      </div>
+      <div
+        class="MuiBox-root MuiBox-root-56"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4"
+        >
+          Description
+        </h4>
+        <span
+          class="MuiTypography-root makeStyles-description-46 MuiTypography-body1"
+        >
+          <div>
+            <div>
+              <p>
+                Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected
+behaviors or runtime errors. This rule statically validates the good behavior of composite formats when calling the methods of
+
+                <code>
+                  String.Format
+                </code>
+                , 
+                <code>
+                  StringBuilder.AppendFormat
+                </code>
+                , 
+                <code>
+                  Console.Write
+                </code>
+                , 
+                <code>
+                  Console.WriteLine
+                </code>
+                ,
+
+                <code>
+                  TextWriter.Write
+                </code>
+                , 
+                <code>
+                  TextWriter.WriteLine
+                </code>
+                , 
+                <code>
+                  Debug.WriteLine(String, Object[])
+                </code>
+                ,
+
+                <code>
+                  Trace.TraceError(String, Object[])
+                </code>
+                , 
+                <code>
+                  Trace.TraceInformation(String, Object[])
+                </code>
+                ,
+
+                <code>
+                  Trace.TraceWarning(String, Object[])
+                </code>
+                 and 
+                <code>
+                  TraceSource.TraceInformation(String, Object[])
+                </code>
+                . 
+              </p>
+              
+
+              <h2>
+                Noncompliant Code Example
+              </h2>
+              
+
+              <pre>
+                s = string.Format("{0}", arg0, arg1); // Noncompliant, arg1 is declared but not used.
+s = string.Format("{0} {2}", arg0, arg1, arg2); // Noncompliant, the format item with index 1 is missing so arg1 will not be used.
+s = string.Format("foo"); // Noncompliant, there is no need to use string.Format here.
+
+              </pre>
+              
+
+              <h2>
+                Compliant Solution
+              </h2>
+              
+
+              <pre>
+                s = string.Format("{0}", arg0);
+s = string.Format("{0} {1}", arg0, arg2);
+s = "foo";
+
+              </pre>
+              
+
+              <h2>
+                Exceptions
+              </h2>
+              
+
+              <ul>
+                
+  
+                <li>
+                   No issue is raised if the format string is not a 
+                  <code>
+                    const
+                  </code>
+                  . 
+                </li>
+                
+
+              </ul>
+              
+
+              <pre>
+                var pattern = "{0} {1} {2}";
+var res = string.Format(pattern, 1, 2); // Compliant, not const string are not recognized
+
+              </pre>
+              
+
+              <ul>
+                
+  
+                <li>
+                   No issue is raised if the argument is not an inline creation array. 
+                </li>
+                
+
+              </ul>
+              
+
+              <pre>
+                var array = new int[] {};
+var res = string.Format("{0} {1}", array); // Compliant we don't know the size of the array
+
+              </pre>
+              
+
+              <ul>
+                
+  
+                <li>
+                   This rule doesn't check whether the format specifier (defined after the 
+                  <code>
+                    :
+                  </code>
+                  ) is actually valid. 
+                </li>
+                
+
+              </ul>
+              
+
+              <h2>
+                See
+              </h2>
+              
+
+              <ul>
+                
+  
+                <li>
+                   
+                  <a
+                    href="https://wiki.sei.cmu.edu/confluence/x/J9YxBQ"
+                  >
+                    CERT, FIO47-C.
+                  </a>
+                   - Use valid format strings 
+                </li>
+                
+
+              </ul>
+              
+
+
+            </div>
+            <hr />
+            <a
+              href="https://github.com/SonarSource/rspec/blob/master/rules/S3457"
+            >
+              Edit on Github
+            </a>
+            <br />
+            <hr />
+            <pre>
+              <code
+                class="json hljs"
+              >
+                {
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "title"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Composite format strings should be used correctly"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "type"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "CODE_SMELL"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "status"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "ready"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "remediation"
+                    </span>
+                  </span>
+                </span>
+                : {
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "func"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Constant/Issue"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "constantCost"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "10min"
+                    </span>
+                  </span>
+                </span>
+                
+  },
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "tags"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "confusing"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultQualityProfiles"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Sonar way"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "defaultSeverity"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "Major"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "ruleSpecification"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "RSPEC-3457"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "sqKey"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "S3457"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "scope"
+                    </span>
+                  </span>
+                </span>
+                : 
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "All"
+                    </span>
+                  </span>
+                </span>
+                ,
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "all_languages"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "cfamily"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "csharp"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "java"
+                    </span>
+                  </span>
+                </span>
+                ,
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "python"
+                    </span>
+                  </span>
+                </span>
+                
+  ],
+  
+                <span
+                  class="hljs-attr"
+                >
+                  <span
+                    class="hljs-attr"
+                  >
+                    <span
+                      class="hljs-attr"
+                    >
+                      "allKeys"
+                    </span>
+                  </span>
+                </span>
+                : [
+    
+                <span
+                  class="hljs-string"
+                >
+                  <span
+                    class="hljs-string"
+                  >
+                    <span
+                      class="hljs-string"
+                    >
+                      "S3457"
+                    </span>
+                  </span>
+                </span>
+                
+  ]
+}
+              </code>
+            </pre>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/__snapshots__/SearchPage.test.tsx.snap
+++ b/frontend/src/__tests__/__snapshots__/SearchPage.test.tsx.snap
@@ -1,0 +1,639 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the list of all rules 1`] = `
+<DocumentFragment>
+  <div
+    class="makeStyles-root-1"
+  >
+    <div
+      class="makeStyles-searchBar-3"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthMd"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4"
+            >
+              Search Rule Specifications
+            </h4>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
+                data-shrink="true"
+                for="title-query"
+                id="title-query-label"
+              >
+                Rule Title and Description
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+              >
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input"
+                  id="title-query"
+                  placeholder="Search in rule titles and descriptions"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+                  >
+                    <span>
+                      Rule Title and Description
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-3"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                data-shrink="true"
+              >
+                Rule type
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  role="button"
+                  tabindex="0"
+                >
+                  Any
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="ANY"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+                  >
+                    <span>
+                      Rule type
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-5"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                data-shrink="false"
+              >
+                Rule Tags
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span>
+                    ​
+                  </span>
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value=""
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-9"
+                  >
+                    <span>
+                      Rule Tags
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                data-shrink="true"
+              >
+                Language
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  role="button"
+                  tabindex="0"
+                >
+                  Any
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="ANY"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-9 PrivateNotchedOutline-legendNotched-10"
+                  >
+                    <span>
+                      Language
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined"
+                data-shrink="false"
+              >
+                Default Quality Profiles
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span>
+                    ​
+                  </span>
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value=""
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-7 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-9"
+                  >
+                    <span>
+                      Default Quality Profiles
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="makeStyles-searchResults-4"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthMd"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          >
+            <div
+              class="MuiBox-root MuiBox-root-11 makeStyles-topRow-5"
+            >
+              <div
+                class="MuiBox-root MuiBox-root-12 makeStyles-resultsCount-6"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1"
+                >
+                  Number of rules found: 3
+                </h6>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-13 makeStyles-searchHitBox-2"
+            >
+              <div
+                class="MuiPaper-root MuiCard-root makeStyles-searchHit-14 MuiPaper-outlined MuiPaper-rounded"
+              >
+                <div
+                  class="MuiCardContent-root"
+                >
+                  <h5
+                    class="MuiTypography-root makeStyles-ruleid-15 MuiTypography-h5 MuiTypography-gutterBottom"
+                  >
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S1000"
+                    >
+                      <div>
+                         Rule S1000 
+                      </div>
+                    </a>
+                  </h5>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                  >
+                    Header files should not contain unnamed namespaces
+                  </p>
+                  <div
+                    class="MuiTypography-root makeStyles-language-16 MuiTypography-body2"
+                  >
+                    <div
+                      class="MuiChip-root makeStyles-targetedMarker-20 MuiChip-colorSecondary MuiChip-outlined MuiChip-outlinedSecondary"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Targeted
+                      </span>
+                    </div>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S1000/cfamily"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          cfamily
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-23 makeStyles-searchHitBox-2"
+            >
+              <div
+                class="MuiPaper-root MuiCard-root makeStyles-searchHit-14 MuiPaper-outlined MuiPaper-rounded"
+              >
+                <div
+                  class="MuiCardContent-root"
+                >
+                  <h5
+                    class="MuiTypography-root makeStyles-ruleid-15 MuiTypography-h5 MuiTypography-gutterBottom"
+                  >
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S3457"
+                    >
+                      <div>
+                         Rule S3457 
+                      </div>
+                    </a>
+                  </h5>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                  >
+                    Composite format strings should be used correctly
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                  >
+                    Printf-style format strings should be used correctly
+                  </p>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                  >
+                    String formatting should be used correctly
+                  </p>
+                  <div
+                    class="MuiTypography-root makeStyles-language-16 MuiTypography-body2"
+                  >
+                    <div
+                      class="MuiChip-root makeStyles-targetedMarker-20 MuiChip-colorSecondary MuiChip-outlined MuiChip-outlinedSecondary"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Targeted
+                      </span>
+                    </div>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S3457/cfamily"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          cfamily
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S3457/csharp"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          csharp
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S3457/java"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          java
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S3457/python"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          python
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root MuiBox-root-24 makeStyles-searchHitBox-2"
+            >
+              <div
+                class="MuiPaper-root MuiCard-root makeStyles-searchHit-14 MuiPaper-outlined MuiPaper-rounded"
+              >
+                <div
+                  class="MuiCardContent-root"
+                >
+                  <h5
+                    class="MuiTypography-root makeStyles-ruleid-15 MuiTypography-h5 MuiTypography-gutterBottom"
+                  >
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S987"
+                    >
+                      <div>
+                         Rule S987 
+                      </div>
+                    </a>
+                  </h5>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom"
+                  >
+                    "&lt;signal.h&gt;" should not be used
+                  </p>
+                  <div
+                    class="MuiTypography-root makeStyles-language-16 MuiTypography-body2"
+                  >
+                    <div
+                      class="MuiChip-root makeStyles-targetedMarker-20 MuiChip-colorSecondary MuiChip-outlined MuiChip-outlinedSecondary"
+                    >
+                      <span
+                        class="MuiChip-label"
+                      >
+                        Targeted
+                      </span>
+                    </div>
+                    <a
+                      class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
+                      href="/S987/cfamily"
+                      style="text-decoration: none;"
+                    >
+                      <div
+                        class="MuiButtonBase-root MuiChip-root makeStyles-targetedLanguageChip-18 MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <span
+                          class="MuiChip-label"
+                        >
+                          cfamily
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <nav
+              aria-label="pagination navigation"
+              class="MuiPagination-root"
+            >
+              <ul
+                class="MuiPagination-ul"
+              >
+                <li>
+                  <button
+                    aria-label="Go to previous page"
+                    class="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-page Mui-disabled Mui-disabled"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiPaginationItem-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                      />
+                    </svg>
+                  </button>
+                </li>
+                <li>
+                  <button
+                    aria-current="true"
+                    aria-label="page 1"
+                    class="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-page Mui-selected"
+                    tabindex="0"
+                    type="button"
+                  >
+                    1
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </li>
+                <li>
+                  <button
+                    aria-label="Go to next page"
+                    class="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-page Mui-disabled Mui-disabled"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiPaginationItem-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                      />
+                    </svg>
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/deployment/__tests__/resources/plugin_rules/S3457/csharp-metadata.json
+++ b/frontend/src/deployment/__tests__/resources/plugin_rules/S3457/csharp-metadata.json
@@ -15,5 +15,14 @@
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-3457",
   "sqKey": "S3457",
-  "scope": "All"
+  "scope": "All",
+  "all_languages": [
+    "cfamily",
+    "csharp",
+    "java",
+    "python"
+  ],
+  "allKeys": [
+    "S3457"
+  ]
 }

--- a/frontend/src/testutils.ts
+++ b/frontend/src/testutils.ts
@@ -9,7 +9,7 @@
  *        an object containing either `json` or `text` field: {json: ...} or {text: ...}
  * @returns a function that can be passed to replace the implementaion of `fetch`.
  */
-export function fetchMock(mockUrls) {
+export function fetchMock(mockUrls: Record<string, {[K in "json" | "text"]?: any}>): (string, any) => Promise {
   return function(url, opts) {
     if (url in mockUrls) {
       const response = mockUrls[url];

--- a/frontend/src/testutils.ts
+++ b/frontend/src/testutils.ts
@@ -1,4 +1,7 @@
 
+type Fetched = "json" | "text"
+type FetchResult = {[K in Fetched]?: any}
+
 /**
  * Creates a mock `fetch` function. The returned function responds to each url
  * with a promise resolving an object with the provided `json` or `text` field.
@@ -9,7 +12,7 @@
  *        an object containing either `json` or `text` field: {json: ...} or {text: ...}
  * @returns a function that can be passed to replace the implementaion of `fetch`.
  */
-export function fetchMock(mockUrls: Record<string, {[K in "json" | "text"]?: any}>): (string, any) => Promise {
+export function fetchMock(mockUrls: Record<string, FetchResult>):(url: string, opts: any) => Promise<FetchResult> {
   return function(url, opts) {
     if (url in mockUrls) {
       const response = mockUrls[url];

--- a/frontend/src/testutils.ts
+++ b/frontend/src/testutils.ts
@@ -1,6 +1,6 @@
 
-type Fetched = "json" | "text"
-type FetchResult = {[K in Fetched]?: any}
+type Fetched = 'json' | 'text';
+type FetchResult = {[K in Fetched]?: any};
 
 /**
  * Creates a mock `fetch` function. The returned function responds to each url
@@ -17,12 +17,12 @@ export function fetchMock(mockUrls: Record<string, FetchResult>):(url: string, o
     if (url in mockUrls) {
       const response = mockUrls[url];
       if ('json' in response) {
-        return Promise.resolve({json: () => Promise.resolve(response.json)})
+        return Promise.resolve({json: () => Promise.resolve(response.json)});
       } else {
-        return Promise.resolve({text: () => Promise.resolve(response.text)})
+        return Promise.resolve({text: () => Promise.resolve(response.text)});
       }
     } else {
-      return Promise.reject(`unexpected url ${url}`)
+      return Promise.reject(`unexpected url ${url}`);
     }
-  }
+  };
 }

--- a/frontend/src/testutils.ts
+++ b/frontend/src/testutils.ts
@@ -1,0 +1,25 @@
+
+/**
+ * Creates a mock `fetch` function. The returned function responds to each url
+ * with a promise resolving an object with the provided `json` or `text` field.
+ * can be used as
+ *   jest.spyOn(global, 'fetch').mockImplementation(fetchMock(mockUrls));
+ *
+ * @param mockUrls a dictionary url -> value, where url is a string, and the value is
+ *        an object containing either `json` or `text` field: {json: ...} or {text: ...}
+ * @returns a function that can be passed to replace the implementaion of `fetch`.
+ */
+export function fetchMock(mockUrls) {
+  return function(url, opts) {
+    if (url in mockUrls) {
+      const response = mockUrls[url];
+      if ('json' in response) {
+        return Promise.resolve({json: () => Promise.resolve(response.json)})
+      } else {
+        return Promise.resolve({text: () => Promise.resolve(response.text)})
+      }
+    } else {
+      return Promise.reject(`unexpected url ${url}`)
+    }
+  }
+}

--- a/frontend/src/utils/__tests__/useRuleCoverage.test.ts
+++ b/frontend/src/utils/__tests__/useRuleCoverage.test.ts
@@ -66,4 +66,14 @@ describe('search hook', () => {
     expect(result.current.ruleStateInAnalyzer('cfamily', ['S200'])).toBe('targeted');
     expect(result.current.ruleStateInAnalyzer('cfamily', ['S234'])).toBe('removed');
   });
+
+  test('reports for nonexisting language', async () => {
+    const original = console.error;
+    console.error = jest.fn();
+    const { result, waitForNextUpdate } = renderHook(() => useRuleCoverage());
+    await waitForNextUpdate();
+    expect(result.current.ruleStateInAnalyzer('english', ['S100'])).toBe('targeted');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    console.error = original;
+  });
 });

--- a/frontend/src/utils/useRuleCoverage.ts
+++ b/frontend/src/utils/useRuleCoverage.ts
@@ -80,7 +80,9 @@ export function useRuleCoverage() {
   function ruleStateInAnalyzer(language: string, ruleKeys: string[]): 'covered' | 'targeted' | 'removed' {
     const languageKeys = languageToSonarpedia.get(language);
     if (!languageKeys || coveredRulesError || coveredRulesIsLoading) {
-      console.error(`Failed to retrieve coverage for following languages: ${languageKeys}`);
+      if (coveredRulesError) {
+        console.error(`Failed to retrieve coverage for following languages: ${languageKeys} (${coveredRulesError})`);
+      }
       return 'targeted';
     }
     if (!coveredRules) {
@@ -88,7 +90,7 @@ export function useRuleCoverage() {
     }
 
     const result: Version[] = [];
-    languageKeys.forEach(lang => 
+    languageKeys.forEach(lang =>
       ruleKeys.forEach(ruleKey => {
         if (lang in coveredRules && ruleKey in coveredRules[lang]) {
           result.push(coveredRules[lang][ruleKey]);


### PR DESCRIPTION
Mostly snapshot testing, with quite big snapshots. I think they will need to be broken down in the future if they break too often.
Also no interaction testing for the moment.

Not sure what to do with these warnings caused by the `react-highlight` (it uses `highlightBlock` inside. our code doesn't use `highlightBlock` directly). Maybe they will go away if we upgrade it?
```
    console.log
      Deprecated as of 10.7.0. highlightBlock will be removed entirely in v12.0

      at deprecated (node_modules/highlight.js/lib/core.js:1490:11)

    console.log
      Deprecated as of 10.7.0. Please use highlightElement now.

      at deprecated (node_modules/highlight.js/lib/core.js:1490:11)
```