### PR TITLE
Add styling guide to docs

### DIFF
--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -8,7 +8,7 @@ The official Associated Press Style should be used as a fall-back for topics not
 The guide might be extended in the future when unanimities emerge.
 
 
-Following it should be considered a goal to work towards to to get more homogenous texts.
+Following it should be considered a goal to work towards to get more homogenous texts.
 This will be a long process consisting of many baby steps, such as adjusting the style when rule descriptions are rewritten for the Progressive Education Framework.
 It is acceptable not to have 100% consistency across all texts. The higher the consistency, the better, but differences are expected.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -72,8 +72,8 @@ Do not add punctutation for enumerations.
 
 == Code
 
-Only use inline literals (backtick) for direct code references, for instance, variable names or values, or paths. Inline literals should not be used for anything else.
+Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
 
 Example:: The function throws exceptions of the type `RuntimeException`.
-Example:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
+Example:: Compiling source file "src/generic_file.py" breaks an `assert` call in pytest framework.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -37,13 +37,10 @@ Example:: It is the right way!
 == Numbers
 
 In general, spell out numbers one through nine. Use digits for numbers 10 and higher.
-Be aware that there are many exceptions to this rule. Use digits for any of these cases:
+Be aware that there are many exceptions to this rule. For instance, use digits for units or percentages.
 
- * units
- * percentages
-
-
-Example:: 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
+Example:: 5°C is 9% warmer than yesterday.
+Example:: The condition checks if the value is greater than eight and smaller than 100.
 
 
 Commas should be used to group three digits of numbers larger than 999.
@@ -60,7 +57,8 @@ Do not capitalize the first word after a colon unless it is the start of a sente
 
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
 
-Example:: My code is slick and works. My code is not slow, unreliable, and full of bugs.
+Example:: My code is slick and works.
+Example:: My code is not slow, unreliable, and full of bugs.
 
 === Parentheses
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -73,7 +73,8 @@ Do not add punctutation for enumerations.
 
 == Code
 
-Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
+Only use inline literals (backtick) for direct code references, for instance, variable names or values, or paths. Inline literals should not be used for anything else.
 
 Example:: The function throws exceptions of the type `RuntimeException`.
+Example:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -14,7 +14,7 @@ It is acceptable not to have 100% consistency across all texts. The higher the c
 
 == Language
 
-Use *American English* and its notation.
+Use _American English_ and its notation.
 
 == Acronyms
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -61,7 +61,7 @@ Do not capitalize the first word after a colon unless it is the start of a sente
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
 
 Write:: My code is slick and works. My code is not slow, unreliable, and full of bugs.
-Avoid:: My code is click, and works. My code is not slow, unreliable and full of bugs.
+Avoid:: My code is slick, and works. My code is not slow, unreliable and full of bugs.
 
 === Parentheses
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -42,6 +42,7 @@ Be aware that there are many exceptions to this rule. Use digits for any of thes
  * units
  * percentages
 
+
 Example:: 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
 
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -52,10 +52,6 @@ Commas should be used to group three digits of numbers larger than 999.
 
 == Punctuation
 
-=== Apostrophe
-
-TODO
-
 === Colon
 
 Do not capitalize the first word after a colon unless it is the start of a sentence or a proper noun.

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -59,7 +59,7 @@ Do not capitalize the first word after a colon unless it is the start of a sente
 
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
 
-> My code is slick and works. My code is not slow, unreliable, and full of bugs.
+Example:: My code is slick and works. My code is not slow, unreliable, and full of bugs.
 
 === Parentheses
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -78,12 +78,26 @@ Avoid:: This is a test (example).
 Do not capitalize the first word of list entries unless it is the start of a sentence or a proper noun.
 
 Write::
-Check the variables:
- * foo
- * bar
+Check the values:
+ * size
+ * length
 
+Avoid::
+Check the values:
+ * Size
+ * Length
 
 Do not add punctutation for enumerations.
