### PR TITLE
Test to accelerate validation

### DIFF
--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -65,7 +65,7 @@ do
       fi
       RULE="$language/rule.adoc"
       if test -f "$RULE"; then
-        TMP_ADOC="$language/tmp.adoc"
+        TMP_ADOC="$language/tmp_$(basename "${dir}")_${language##*/}.adoc"
         echo "== Description" > "$TMP_ADOC"
         cat "$RULE" >> "$TMP_ADOC"
       else
@@ -76,7 +76,7 @@ do
 
     # Check that all adoc are included
     find "$dir" -name "*.adoc" -execdir sh -c 'grep -h "include::" "$1" | grep -v "rule.adoc" | sed "s/include::\(.*\)\[\]/\1/" | xargs -r -I@ realpath "$PWD/@"' shell {} \; > included
-    find "$dir" -name "*.adoc" ! -name 'rule.adoc' ! -name 'tmp.adoc' -exec sh -c 'realpath $1' shell {} \; > created
+    find "$dir" -name "*.adoc" ! -name 'rule.adoc' ! -name 'tmp*.adoc' -exec sh -c 'realpath $1' shell {} \; > created
     orphans=$(comm -1 -3 <(sort -u included) <(sort -u created))
     if [[ -n "$orphans" ]]; then
         printf 'ERROR: These adoc files are not included anywhere:\n-----\n%s\n-----\n' "$orphans"
@@ -86,8 +86,8 @@ do
   fi
 done
 
-if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp.adoc; then
-    if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp.adoc; then
+if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+    if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
         echo "ERROR: malformed asciidoc files in rspecator-view"
         exit_code=1
     fi

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -65,6 +65,9 @@ do
       fi
       RULE="$language/rule.adoc"
       if test -f "$RULE"; then
+        # We build this filename that describes the path to workaround the fact that asciidoctor will not tell
+        # us the path of the file in case of error.
+        # We can remove it if https://github.com/asciidoctor/asciidoctor/issues/3414 is fixed.
         TMP_ADOC="$language/tmp_$(basename "${dir}")_${language##*/}.adoc"
         echo "== Description" > "$TMP_ADOC"
         cat "$RULE" >> "$TMP_ADOC"

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -86,18 +86,18 @@ do
   fi
 done
 
-if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
-    if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
-        echo "ERROR: malformed asciidoc files in rspecator-view"
-        exit_code=1
-    fi
-else
-  echo "ERROR: malformed asciidoc files"
-  exit_code=1
+if [[ $(find rules -name "tmp*.adoc" -print -quit) ]]; then
+  if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+      if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+          echo "ERROR: malformed asciidoc files in rspecator-view"
+          exit_code=1
+      fi
+  else
+    echo "ERROR: malformed asciidoc files"
+    exit_code=1
+  fi
+  find rules -name "tmp*.adoc" -exec rm -f {} \;
 fi
-
-find rules -name tmp.adoc -exec rm -f {} \;
-
 
 if (( exit_code == 0 )); then
     echo "Success"

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -86,9 +86,13 @@ do
   fi
 done
 
-if [[ $(find rules -name "tmp*.adoc" -print -quit) ]]; then
+ADOC_COUNT=$(find rules -name "tmp*.adoc" | wc -l)
+
+if [[ $ADOC_COUNT ]]; then
   if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
-      if ! asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+      if asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+          echo "${ADOC_COUNT} documents checked with succes"
+      else
           echo "ERROR: malformed asciidoc files in rspecator-view"
           exit_code=1
       fi
@@ -96,7 +100,8 @@ if [[ $(find rules -name "tmp*.adoc" -print -quit) ]]; then
     echo "ERROR: malformed asciidoc files"
     exit_code=1
   fi
-  find rules -name "tmp*.adoc" -exec rm -f {} \;
+else
+  echo "No new asciidoc file changed"
 fi
 
 if (( exit_code == 0 )); then


### PR DESCRIPTION
Run asciidoctor on all files at once instead of one by one. That allows us to considerably reduce the time it takes. On the current CI, we go from ~25 minutes to ~5 minutes to analyze all adocs.

There are two visible downsides:
* It is no longer clear which file is failing. This is mitigated by the fact that I renamed each `tmp.adoc` to contain the name of the rule and the language `tmp_S1234_cfamily.adoc`. The real problem should be handled by asciidoctor, but so far, the Issue on their side is stuck: https://github.com/asciidoctor/asciidoctor/issues/3414
* The analysis fails after the first error.

These downsides were considered reasonable because:
* For small changelists they are transparent (if you modify one rule, you know which file is touched and you probably don't have a lot of errors)
* For big changelists they bring a huge time benefit which greatly compensates the potential time loss of having to run tests locally when things go really bad.