### PR TITLE
Reduce amount of debug output in validate_asciidoc.sh

### DIFF
--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -38,7 +38,6 @@ do
     continue
   fi
   dir=${dir%*/}
-  echo "${dir##*/}"
 
   subdircount=$(find "$dir" -maxdepth 1 -type d | wc -l)
 
@@ -58,21 +57,17 @@ do
     for language in $dir/*/
     do
       language=${language%*/}
-      echo "${language##*/}"
       if [[ ! "${supportedLanguages[*]}" == *"${language##*/}"* ]]; then
         echo "ERROR: ${language##*/} is not a supported language"
         exit_code=1
       fi
       RULE="$language/rule.adoc"
       if test -f "$RULE"; then
-        echo "$RULE exists."
         TMP_ADOC="$language/tmp.adoc"
         echo "== Description" > "$TMP_ADOC"
         cat "$RULE" >> "$TMP_ADOC"
         if asciidoctor --failure-level=WARNING -o /dev/null "$TMP_ADOC"; then
-            if asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null "$TMP_ADOC"; then
-                echo "$RULE syntax is fine"
-            else
+            if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null "$TMP_ADOC"; then
                 echo "ERROR: $RULE has incorrect asciidoc in rspecator-view mode"
                 exit_code=1
             fi
@@ -98,7 +93,6 @@ do
   fi
 done
 
-echo "Finished."
 if (( exit_code == 0 )); then
     echo "Success"
 else

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -31,6 +31,8 @@ else
 fi
 cd ..
 
+echo "Testing the following rules: ${affected_rules}"
+
 for dir in $affected_rules
 do
   if [ ! -d "$dir" ]; then


### PR DESCRIPTION
It can be hard to spot actual issues in the log with so much debug output. This PR removes most of it.