### PR TITLE
Remove redirecting link to cognitive complexity white-paper

### DIFF
--- a/rules/S3776/see.adoc
+++ b/rules/S3776/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://redirect.sonarsource.com/doc/cognitive-complexity.html[Cognitive Complexity]
+* https://www.sonarsource.com/docs/CognitiveComplexity.pdf[Cognitive Complexity]

--- a/rules/S5871/rule.adoc
+++ b/rules/S5871/rule.adoc
@@ -6,5 +6,5 @@ Because boolean expressions become more difficult to understand with mixed opera
 
 == See
 
-* https://redirect.sonarsource.com/doc/cognitive-complexity.html[Cognitive Complexity]
+* https://www.sonarsource.com/docs/CognitiveComplexity.pdf[Cognitive Complexity]
 

--- a/rules/S6194/rule.adoc
+++ b/rules/S6194/rule.adoc
@@ -3,5 +3,5 @@ Cognitive Complexity is a measure of how hard the control flow of a function is 
 
 == See
 
-* https://redirect.sonarsource.com/doc/cognitive-complexity.html[Cognitive Complexity]
+* https://www.sonarsource.com/docs/CognitiveComplexity.pdf[Cognitive Complexity]
 


### PR DESCRIPTION
Use the direct link to the pdf instead. Currently, both links are equivalent, but the redirection might not work in the future.