### PR TITLE
Add message for omitted attributes.

### DIFF
--- a/rules/S6403/message.adoc
+++ b/rules/S6403/message.adoc
@@ -1,3 +1,5 @@
 === Message
 
 Make sure creating a GCP SQL instance without requiring TLS is safe here.
+
+Omitting {parameter} allows unencrypted connection to the database. Make sure it is safe here.

--- a/rules/S6403/message.adoc
+++ b/rules/S6403/message.adoc
@@ -2,4 +2,4 @@
 
 Make sure creating a GCP SQL instance without requiring TLS is safe here.
 
-Omitting {parameter} allows unencrypted connection to the database. Make sure it is safe here.
+Omitting {parameter} allows unencrypted connections to the database. Make sure it is safe here.


### PR DESCRIPTION
To follow the message standard we have set up, I would suggest formulating a second message for this rule as well, highlighting the absence of an attribute/block.