+
+Write::
+Check the values:
+ * size
+ * length
+
+Avoid::
+Check the values:
+ * size,
+ * length.
 
 == Code
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -1,0 +1,82 @@
+= Styling Guide
+
+This document provides styling guidelines for `+rule.adoc+` and its dependencies.
+
+
+The RSPEC styling guide is loosely based on the Associated Press Style and specially geared to rule descriptions.
+The official Associated Press Style should be used as fall-back for topics that are not defined here.
+The guide might be extended in the future when unanimities emerge.
+
+
+Following it should be considered a goal to work towards to to get more homogenous texts.
+This will be a long process consisting out of many baby steps, for example, adjusting the style when rule descriptions are rewritten for the Progressive Education Framework.
+It is fine to not have 100% consistency across all texts. Simply put, the higher the constistency the better, but differences are expected.
+
+== Language
+
+Use *American English* and its notation.
+
+== Acronyms
+
+Do not use acronyms without defining them first unless they are considered well known by the target audience.
+For example, the acronym `JDK` can be considered common knowledge for a Java developer and does not have to be defined.
+The definition of what is and is not a well known acronym is somewhat subjective.
+It is up to the reviewers of RSPEC pull requests to challenge the use of acronyms that might not be well known.
+
+If possible and sensible spell out the acronym on first use and use generic terms on subsequent mentions.
+For example, refer to _Cross-Site Scripting_ as _the vulnerability_.
+
+> Cross-Site Scripting allows to inject JavaScript code in the context of a web site.
+> The vulnerability can be abused to hijack sessions.
+
+== Contractions
+
+Contractions are considered informal writing and therefore should not be used.
+
+> It is not the first time I write a rule description.
+
+== Numbers
+
+In general, spell out numbers one through nine. Use figures for numbers 10 and higher.
+Be aware that there are many exceptions to this rule. Use figures for any of these cases:
+
+ * units
+ * percentages
+
+> 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
+
+
+Commas should be used to group three digits of numbers that are larger than 999.
+
+> My program creates 1,000,000 forks.
+
+== Punctuation
+
+=== Apostrophe
+
+TODO
+
+=== Colon
+
+Do not capitalize the first word after a colon unless it is the start of a sentence or a proper noun.
+
+==== Comma
+
+To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
+
+> My code is slick and works. My code is not slow, unreliable, and full of bugs.
+
+=== Parentheses
+
+Parentheses should be avoided. If the information is relevant it is preferred to incorparate it directly in a sentence.
+
+== Lists
+
+TODO
+
+== Code
+
+Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
+
+> The function throws exceptions of the type `RuntimeException`.
+

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -26,14 +26,13 @@ It is up to the reviewers of RSPEC pull requests to challenge the use of acronym
 If possible and sensible, spell out the acronym on first use and use generic terms on subsequent mentions.
 For example, refer to _Cross-Site Scripting_ as _the vulnerability_.
 
-> Cross-Site Scripting allows to inject JavaScript code in the context of a website.
-> The vulnerability can be abused to hijack sessions.
+Example:: Cross-Site Scripting allows to inject JavaScript code in the context of a website. The vulnerability can be abused to hijack sessions.
 
 == Contractions
 
 Contractions are considered informal writing and therefore should not be used.
 
-> It is not the first time I have written a rule description.
+Example:: It is the right way!
 
 == Numbers
 
@@ -43,12 +42,12 @@ Be aware that there are many exceptions to this rule. Use figures for any of the
  * units
  * percentages
 
-> 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
+Example:: 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
 
 
 Commas should be used to group three digits of numbers larger than 999.
 
-> My program creates 1,000,000 forks.
+Example:: My program creates 1,000,000 forks.
 
 == Punctuation
 
@@ -76,5 +75,5 @@ Do not add punctutation for enumerations.
 
 Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
 
