### PR TITLE
Fix the snapshot-test failure resulted from the merge

### DIFF
--- a/frontend/src/__tests__/__snapshots__/RulePage.test.tsx.snap
+++ b/frontend/src/__tests__/__snapshots__/RulePage.test.tsx.snap
@@ -168,11 +168,6 @@ exports[`renders C# version of S3457 (using GH for issues instead of Jira) 1`] =
       <div
         class="MuiBox-root MuiBox-root-36"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4"
-        >
-          Description
-        </h4>
         <span
           class="MuiTypography-root makeStyles-description-26 MuiTypography-body1"
         >
@@ -930,11 +925,6 @@ exports[`renders cfamily version of S1000 1`] = `
       <div
         class="MuiBox-root MuiBox-root-16"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4"
-        >
-          Description
-        </h4>
         <span
           class="MuiTypography-root makeStyles-description-6 MuiTypography-body1"
         >
@@ -1946,11 +1936,6 @@ exports[`renders generic version of S3457 1`] = `
       <div
         class="MuiBox-root MuiBox-root-56"
       >
-        <h4
-          class="MuiTypography-root MuiTypography-h4"
-        >
-          Description
-        </h4>
         <span
           class="MuiTypography-root makeStyles-description-46 MuiTypography-body1"
         >


### PR DESCRIPTION
The broken UI test on master is the result of a temporary relaxation of the policy of "merge only PRs that are up-to-date with master": a snapshot-based test was introduced in one PR (#709) and was passing, and a UI change was introduced in another PR(#715) that changed the snapshot (but was not covered by the test at the time the second PR diverged from master)