### PR TITLE
Mock analyzer repos for the coverage test

### DIFF
--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -142,18 +142,18 @@ def collect_coverage_for_all_versions(repo, coverage):
 
 def collect_coverage_for_version(analyzer_name, git_repo, version, coverage):
   g = Git(git_repo)
-  repo_dir = git_repo.working_tree_dir
   print(f"{analyzer_name} {version}")
-  with pushd(repo_dir):
-    try:
+  repo_dir = git_repo.working_tree_dir
+  try:
+    with pushd(repo_dir):
       git_repo.head.reference = git_repo.commit(version)
       git_repo.head.reset(index=True, working_tree=True)
       g.checkout(version)
       implemented_rules = all_implemented_rules()
       coverage.add_analyzer_version(analyzer_name, version, implemented_rules)
-    except Exception as e:
-      print(f"{analyzer_name} {version} checkout failed: {e}")
-      raise
+  except Exception as e:
+    print(f"{analyzer_name} {version} checkout failed: {e}")
+    raise
 
 def update_coverage_for_all_repos():
   print(f"batch mode for {REPOS}")

--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -5,7 +5,7 @@ from git import Repo
 from git import Git
 from pathlib import Path
 
-from rspec_tools.utils import load_json
+from rspec_tools.utils import (load_json, pushd)
 
 REPOS = ['sonar-abap','sonar-cpp','sonar-cobol','sonar-dotnet','sonar-css','sonar-flex','slang-enterprise','sonar-java','SonarJS','sonar-php','sonar-pli','sonar-plsql','sonar-python','sonar-rpg','sonar-swift','sonar-text','sonar-tsql','sonar-vb','sonar-html','sonar-xml','sonar-kotlin', 'sonar-secrets', 'sonar-security', 'sonar-iac']
 
@@ -144,16 +144,16 @@ def collect_coverage_for_version(analyzer_name, git_repo, version, coverage):
   g = Git(git_repo)
   repo_dir = git_repo.working_tree_dir
   print(f"{analyzer_name} {version}")
-  os.chdir(repo_dir)
-  try:
-    git_repo.head.reference = git_repo.commit(version)
-    git_repo.head.reset(index=True, working_tree=True)
-    g.checkout(version)
-    implemented_rules = all_implemented_rules()
-    coverage.add_analyzer_version(analyzer_name, version, implemented_rules)
-  except Exception as e:
-    print(f"{analyzer_name} {version} checkout failed: {e}")
-  os.chdir('..')
+  with pushd(repo_dir):
+    try:
+      git_repo.head.reference = git_repo.commit(version)
+      git_repo.head.reset(index=True, working_tree=True)
+      g.checkout(version)
+      implemented_rules = all_implemented_rules()
+      coverage.add_analyzer_version(analyzer_name, version, implemented_rules)
+    except Exception as e:
+      print(f"{analyzer_name} {version} checkout failed: {e}")
+      raise
 
 def update_coverage_for_all_repos():
   print(f"batch mode for {REPOS}")

--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -140,9 +140,9 @@ def collect_coverage_for_all_versions(repo, coverage):
     collect_coverage_for_version(repo, git_repo, version, coverage)
   collect_coverage_for_version(repo, git_repo, 'master', coverage)
 
-def collect_coverage_for_version(analyzer_name, git_repo, version, coverage):
+def collect_coverage_for_version(repo_name, git_repo, version, coverage):
   g = Git(git_repo)
-  print(f"{analyzer_name} {version}")
+  print(f"{repo_name} {version}")
   repo_dir = git_repo.working_tree_dir
   try:
     with pushd(repo_dir):
@@ -150,9 +150,9 @@ def collect_coverage_for_version(analyzer_name, git_repo, version, coverage):
       git_repo.head.reset(index=True, working_tree=True)
       g.checkout(version)
       implemented_rules = all_implemented_rules()
-      coverage.add_analyzer_version(analyzer_name, version, implemented_rules)
+      coverage.add_analyzer_version(repo_name, version, implemented_rules)
   except Exception as e:
