### PR TITLE
Bump memory limit for metadata validation task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ validate_metadata_task:
     <<: *CONTAINER_DEFINITION
     dockerfile: ci/Dockerfile
     cpu: 1
-    memory: 1G
+    memory: 2G
   metadata_tests_script:
     - ./ci/validate_metadata.sh
 


### PR DESCRIPTION
1G is not enough for pipenv to install all the dependencies (at least the deps for #771)