### PR TITLE
Modify rule S5131(Education Framework): Fix typos

### DIFF
--- a/rules/S5131/csharp/razor/rule.adoc
+++ b/rules/S5131/csharp/razor/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/csharp/system.web/rule.adoc
+++ b/rules/S5131/csharp/system.web/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/java/javax.servlet.http/rule.adoc
+++ b/rules/S5131/java/javax.servlet.http/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/java/jsp/rule.adoc
+++ b/rules/S5131/java/jsp/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/java/thymeleaf/rule.adoc
+++ b/rules/S5131/java/thymeleaf/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/javascript/rule.adoc
+++ b/rules/S5131/javascript/rule.adoc
@@ -6,7 +6,7 @@ include::../rationale.adoc[]
 
 include::../impact.adoc[]
 
-include::../threat.adoc[]
+include::../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/php/laravel/rule.adoc
+++ b/rules/S5131/php/laravel/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/php/native/rule.adoc
+++ b/rules/S5131/php/native/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/php/symfony/rule.adoc
+++ b/rules/S5131/php/symfony/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/python/django/rule.adoc
+++ b/rules/S5131/python/django/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/python/dtl/rule.adoc
+++ b/rules/S5131/python/dtl/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/python/flask/rule.adoc
+++ b/rules/S5131/python/flask/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 

--- a/rules/S5131/python/jinja/rule.adoc
+++ b/rules/S5131/python/jinja/rule.adoc
@@ -6,7 +6,7 @@ include::../../rationale.adoc[]
 
 include::../../impact.adoc[]
 
-include::../../threat.adoc[]
+include::../../threats.adoc[]
 
 == How to fix it?
 
@@ -20,7 +20,7 @@ include::../../threat.adoc[]
 
 ----
 
-== How does this work?
+=== How does this work?
 
 === Pitfalls
 


### PR DESCRIPTION
I noticed some minor issues with the new skeleton:
- the name change on `threats.adoc` was not reflected in the files mentioning it
- The subsection "How does this work?" was not reflected as a subsection of "How to fix it?"