-> The function throws exceptions of the type `RuntimeException`.
+Example:: The function throws exceptions of the type `RuntimeException`.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -3,14 +3,14 @@
 This document provides styling guidelines for `+rule.adoc+` and its dependencies.
 
 
-The RSPEC styling guide is loosely based on the Associated Press Style and specially geared to rule descriptions.
-The official Associated Press Style should be used as fall-back for topics that are not defined here.
+The RSPEC styling guide is loosely based on the Associated Press Style and geared to rule descriptions.
+The official Associated Press Style should be used as a fall-back for topics not defined here.
 The guide might be extended in the future when unanimities emerge.
 
 
 Following it should be considered a goal to work towards to to get more homogenous texts.
-This will be a long process consisting out of many baby steps, for example, adjusting the style when rule descriptions are rewritten for the Progressive Education Framework.
-It is fine to not have 100% consistency across all texts. Simply put, the higher the constistency the better, but differences are expected.
+This will be a long process consisting of many baby steps, such as adjusting the style when rule descriptions are rewritten for the Progressive Education Framework.
+It is acceptable not to have 100% consistency across all texts. The higher the consistency, the better, but differences are expected.
 
 == Language
 
@@ -19,21 +19,21 @@ Use *American English* and its notation.
 == Acronyms
 
 Do not use acronyms without defining them first unless they are considered well known by the target audience.
-For example, the acronym `JDK` can be considered common knowledge for a Java developer and does not have to be defined.
-The definition of what is and is not a well known acronym is somewhat subjective.
+For example, the acronym _JDK_ can be considered common knowledge for a Java developer and does not have to be defined.
+The definition of what is and is not a well-known acronym is somewhat subjective.
 It is up to the reviewers of RSPEC pull requests to challenge the use of acronyms that might not be well known.
 
-If possible and sensible spell out the acronym on first use and use generic terms on subsequent mentions.
+If possible and sensible, spell out the acronym on first use and use generic terms on subsequent mentions.
 For example, refer to _Cross-Site Scripting_ as _the vulnerability_.
 
-> Cross-Site Scripting allows to inject JavaScript code in the context of a web site.
+> Cross-Site Scripting allows to inject JavaScript code in the context of a website.
 > The vulnerability can be abused to hijack sessions.
 
 == Contractions
 
 Contractions are considered informal writing and therefore should not be used.
 
-> It is not the first time I write a rule description.
+> It is not the first time I have written a rule description.
 
 == Numbers
 
@@ -46,7 +46,7 @@ Be aware that there are many exceptions to this rule. Use figures for any of the
 > 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
 
 
-Commas should be used to group three digits of numbers that are larger than 999.
+Commas should be used to group three digits of numbers larger than 999.
 
 > My program creates 1,000,000 forks.
 
@@ -68,7 +68,7 @@ To avoid ambiguity, add the Oxford comma after the penultimate term in a series 
 
 === Parentheses
 
-Parentheses should be avoided. If the information is relevant it is preferred to incorparate it directly in a sentence.
+Parentheses should be avoided. If the information is relevant, it is preferred to incorporate it directly in a sentence.
 
 == Lists
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -87,7 +87,7 @@ Check the values:
  * Size
  * Length
 
-Do not add punctutation for enumerations.
+Do not add punctuation for enumerations.
 
 Write::
 Check the values:

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -72,7 +72,9 @@ Parentheses should be avoided. If the information is relevant, it is preferred t
 
 == Lists
 
-TODO
+Do not capitalize the first word of list entries unless it is the start of a sentence or a proper noun.
+
+Do not add punctutation for enumerations.
 
 == Code
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -26,26 +26,29 @@ It is up to the reviewers of RSPEC pull requests to challenge the use of acronym
 If possible and sensible, spell out the acronym on first use and use generic terms on subsequent mentions.
 For example, refer to _Cross-Site Scripting_ as _the vulnerability_.
 