-    print(f"{analyzer_name} {version} checkout failed: {e}")
+    print(f"{repo_name} {version} checkout failed: {e}")
     raise
 
 def update_coverage_for_all_repos():

--- a/rspec-tools/rspec_tools/utils.py
+++ b/rspec-tools/rspec_tools/utils.py
@@ -1,6 +1,7 @@
 from rspec_tools.errors import InvalidArgumentError
 from pathlib import Path
 from typing import List
+from contextlib import contextmanager
 import shutil
 import re
 import tempfile
@@ -147,3 +148,12 @@ def resolve_rule(rule_id: str) -> int:
 def load_json(file):
   with open(file) as json_file:
     return json.load(json_file)
+
+@contextmanager
+def pushd(new_dir):
+  previous_dir = os.getcwd()
+  os.chdir(new_dir)
+  try:
+    yield
+  finally:
+    os.chdir(previous_dir)

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -168,6 +168,8 @@ def test_update_coverage_no_sonarpedia(tmpdir, mock_git_analyzer_repos, capsys):
     cov = load_json(coverage)
     assert cov == {}
 
+def test_update_coverage_no_sonarpedia(tmpdir, mock_git_analyzer_repos, capsys):
+  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
     with pytest.raises(Exception):
       update_coverage_for_repo_version('broken', 'non-existing')
     assert 'checkout failed' in capsys.readouterr().out

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -1,6 +1,10 @@
 import os
+import shutil
+import pytest
+from git import Repo
+from pathlib import Path
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import (patch, PropertyMock)
 
 from rspec_tools.coverage import (update_coverage_for_all_repos,
                                   update_coverage_for_repo,
@@ -17,9 +21,88 @@ def pushd(new_dir):
   finally:
     os.chdir(previous_dir)
 
+def clear_working_dir(repo_dir):
+  for f in os.listdir(repo_dir):
+    if f != '.git':
+      if os.path.isdir(repo_dir / f):
+        shutil.rmtree(repo_dir / f)
+      else:
+        os.remove(repo_dir / f)
 
-def test_update_coverage_for_repo_version(tmpdir):
-  with pushd(tmpdir):
+# Need to keep the tags ordered, and set the commit dates,
+# so FS is not convenient. use json instead:
+JSTS_SONARPEDIA='{"rules-metadata-path": "r", "languages":["JS", "TS"]}'
+MOCK_REPOS=[{'name':'SonarJS',
+             'versions': [
+               {'name': '3.3.0.5702',
+                'date': '2020-03-03 10:00:00',
+                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
+                          ['r/Sonar_way_profile.json', '{}'],
+                          ['r/S100.json', '{}'], ['r/S1145.json', '{}'],
+                          # not in the rules directory, so not a rule:
+                          ['S200.json', '{}']]},
+               {'name': '5.0.0.6962',
+                'date': '2020-05-01 10:00:00',
+                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
+                          ['r/Sonar_way_profile.json', '{}'],
+                          ['r/S100.json', '{}'], ['r/S1145.json', '{}'], ['r/S1192.json', '{}']]},
+               {'name': '6.7.0.14237',
+                'date': '2020-06-07 10:00:00',
+                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
+                          ['r/Sonar_way_profile.json', '{}'],
+                          ['r/S100.json', '{}'], ['r/S1145.json', '{}'], ['r/S1192.json', '{}']]},
+               {'name': '7.0.0.14528',
+                'date': '2020-07-01 10:00:00',
+                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
+                          ['r/Sonar_way_profile.json', '{}'],
+                          ['r/S100.json', '{}'], ['r/S1192.json', '{}'],
+                          # add a CSS analyzer in this version
+                          ['css-plugin/sonarpedia.json', '{"rules-metadata-path":"cssr", "languages":["CSS"]}'],
+                          ['css-plugin/cssr/S100.json', '{}'],
+                          # add a XML analyzer here too
+                          ['xml/sonarpedia.json', '{"rules-metadata-path":"r", "languages":["XML"]}'],
+                          ['xml/r/S1000.json', '{}']]},
+             ]},
+            {'name':'sonar-xml',
+             'versions': [
+               {'name': '1.2.0.1342',
+                'date': '2020-01-02 10:00:00',
+                'files': [['r/Sonar_way_profile.json', '{}'],
+                          ['sonarpedia.json', '{"rules-metadata-path": "r", "languages":["XML"]}'],
+                          ['r/S103.json', '{}']]}
+             ]}]
+
+@pytest.fixture
+def mock_git_analyzer_repos(tmpdir):
+  mocked_repos = {};
+  for mock_spec in MOCK_REPOS:
+    repo_name = mock_spec['name']
+    repo_dir = tmpdir.mkdir('mock-' + repo_name)
+    repo = Repo.init(str(repo_dir))
+    with repo.config_writer() as config_writer:
+      config_writer.set_value('user', 'name', 'originuser')
+      config_writer.set_value('user', 'email', 'originuser@mock.mock')
+    for tag in mock_spec['versions']:
+      clear_working_dir(repo_dir)
+      for fname, contents in tag['files']:
+        path = Path(repo_dir / fname)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, 'x') as f:
+          f.write(contents)
+      repo.git.add('--all')
+      repo.index.commit(f"adding version {tag['name']}", commit_date=tag['date'], author_date=tag['date'])
+      repo.create_tag(tag['name'])
+    mocked_repos[repo_name] = repo
+  def mock_clone_repo(repo_url, repo_name):
+    return mocked_repos[repo_url.split('/')[-1]]
+  def precloned_repo(x):
+    Repo(x)
+  mock=PropertyMock(side_effect=precloned_repo)
+  mock.clone_from=PropertyMock(side_effect=mock_clone_repo)
+  return mock
+
+def test_update_coverage_for_repo_version(tmpdir, mock_git_analyzer_repos):
+  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
     VER = '3.3.0.5702'
     REPO = 'SonarJS'
     update_coverage_for_repo_version(REPO, VER)
