### PR TITLE
RULEAPI-703: Fix warnings emitted during `npm run predeploy`

### DIFF
--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -316,7 +316,7 @@ export function RulePage(props: any) {
       </Box>
 
       <Box>
-        <Typography variant="h4">Description</Typography>
+        <Typography variant="h4">Rule Documentation</Typography>
         <Typography component={'span'} className={classes.description}>
           {description}
         </Typography>

--- a/frontend/src/RulePage.tsx
+++ b/frontend/src/RulePage.tsx
@@ -316,7 +316,6 @@ export function RulePage(props: any) {
       </Box>
 
       <Box>
-        <Typography variant="h4">Rule Documentation</Typography>
         <Typography component={'span'} className={classes.description}>
           {description}
         </Typography>

--- a/frontend/src/deployment/__tests__/description.test.ts
+++ b/frontend/src/deployment/__tests__/description.test.ts
@@ -18,10 +18,17 @@ test('generates html from asciidoc', () => {
 
         const ruleHtml = fs.readFileSync(path.join(dstPath, 'S100', 'java-description.html'));
         expect(ruleHtml.toString()).toEqual(
-          ['<div class="paragraph">',
-          '<p>Generic content',
-          'Specific content</p>',
-          '</div>'].join('\n')
+          [
+            '<div class="sect1">',
+            '<h2 id="_description">Description</h2>',
+            '<div class="sectionbody">',
+            '<div class="paragraph">',
+            '<p>Generic content',
+            'Specific content</p>',
+            '</div>',
+            '</div>',
+            '</div>'
+          ].join('\n')
         );
       });
     });

--- a/frontend/src/deployment/description.ts
+++ b/frontend/src/deployment/description.ts
@@ -73,11 +73,18 @@ function generate_rule_description(srcDir: string, language: string) {
     }
     const baseDir = path.resolve(path.dirname(ruleSrcFile));
     const opts = {
-        attributes: {'rspecator-view': ''},
+        attributes: {
+          'rspecator-view': '',
+          docfile: ruleSrcFile,
+        },
         safe: 'unsafe',
         base_dir: baseDir,
         backend: 'xhtml5',
         to_file: false
     };
-    return asciidoc.convertFile(ruleSrcFile, opts);
+
+    // Every rule documentation has an implicit level-1 "Description" header.
+    const fileData = fs.readFileSync(ruleSrcFile);
+    const data = '== Description\n\n' + fileData;
+    return asciidoc.convert(data, opts);
 }


### PR DESCRIPTION
Follow up from #702.

Parse custom string instead of file and explicitly introduce level-1 section so that asciidoctor sees it.

Preview at: https://marco-antognini-sonarsource.github.io/rspec/#/rspec/S100

Does it look reasonable?