### PR TITLE
Use full clone for tests to enable proper new-code detection on SonarQube

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,7 +88,7 @@ validate_asciidoc_task:
     <<: *CONTAINER_DEFINITION
     dockerfile: ci/Dockerfile
     cpu: 1
-    memory: 1G
+    memory: 2G
   env:
     CIRRUS_CLONE_DEPTH: 0
   asciidoc_tests_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ env:
   SONAR_SCANNER_VERSION: 4.6.1.2450
   SONAR_SCANNER_HOME: ${HOME}/.sonar/sonar-scanner-${SONAR_SCANNER_VERSION}-linux
   PATH: ${SONAR_SCANNER_HOME}/bin:$PATH
-  CIRRUS_CLONE_DEPTH: 1
+  CIRRUS_CLONE_DEPTH: 0
   # Use bash (instead of sh on linux or cmd.exe on windows)
   CIRRUS_SHELL: bash
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,8 +78,6 @@ validate_metadata_task:
     dockerfile: ci/Dockerfile
     cpu: 1
     memory: 1G
-  env:
-    CIRRUS_CLONE_DEPTH: 0
   metadata_tests_script:
     - ./ci/validate_metadata.sh
 
@@ -89,8 +87,6 @@ validate_asciidoc_task:
     dockerfile: ci/Dockerfile
     cpu: 1
     memory: 2G
-  env:
-    CIRRUS_CLONE_DEPTH: 0
   asciidoc_tests_script:
     - ./ci/validate_asciidoc.sh
 

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -8,4 +8,3 @@ sonar.test.inclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx
 sonar.javascript.coveragePlugin=lcov
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.cpd.exclusions=src/deployment/__tests__/resources/**
-sonar.coverage.exclusions=src/deployment/index.ts

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -8,3 +8,4 @@ sonar.test.inclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx
 sonar.javascript.coveragePlugin=lcov
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.cpd.exclusions=src/deployment/__tests__/resources/**
+sonar.coverage.exclusions=src/deployment/index.ts


### PR DESCRIPTION
~Excluding the file from coverage analysis for now to avoid SQ blocking PRs that do not touch the code at all. (for some reason, since this file was merged despite the failing QG on SQ, other PRs that target master are assumed to have changed this file and therefore also fail QG)~