-Example:: Cross-Site Scripting allows to inject JavaScript code in the context of a website. The vulnerability can be abused to hijack sessions.
+Write:: Cross-Site Scripting allows to inject JavaScript code in the context of a website. The vulnerability can be abused to hijack sessions.
+Avoid:: XSS allows to inject JS code in the context of a website. XSS can be abused to hijack sessions.
 
 == Contractions
 
 Contractions are considered informal writing and therefore should not be used.
 
-Example:: It is the right way!
+Write:: It is the right way!
+Avoid:: It's not the right way!
 
 == Numbers
 
 In general, spell out numbers one through nine. Use digits for numbers 10 and higher.
 Be aware that there are many exceptions to this rule. For instance, use digits for units or percentages.
 
-Example:: 5°C is 9% warmer than yesterday.
-Example:: The condition checks if the value is greater than eight and smaller than 100.
+Write:: 5°C is 9% warmer than yesterday. The condition checks if the value is greater than eight and smaller than 100.
+Avoid:: The condition checks if the value is greater than 8 and smaller than one hundred.
 
 
 Commas should be used to group three digits of numbers larger than 999.
 
-Example:: My program creates 1,000,000 forks.
+Write:: My program creates 1,000,000 forks.
+Avoid:: My program creates 1000000 forks.
 
 == Punctuation
 
@@ -57,8 +60,8 @@ Do not capitalize the first word after a colon unless it is the start of a sente
 
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
 
-Example:: My code is slick and works.
-Example:: My code is not slow, unreliable, and full of bugs.
+Write:: My code is slick and works. My code is not slow, unreliable, and full of bugs.
+Avoid:: My code is click, and works. My code is not slow, unreliable and full of bugs.
 
 === Parentheses
 
@@ -74,6 +77,6 @@ Do not add punctutation for enumerations.
 
 Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
 
-Example:: The function throws exceptions of the type `RuntimeException`.
-Example:: Compiling source file "src/generic_file.py" breaks an `assert` call in pytest framework.
+Write:: Compiling source file "src/generic_file.py" breaks an `assert` call in pytest framework.
+Avoid:: Compiling source file `src/generic_file.py` breaks an `assert` call in `pytest` framework.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -56,6 +56,9 @@ Avoid:: My program creates 1000000 forks.
 
 Do not capitalize the first word after a colon unless it is the start of a sentence or a proper noun.
 
+Write:: There is only one thing we can do: rewrite.
+Avoid:: There is only one thing we can do: Rewrite.
+
 === Comma
 
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
@@ -66,6 +69,9 @@ Avoid:: My code is slick, and works. My code is not slow, unreliable and full of
 === Parentheses
 
 Parentheses should be avoided. If the information is relevant, it is preferred to incorporate it directly in a sentence.
+
+Write:: This is a test that forms an example.
+Avoid:: This is a test (example).
 
 == Lists
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -60,7 +60,7 @@ TODO
 
 Do not capitalize the first word after a colon unless it is the start of a sentence or a proper noun.
 
-==== Comma
+=== Comma
 
 To avoid ambiguity, add the Oxford comma after the penultimate term in a series of three or more terms.
 

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -77,6 +77,12 @@ Avoid:: This is a test (example).
 
 Do not capitalize the first word of list entries unless it is the start of a sentence or a proper noun.
 
+Write::
+Check the variables:
+ * foo
+ * bar
+
+
 Do not add punctutation for enumerations.
 
 == Code


### PR DESCRIPTION
This PR adds a styling guide as discussed in the ["Language styling guide for RSPEC"](https://discuss.sonarsource.com/t/language-styling-guide-for-rspec/9640) circle.

This document aims to specify the most common use cases that we encounter, similar to the ["Associated Press Style Quick Reference Guide"](https://www.codot.gov/business/grants/safetygrants/assets/APStyleGuideCheatSheet.pdf). It is not and does not aim to be a full reference for every possible case.