### PR TITLE
Modify rule S105: add comment about smart tabs

### DIFF
--- a/rules/S105/comments-and-links.adoc
+++ b/rules/S105/comments-and-links.adoc
@@ -15,3 +15,16 @@ Low value rule for python as:
 * tabs are accepted if the rest of [the code base is already using it](\https://www.python.org/dev/peps/pep-0008/#id18).
 * pycodestyle already supports all PEP8 rules and there is no point for us to reimplement them.
 
+=== on 23 Jan 2022, 22:20 JY Cr wrote:
+
+Fixing the visual size of the indentations for everyone makes it difficult to read the code for people who need a size adapted to their needs or their context.
+
+Indeed, the advantage of tabulation is precisely to make it possible to adapt the readability of the code according to the constraints of the user.
+
+This is an fundamental accessibility criterion.
+
+In addition, this allows a group of developers, some of whom prefer large indentations, and others, more restrained indentations, to work on the same code base (each configuring according to his needs, on his IDE, the visual size of the desired intentation).
+
+Here is an article motivating the deprecation of this rule: https://dev.to/alexandersandberg/why-we-should-default-to-tabs-instead-of-spaces-for-an-accessible-first-environment-101f
+
+In order not to go against readability and accessibility aspects, while avoiding problems related to alignment (different concept from indentation), it is preferable to favor "[smart tabs](https://www.emacswiki.org/emacs/SmartTabs) indentation".


### PR DESCRIPTION
Fixing the visual size of the indentations for everyone makes it difficult to read the code for people who need a size adapted to their needs or their context.

Indeed, the advantage of tabulation is precisely to make it possible to adapt the readability of the code according to the constraints of the user.

This is an fundamental accessibility criterion.

In addition, this allows a group of developers, some of whom prefer large indentations, and others, more restrained indentations, to work on the same code base (each configuring according to his needs, on his IDE, the visual size of the desired intentation).

Here is an article motivating the deprecation of this rule: https://dev.to/alexandersandberg/why-we-should-default-to-tabs-instead-of-spaces-for-an-accessible-first-environment-101f