@@ -28,6 +111,7 @@ def test_update_coverage_for_repo_version(tmpdir):
     cov = load_json(coverage)
     assert 'JAVASCRIPT' in cov
     assert 'S100' in cov['JAVASCRIPT']
+    assert 'S200' not in cov['JAVASCRIPT'] # S200.json is not in the rules directory in mock
     assert cov['JAVASCRIPT']['S100'] == {'since': REPO + ' ' + VER, 'until': REPO + ' ' + VER}
 
     # Running it again changes nothing
@@ -49,8 +133,8 @@ def test_update_coverage_for_repo_version(tmpdir):
     assert load_json(coverage)['JAVASCRIPT']['S100'] == REPO + ' ' + VER
 
 
-def test_update_coverage_for_repo(tmpdir):
-  with pushd(tmpdir):
+def test_update_coverage_for_repo(tmpdir, mock_git_analyzer_repos):
+  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
     REPO = 'SonarJS'
     update_coverage_for_repo(REPO)
     coverage = tmpdir.join('covered_rules.json')
@@ -65,13 +149,16 @@ def test_update_coverage_for_repo(tmpdir):
 
 
 @patch('rspec_tools.coverage.REPOS', ['SonarJS', 'sonar-xml'])
-def test_update_coverage_for_all_repos(tmpdir):
-  with pushd(tmpdir):
+def test_update_coverage_for_all_repos(tmpdir, mock_git_analyzer_repos):
+  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
     update_coverage_for_all_repos()
     coverage = tmpdir.join('covered_rules.json')
     assert coverage.exists()
     cov = load_json(coverage)
     assert {'JAVASCRIPT', 'TYPESCRIPT', 'XML', 'CSS'} == set(cov.keys())
     assert 'S100' in cov['JAVASCRIPT']
+    assert {'S100'} == set(cov['CSS'].keys())
     assert 'S100' not in cov['XML']
     assert 'S103' in cov['XML']
+    assert {'S103', 'S1000'} == set(cov['XML'].keys())
+    assert cov['XML']['S1000'] == 'SonarJS 7.0.0.14528'


### PR DESCRIPTION
This removes the dependency on online repositories (on GitHub),
and speeds up the test by stripping the number of versions and files in them to a minimum.
Prepare ground for RULEAPI-753