### PR TITLE
Revert "RULEAPI-755 Update CWE URLs by removing .html suffix, fix http protcol"

### DIFF
--- a/rules/S1041/cfamily/rule.adoc
+++ b/rules/S1041/cfamily/rule.adoc
@@ -5,7 +5,7 @@ include::../compliant.adoc[]
 == See
 
 * MISRA {cpp}:2008, 15-3-2
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1041/see.adoc
+++ b/rules/S1041/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition

--- a/rules/S1049/cfamily/rule.adoc
+++ b/rules/S1049/cfamily/rule.adoc
@@ -42,7 +42,7 @@ void goo ( ) throw ( Exception, int )
 == See
 
 * MISRA {cpp}:2008, 15-5-2
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 * https://www.securecoding.cert.org/confluence/x/EADTAQ[CERT, ERR55-CPP.] - Honor exception specifications
 
 

--- a/rules/S1053/cfamily/rule.adoc
+++ b/rules/S1053/cfamily/rule.adoc
@@ -36,7 +36,7 @@ void fn ( std::string str )
 == See
 
 * MISRA {cpp}:2008, 18-0-5
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1057/plsql/rule.adoc
+++ b/rules/S1057/plsql/rule.adoc
@@ -26,8 +26,8 @@ END;
 == See
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cwe.mitre.org/data/definitions/269[MITRE, CWE-269] - Improper Privilege Management
-* https://cwe.mitre.org/data/definitions/270[MITRE, CWE-270] - Privilege Context Switching Error
+* https://cwe.mitre.org/data/definitions/269.html[MITRE, CWE-269] - Improper Privilege Management
+* https://cwe.mitre.org/data/definitions/270.html[MITRE, CWE-270] - Privilege Context Switching Error
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1079/cfamily/rule.adoc
+++ b/rules/S1079/cfamily/rule.adoc
@@ -33,8 +33,8 @@ scanf("%9s", buffer);     // Compliant - will not overflow
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-* https://cwe.mitre.org/data/definitions/676[MITRE, CWE-676] - Use of Potentially Dangerous Function
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/676.html[MITRE, CWE-676] - Use of Potentially Dangerous Function
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 

--- a/rules/S1081/cfamily/rule.adoc
+++ b/rules/S1081/cfamily/rule.adoc
@@ -31,8 +31,8 @@ gets_s(str, sizeof(str)); // Prevent overflows by enforcing a maximum size for `
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/676[MITRE, CWE-676] - Use of Potentially Dangerous Function
-* https://cwe.mitre.org/data/definitions/119[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
+* https://cwe.mitre.org/data/definitions/676.html[MITRE, CWE-676] - Use of Potentially Dangerous Function
+* https://cwe.mitre.org/data/definitions/119.html[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 

--- a/rules/S1104/see.adoc
+++ b/rules/S1104/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/493[MITRE, CWE-493] - Critical Public Variable Without Final Modifier
+* https://cwe.mitre.org/data/definitions/493.html[MITRE, CWE-493] - Critical Public Variable Without Final Modifier

--- a/rules/S1111/java/rule.adoc
+++ b/rules/S1111/java/rule.adoc
@@ -13,7 +13,7 @@ public void dispose() throws Throwable {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/586[MITRE, CWE-586] - Explicit Call to Finalize()
+* https://cwe.mitre.org/data/definitions/586.html[MITRE, CWE-586] - Explicit Call to Finalize()
 * https://wiki.sei.cmu.edu/confluence/x/4jZGBQ[CERT, MET12-J.] - Do not use finalizers
 
 

--- a/rules/S1114/java/rule.adoc
+++ b/rules/S1114/java/rule.adoc
@@ -31,7 +31,7 @@ protected void finalize() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/568[MITRE, CWE-568] - finalize() Method Without super.finalize()
+* https://cwe.mitre.org/data/definitions/568.html[MITRE, CWE-568] - finalize() Method Without super.finalize()
 * https://wiki.sei.cmu.edu/confluence/x/4jZGBQ[CERT, MET12-J.] - Do not use finalizers
 
 

--- a/rules/S112/cfamily/rule.adoc
+++ b/rules/S112/cfamily/rule.adoc
@@ -19,7 +19,7 @@ throw std::invalid_argument("Unexpected null 'user_id' argument.");
 
 == See
 
-* https://cwe.mitre.org/data/definitions/397[MITRE, CWE-397] - Declaration of Throws for Generic Exception
+* https://cwe.mitre.org/data/definitions/397.html[MITRE, CWE-397] - Declaration of Throws for Generic Exception
 * https://wiki.sei.cmu.edu/confluence/x/_DdGBQ[CERT, ERR07-J.] - Do not throw RuntimeException, Exception, or Throwable
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#Re-exception-types[{cpp} Core Guidelines E.14] - Use purpose-designed user-defined types as exceptions (not built-in types)
 

--- a/rules/S112/java/rule.adoc
+++ b/rules/S112/java/rule.adoc
@@ -23,7 +23,7 @@ public void myOtherMethod throws Exception {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/397[MITRE, CWE-397] - Declaration of Throws for Generic Exception
+* https://cwe.mitre.org/data/definitions/397.html[MITRE, CWE-397] - Declaration of Throws for Generic Exception
 * https://wiki.sei.cmu.edu/confluence/x/_DdGBQ[CERT, ERR07-J.] - Do not throw RuntimeException, Exception, or Throwable
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S112/python/rule.adoc
+++ b/rules/S112/python/rule.adoc
@@ -91,7 +91,7 @@ def caller():
 
 * PEP 352 - https://www.python.org/dev/peps/pep-0352/#exception-hierarchy-changes[Required Superclass for Exceptions]
 * Python Documentation - https://docs.python.org/3/library/exceptions.html#BaseException[Built-in exceptions]
-* https://cwe.mitre.org/data/definitions/397[MITRE, CWE-397] - Declaration of Throws for Generic Exception
+* https://cwe.mitre.org/data/definitions/397.html[MITRE, CWE-397] - Declaration of Throws for Generic Exception
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S112/see.adoc
+++ b/rules/S112/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/397[MITRE, CWE-397] - Declaration of Throws for Generic Exception
+* https://cwe.mitre.org/data/definitions/397.html[MITRE, CWE-397] - Declaration of Throws for Generic Exception

--- a/rules/S1121/cfamily/rule.adoc
+++ b/rules/S1121/cfamily/rule.adoc
@@ -19,7 +19,7 @@ while ((run = keepRunning())) {
 * MISRA C:2004, 13.1 - Assignment operators shall not be used in expressions that yield a Boolean value
 * MISRA {cpp}:2008, 6-2-1 - Assignment operators shall not be used in sub-expressions
 * MISRA C:2012, 13.4 - The result of an assignment operator should not be used
-* https://cwe.mitre.org/data/definitions/481[MITRE, CWE-481] - Assigning instead of Comparing
+* https://cwe.mitre.org/data/definitions/481.html[MITRE, CWE-481] - Assigning instead of Comparing
 * https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[CERT, EXP45-C.] - Do not perform assignments in selection statements
 * https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[CERT, EXP51-J.] - Do not perform assignments in conditional expressions
 

--- a/rules/S1121/java/rule.adoc
+++ b/rules/S1121/java/rule.adoc
@@ -24,7 +24,7 @@ result = (bresult = new byte[len]);
 
 == See
 
-* https://cwe.mitre.org/data/definitions/481[MITRE, CWE-481] - Assigning instead of Comparing
+* https://cwe.mitre.org/data/definitions/481.html[MITRE, CWE-481] - Assigning instead of Comparing
 * https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[CERT, EXP45-C.] - Do not perform assignments in selection statements
 * https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[CERT, EXP51-J.] - Do not perform assignments in conditional expressions
 

--- a/rules/S1121/see.adoc
+++ b/rules/S1121/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/481[MITRE, CWE-481] - Assigning instead of Comparing
+* https://cwe.mitre.org/data/definitions/481.html[MITRE, CWE-481] - Assigning instead of Comparing

--- a/rules/S1127/rule.adoc
+++ b/rules/S1127/rule.adoc
@@ -23,7 +23,7 @@ if (!"foo".equals(variable)) { /* ... */ }
 
 == See
 
-* https://cwe.mitre.org/data/definitions/597[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
+* https://cwe.mitre.org/data/definitions/597.html[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1134/see.adoc
+++ b/rules/S1134/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/546[MITRE, CWE-546] - Suspicious Comment
+* https://cwe.mitre.org/data/definitions/546.html[MITRE, CWE-546] - Suspicious Comment

--- a/rules/S1135/see.adoc
+++ b/rules/S1135/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/546[MITRE, CWE-546] - Suspicious Comment
+* https://cwe.mitre.org/data/definitions/546.html[MITRE, CWE-546] - Suspicious Comment

--- a/rules/S1143/cfamily/rule.adoc
+++ b/rules/S1143/cfamily/rule.adoc
@@ -39,7 +39,7 @@ void fun() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/584[MITRE, CWE-584] - Return Inside Finally Block
+* https://cwe.mitre.org/data/definitions/584.html[MITRE, CWE-584] - Return Inside Finally Block
 * https://wiki.sei.cmu.edu/confluence/x/BTdGBQ[CERT, ERR04-J.] - Do not complete abruptly from a finally block
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1143/java/rule.adoc
+++ b/rules/S1143/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/584[MITRE, CWE-584] - Return Inside Finally Block
+* https://cwe.mitre.org/data/definitions/584.html[MITRE, CWE-584] - Return Inside Finally Block
 * https://wiki.sei.cmu.edu/confluence/x/BTdGBQ[CERT, ERR04-J.] - Do not complete abruptly from a finally block
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1143/see.adoc
+++ b/rules/S1143/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/584[MITRE, CWE-584] - Return Inside Finally Block
+* https://cwe.mitre.org/data/definitions/584.html[MITRE, CWE-584] - Return Inside Finally Block

--- a/rules/S1145/see.adoc
+++ b/rules/S1145/see.adoc
@@ -1,5 +1,5 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True

--- a/rules/S1147/java/rule.adoc
+++ b/rules/S1147/java/rule.adoc
@@ -18,7 +18,7 @@ These methods are ignored inside ``++main++``.
 
 == See
 
-* https://cwe.mitre.org/data/definitions/382[MITRE, CWE-382] - Use of System.exit()
+* https://cwe.mitre.org/data/definitions/382.html[MITRE, CWE-382] - Use of System.exit()
 * https://wiki.sei.cmu.edu/confluence/x/7zZGBQ[CERT, ERR09-J.] - Do not allow untrusted code to terminate the JVM
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1148/java/rule.adoc
+++ b/rules/S1148/java/rule.adoc
@@ -36,7 +36,7 @@ try {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1166/cfamily/rule.adoc
+++ b/rules/S1166/cfamily/rule.adoc
@@ -11,7 +11,7 @@ include::../exceptions.adoc[]
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
 * https://wiki.sei.cmu.edu/confluence/x/xDdGBQ[CERT, ERR00-J.] - Do not suppress or ignore checked exceptions
-* https://cwe.mitre.org/data/definitions/778[MITRE, CWE-778] - Insufficient Logging
+* https://cwe.mitre.org/data/definitions/778.html[MITRE, CWE-778] - Insufficient Logging
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1166/java/rule.adoc
+++ b/rules/S1166/java/rule.adoc
@@ -11,7 +11,7 @@ include::../exceptions.adoc[]
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
 * https://wiki.sei.cmu.edu/confluence/x/xDdGBQ[CERT, ERR00-J.] - Do not suppress or ignore checked exceptions
-* https://cwe.mitre.org/data/definitions/778[MITRE, CWE-778] - Insufficient Logging
+* https://cwe.mitre.org/data/definitions/778.html[MITRE, CWE-778] - Insufficient Logging
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1166/see.adoc
+++ b/rules/S1166/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
-* https://cwe.mitre.org/data/definitions/778[MITRE, CWE-778] - Insufficient Logging
+* https://cwe.mitre.org/data/definitions/778.html[MITRE, CWE-778] - Insufficient Logging

--- a/rules/S1169/plsql/rule.adoc
+++ b/rules/S1169/plsql/rule.adoc
@@ -52,7 +52,7 @@ END;
 
 == See
 
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1174/java/rule.adoc
+++ b/rules/S1174/java/rule.adoc
@@ -19,7 +19,7 @@ public class MyClass {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/583[MITRE, CWE-583] - finalize() Method Declared Public
+* https://cwe.mitre.org/data/definitions/583.html[MITRE, CWE-583] - finalize() Method Declared Public
 * https://wiki.sei.cmu.edu/confluence/x/4jZGBQ[CERT, MET12-J.] - Do not use finalizers
 
 

--- a/rules/S1181/see.adoc
+++ b/rules/S1181/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/396[MITRE, CWE-396] - Declaration of Catch for Generic Exception
+* https://cwe.mitre.org/data/definitions/396.html[MITRE, CWE-396] - Declaration of Catch for Generic Exception
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#Re-exception-types[{cpp} Core Guidelines E.14] - Use purpose-designed user-defined types as exceptions (not built-in types)

--- a/rules/S1182/java/rule.adoc
+++ b/rules/S1182/java/rule.adoc
@@ -72,7 +72,7 @@ class Application {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/580[MITRE, CWE-580] - clone() Method Without super.clone()
+* https://cwe.mitre.org/data/definitions/580.html[MITRE, CWE-580] - clone() Method Without super.clone()
 * https://wiki.sei.cmu.edu/confluence/x/FjZGBQ[CERT, MET53-J.] - Ensure that the clone() method calls super.clone()
 
 

--- a/rules/S1206/java/rule.adoc
+++ b/rules/S1206/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/581[MITRE, CWE-581] - Object Model Violation: Just One of Equals and Hashcode Defined
+* https://cwe.mitre.org/data/definitions/581.html[MITRE, CWE-581] - Object Model Violation: Just One of Equals and Hashcode Defined
 * https://wiki.sei.cmu.edu/confluence/x/7DVGBQ[CERT, MET09-J.] - Classes that define an equals() method must also define a hashCode() method
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1206/see.adoc
+++ b/rules/S1206/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/581[MITRE, CWE-581] - Object Model Violation: Just One of Equals and Hashcode Defined
+* https://cwe.mitre.org/data/definitions/581.html[MITRE, CWE-581] - Object Model Violation: Just One of Equals and Hashcode Defined

--- a/rules/S1217/java/rule.adoc
+++ b/rules/S1217/java/rule.adoc
@@ -24,7 +24,7 @@ myThread.start(); // Compliant
 
 == See
 
-* https://cwe.mitre.org/data/definitions/572[MITRE, CWE-572] - Call to Thread run() instead of start()
+* https://cwe.mitre.org/data/definitions/572.html[MITRE, CWE-572] - Call to Thread run() instead of start()
 * https://wiki.sei.cmu.edu/confluence/x/6DdGBQ[CERT THI00-J.] - Do not invoke Thread.run()
 
 

--- a/rules/S1279/cobol/rule.adoc
+++ b/rules/S1279/cobol/rule.adoc
@@ -12,7 +12,7 @@ DISPLAY "hello world"  *> Noncompliant
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S128/cfamily/rule.adoc
+++ b/rules/S128/cfamily/rule.adoc
@@ -51,7 +51,7 @@ switch (myVariable) {
 * MISRA {cpp}:2008, 6-4-5 - An unconditional throw or break statement shall terminate every non-empty switch-clause
 * MISRA C:2012, 16.1 - All switch statements shall be well-formed
 * MISRA C:2012, 16.3 - An unconditional break statement shall terminate every switch-clause
-* https://cwe.mitre.org/data/definitions/484[MITRE, CWE-484] - Omitted Break Statement in Switch
+* https://cwe.mitre.org/data/definitions/484.html[MITRE, CWE-484] - Omitted Break Statement in Switch
 * https://wiki.sei.cmu.edu/confluence/x/ldYxBQ[CERT, MSC17-C.] - Finish every set of statements associated with a case label with a break statement
 * https://wiki.sei.cmu.edu/confluence/x/1DdGBQ[CERT, MSC52-J.] - Finish every set of statements associated with a case label with a break statement
 

--- a/rules/S128/java/rule.adoc
+++ b/rules/S128/java/rule.adoc
@@ -30,7 +30,7 @@ switch (myVariable) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/484[MITRE, CWE-484] - Omitted Break Statement in Switch
+* https://cwe.mitre.org/data/definitions/484.html[MITRE, CWE-484] - Omitted Break Statement in Switch
 * https://wiki.sei.cmu.edu/confluence/x/ldYxBQ[CERT, MSC17-C.] - Finish every set of statements associated with a case label with a break statement
 * https://wiki.sei.cmu.edu/confluence/x/1DdGBQ[CERT, MSC52-J.] - Finish every set of statements associated with a case label with a break statement
 

--- a/rules/S128/see.adoc
+++ b/rules/S128/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/484[MITRE, CWE-484] - Omitted Break Statement in Switch
+* https://cwe.mitre.org/data/definitions/484.html[MITRE, CWE-484] - Omitted Break Statement in Switch

--- a/rules/S131/cfamily/rule.adoc
+++ b/rules/S131/cfamily/rule.adoc
@@ -40,7 +40,7 @@ switch (param) {
 * MISRA C:2012, 16.1 - All switch statements shall be well-formed
 * MISRA C:2012, 16.4 - Every _switch_ statement shall have a _default_ label
 * MISRA C:2012, 16.5 - A _default_ label shall appear as either the first or the last _switch label_ of a _switch_ statement
-* https://cwe.mitre.org/data/definitions/478[MITRE, CWE-478] - Missing Default Case in Switch Statement
+* https://cwe.mitre.org/data/definitions/478.html[MITRE, CWE-478] - Missing Default Case in Switch Statement
 * https://wiki.sei.cmu.edu/confluence/x/RtYxBQ[CERT, MSC01-C.] - Strive for logical completeness
 
 === See Also

--- a/rules/S131/java/rule.adoc
+++ b/rules/S131/java/rule.adoc
@@ -67,7 +67,7 @@ switch(day) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/478[MITRE, CWE-478] - Missing Default Case in Switch Statement
+* https://cwe.mitre.org/data/definitions/478.html[MITRE, CWE-478] - Missing Default Case in Switch Statement
 * https://wiki.sei.cmu.edu/confluence/x/RtYxBQ[CERT, MSC01-C.] - Strive for logical completeness
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S131/see.adoc
+++ b/rules/S131/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/478[MITRE, CWE-478] - Missing Default Case in Switch Statement
+* https://cwe.mitre.org/data/definitions/478.html[MITRE, CWE-478] - Missing Default Case in Switch Statement

--- a/rules/S1442/see.adoc
+++ b/rules/S1442/see.adoc
@@ -1,4 +1,4 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code

--- a/rules/S1444/cfamily/rule.adoc
+++ b/rules/S1444/cfamily/rule.adoc
@@ -2,7 +2,7 @@ include::../description.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/500[MITRE, CWE-500] - Public Static Field Not Marked Final
+* https://cwe.mitre.org/data/definitions/500.html[MITRE, CWE-500] - Public Static Field Not Marked Final
 * https://wiki.sei.cmu.edu/confluence/x/WjdGBQ[CERT OBJ10-J.] - Do not use public static nonfinal fields
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1444/java/rule.adoc
+++ b/rules/S1444/java/rule.adoc
@@ -22,7 +22,7 @@ public class Greeter {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/500[MITRE, CWE-500] - Public Static Field Not Marked Final
+* https://cwe.mitre.org/data/definitions/500.html[MITRE, CWE-500] - Public Static Field Not Marked Final
 * https://wiki.sei.cmu.edu/confluence/x/WjdGBQ[CERT OBJ10-J.] - Do not use public static nonfinal fields
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1444/see.adoc
+++ b/rules/S1444/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/500[MITRE, CWE-500] - Public Static Field Not Marked Final
+* https://cwe.mitre.org/data/definitions/500.html[MITRE, CWE-500] - Public Static Field Not Marked Final

--- a/rules/S1480/plsql/rule.adoc
+++ b/rules/S1480/plsql/rule.adoc
@@ -3,4 +3,4 @@ TODO
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup

--- a/rules/S1486/abap/rule.adoc
+++ b/rules/S1486/abap/rule.adoc
@@ -25,7 +25,7 @@ ENDIF.
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1493/see.adoc
+++ b/rules/S1493/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - SQL Injection
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - SQL Injection
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S1523/see.adoc
+++ b/rules/S1523/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/95[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
+* https://cwe.mitre.org/data/definitions/95.html[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')

--- a/rules/S1525/javascript/rule.adoc
+++ b/rules/S1525/javascript/rule.adoc
@@ -28,7 +28,7 @@ for (i = 1; i<5; i++) {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1573/rule.adoc
+++ b/rules/S1573/rule.adoc
@@ -3,5 +3,5 @@ If you do not explicitly close a cursor, it will be closed at the end of the tas
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 

--- a/rules/S1628/rpg/rule.adoc
+++ b/rules/S1628/rpg/rule.adoc
@@ -31,7 +31,7 @@ The ``++DEBUG(*YES)++`` and ``++DUMP++`` statements are useful during developmen
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1630/rpg/rule.adoc
+++ b/rules/S1630/rpg/rule.adoc
@@ -55,7 +55,7 @@ F                                     INFSR(*PSSR)
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 
 
 

--- a/rules/S1674/abap/rule.adoc
+++ b/rules/S1674/abap/rule.adoc
@@ -35,7 +35,7 @@ When a block contains a comment, it is not considered to be empty.
 
 == See
 
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 * OWASP Top 10 2017 Category A10 - Insufficient Logging & Monitoring
 
 

--- a/rules/S1685/cobol/rule.adoc
+++ b/rules/S1685/cobol/rule.adoc
@@ -20,7 +20,7 @@ SOURCE-COMPUTER. IBM-370.
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1696/csharp/rule.adoc
+++ b/rules/S1696/csharp/rule.adoc
@@ -41,7 +41,7 @@ public int GetLengthPlusTwo(string str)
 
 == See
 
-* https://cwe.mitre.org/data/definitions/395[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/395.html[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1696/java/rule.adoc
+++ b/rules/S1696/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/395[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/395.html[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference
 * https://tinyurl.com/y6r4amg3[CERT, ERR08-J.] - Do not catch NullPointerException or any of its ancestors
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1696/see.adoc
+++ b/rules/S1696/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/395[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/395.html[MITRE, CWE-395] - Use of NullPointerException Catch to Detect NULL Pointer Dereference

--- a/rules/S1698/cfamily/rule.adoc
+++ b/rules/S1698/cfamily/rule.adoc
@@ -1,8 +1,8 @@
 
 == See
 
-* https://cwe.mitre.org/data/definitions/595[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
-* https://cwe.mitre.org/data/definitions/597[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
+* https://cwe.mitre.org/data/definitions/595.html[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
+* https://cwe.mitre.org/data/definitions/597.html[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
 * https://wiki.sei.cmu.edu/confluence/x/UjdGBQ[CERT, EXP03-J.] - Do not use the equality operators when comparing values of boxed primitives
 * https://wiki.sei.cmu.edu/confluence/x/yDdGBQ[CERT, EXP50-J.] - Do not confuse abstract object equality with reference equality
 

--- a/rules/S1698/java/rule.adoc
+++ b/rules/S1698/java/rule.adoc
@@ -72,8 +72,8 @@ Comparing with ``++java.lang.String++`` and boxed types ``++java.lang.Integer++`
 == See
 
 * S4973 - Strings and Boxed types should be compared using "equals()"
-* https://cwe.mitre.org/data/definitions/595[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
-* https://cwe.mitre.org/data/definitions/597[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
+* https://cwe.mitre.org/data/definitions/595.html[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
+* https://cwe.mitre.org/data/definitions/597.html[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
 * https://wiki.sei.cmu.edu/confluence/x/UjdGBQ[CERT, EXP03-J.] - Do not use the equality operators when comparing values of boxed primitives
 * https://wiki.sei.cmu.edu/confluence/x/yDdGBQ[CERT, EXP50-J.] - Do not confuse abstract object equality with reference equality
 

--- a/rules/S1698/see.adoc
+++ b/rules/S1698/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/595[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
-* https://cwe.mitre.org/data/definitions/597[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
+* https://cwe.mitre.org/data/definitions/595.html[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
+* https://cwe.mitre.org/data/definitions/597.html[MITRE, CWE-597] - Use of Wrong Operator in String Comparison

--- a/rules/S1724/rule.adoc
+++ b/rules/S1724/rule.adoc
@@ -34,7 +34,7 @@ class Bar extends Foo { ... } // compliant Bar is deprecated.
 
 == See
 
-* https://cwe.mitre.org/data/definitions/477[MITRE, CWE-477] - Use of Obsolete Functions
+* https://cwe.mitre.org/data/definitions/477.html[MITRE, CWE-477] - Use of Obsolete Functions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1725/cobol/rule.adoc
+++ b/rules/S1725/cobol/rule.adoc
@@ -21,7 +21,7 @@ CLOSE my-file
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1763/cfamily/rule.adoc
+++ b/rules/S1763/cfamily/rule.adoc
@@ -11,7 +11,7 @@ include::../compliant.adoc[]
 * MISRA C:2004, 14.1 - There shall be no unreachable code
 * MISRA {cpp}:2008, 0-1-1 - A project shall not contain unreachable code
 * MISRA C:2012, 2.1 - A project shall not contain unreachable code
-* https://cwe.mitre.org/data/definitions/561[MITRE, CWE-561] - Dead Code
+* https://cwe.mitre.org/data/definitions/561.html[MITRE, CWE-561] - Dead Code
 * https://wiki.sei.cmu.edu/confluence/x/9DZGBQ[CERT, MSC56-J.] - Detect and remove superfluous code and values
 * https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[CERT, MSC12-C.] - Detect and remove code that has no effect or is never executed
 

--- a/rules/S1763/see.adoc
+++ b/rules/S1763/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/561[MITRE, CWE-561] - Dead Code
+* https://cwe.mitre.org/data/definitions/561.html[MITRE, CWE-561] - Dead Code

--- a/rules/S1854/cfamily/rule.adoc
+++ b/rules/S1854/cfamily/rule.adoc
@@ -15,7 +15,7 @@ This rule ignores:
 
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
 * https://wiki.sei.cmu.edu/confluence/x/39UxBQ[CERT, MSC13-C.] - Detect and remove unused values
 * https://wiki.sei.cmu.edu/confluence/x/9DZGBQ[CERT, MSC56-J.] - Detect and remove superfluous code and values
 

--- a/rules/S1854/java/rule.adoc
+++ b/rules/S1854/java/rule.adoc
@@ -8,7 +8,7 @@ include::../exceptions.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
 * https://wiki.sei.cmu.edu/confluence/x/39UxBQ[CERT, MSC13-C.] - Detect and remove unused values
 * https://wiki.sei.cmu.edu/confluence/x/9DZGBQ[CERT, MSC56-J.] - Detect and remove superfluous code and values
 

--- a/rules/S1854/see.adoc
+++ b/rules/S1854/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')

--- a/rules/S1872/java/rule.adoc
+++ b/rules/S1872/java/rule.adoc
@@ -54,7 +54,7 @@ class Store {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/486[MITRE, CWE-486] - Comparison of Classes by Name
+* https://cwe.mitre.org/data/definitions/486.html[MITRE, CWE-486] - Comparison of Classes by Name
 * https://wiki.sei.cmu.edu/confluence/x/eDdGBQ[CERT, OBJ09-J.] - Compare classes and not class names
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1872/see.adoc
+++ b/rules/S1872/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/486[MITRE, CWE-486] - Comparison of Classes by Name
+* https://cwe.mitre.org/data/definitions/486.html[MITRE, CWE-486] - Comparison of Classes by Name

--- a/rules/S1873/rule.adoc
+++ b/rules/S1873/rule.adoc
@@ -44,8 +44,8 @@ public class Estate {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/582[MITRE, CWE-582] - Array Declared Public, Final, and Static
-* https://cwe.mitre.org/data/definitions/607[MITRE, CWE-607] - Public Static Final Field References Mutable Object
+* https://cwe.mitre.org/data/definitions/582.html[MITRE, CWE-582] - Array Declared Public, Final, and Static
+* https://cwe.mitre.org/data/definitions/607.html[MITRE, CWE-607] - Public Static Final Field References Mutable Object
 * https://wiki.sei.cmu.edu/confluence/x/LjdGBQ[CERT, OBJ01-J.] - Limit accessibility of fields
 * https://wiki.sei.cmu.edu/confluence/x/VzZGBQ[CERT, OBJ13-J.] - Ensure that references to mutable objects are not exposed
 

--- a/rules/S1874/cfamily/rule.adoc
+++ b/rules/S1874/cfamily/rule.adoc
@@ -23,7 +23,7 @@ void example() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/477[MITRE, CWE-477] - Use of Obsolete Functions
+* https://cwe.mitre.org/data/definitions/477.html[MITRE, CWE-477] - Use of Obsolete Functions
 * https://wiki.sei.cmu.edu/confluence/x/6TdGBQ[CERT, MET02-J.] - Do not use deprecated or obsolete classes or methods
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1874/java/rule.adoc
+++ b/rules/S1874/java/rule.adoc
@@ -4,7 +4,7 @@ include::../noncompliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/477[MITRE, CWE-477] - Use of Obsolete Functions
+* https://cwe.mitre.org/data/definitions/477.html[MITRE, CWE-477] - Use of Obsolete Functions
 * https://wiki.sei.cmu.edu/confluence/x/6TdGBQ[CERT, MET02-J.] - Do not use deprecated or obsolete classes or methods
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1874/see.adoc
+++ b/rules/S1874/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/477[MITRE, CWE-477] - Use of Obsolete Functions
+* https://cwe.mitre.org/data/definitions/477.html[MITRE, CWE-477] - Use of Obsolete Functions

--- a/rules/S1875/see.adoc
+++ b/rules/S1875/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+* https://cwe.mitre.org/data/definitions/482.html[MITRE, CWE-482] - Comparing instead of Assigning

--- a/rules/S1876/html/rule.adoc
+++ b/rules/S1876/html/rule.adoc
@@ -46,7 +46,7 @@ It is recommended to remove the comment or change its style so that it is not ou
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/615[MITRE, CWE-615] - Information Exposure Through Comments
+* https://cwe.mitre.org/data/definitions/615.html[MITRE, CWE-615] - Information Exposure Through Comments
 
 
 

--- a/rules/S1944/cfamily/rule.adoc
+++ b/rules/S1944/cfamily/rule.adoc
@@ -24,8 +24,8 @@ int main(int argc, char **argv) {
 * MISRA C:2004, 11.4 - A cast should not be performed between a pointer to object type and an integral type.
 * MISRA {cpp}:2008, 5-2-3 - Casts to a base class from a derived class should not be performed on polymorphic types.
 * https://www.securecoding.cert.org/confluence/x/tgAV[CERT, EXP36-C.] - Do not cast pointers into more strictly aligned pointer types
-* https://cwe.mitre.org/data/definitions/588[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/588.html[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1944/java/rule.adoc
+++ b/rules/S1944/java/rule.adoc
@@ -43,8 +43,8 @@ public class S1944 {
 == See
 
 * https://wiki.sei.cmu.edu/confluence/x/u9UxBQ[CERT, EXP36-C.] - Do not cast pointers into more strictly aligned pointer types
-* https://cwe.mitre.org/data/definitions/588[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/588.html[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1944/see.adoc
+++ b/rules/S1944/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/588[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/588.html[MITRE, CWE-588] - Attempt to Access Child of a Non-structure Pointer
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast

--- a/rules/S1947/rule.adoc
+++ b/rules/S1947/rule.adoc
@@ -31,5 +31,5 @@ if (!isAuthorized($user)) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/698[MITRE, CWE-698] - Execution After Redirect (EAR)
+* https://cwe.mitre.org/data/definitions/698.html[MITRE, CWE-698] - Execution After Redirect (EAR)
 

--- a/rules/S1948/java/rule.adoc
+++ b/rules/S1948/java/rule.adoc
@@ -53,7 +53,7 @@ The alternative to making all members ``++serializable++`` or ``++transient++`` 
 
 == See
 
-* https://cwe.mitre.org/data/definitions/594[MITRE, CWE-594] - Saving Unserializable Objects to Disk
+* https://cwe.mitre.org/data/definitions/594.html[MITRE, CWE-594] - Saving Unserializable Objects to Disk
 * https://docs.oracle.com/javase/6/docs/api/java/io/Serializable.html[Oracle Java 6, Serializable]
 * https://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html[Oracle Java 7, Serializable]
 

--- a/rules/S1951/flex/rule.adoc
+++ b/rules/S1951/flex/rule.adoc
@@ -21,7 +21,7 @@ The ``++trace()++`` function outputs debug statements, which can be read by anyo
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1966/cobol/rule.adoc
+++ b/rules/S1966/cobol/rule.adoc
@@ -44,7 +44,7 @@ END-IF
 
 == See
 
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1967/cobol/rule.adoc
+++ b/rules/S1967/cobol/rule.adoc
@@ -32,7 +32,7 @@ In any case, data loss is always the result when too-large values are moved to t
 
 == See
 
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 
 === See Also
 

--- a/rules/S1989/java/rule.adoc
+++ b/rules/S1989/java/rule.adoc
@@ -38,7 +38,7 @@ public void doGet(HttpServletRequest request, HttpServletResponse response)
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/600[MITRE, CWE-600] - Uncaught Exception in Servlet
+* https://cwe.mitre.org/data/definitions/600.html[MITRE, CWE-600] - Uncaught Exception in Servlet
 * https://wiki.sei.cmu.edu/confluence/x/-zZGBQ[CERT, ERR01-J.] - Do not allow exceptions to expose sensitive information
 
 

--- a/rules/S1998/php/rule.adoc
+++ b/rules/S1998/php/rule.adoc
@@ -26,7 +26,7 @@ myfun($name);
 
 == See
 
-* https://cwe.mitre.org/data/definitions/374[MITRE, CWE-374] - Weakness Base Passing Mutable Objects to an Untrusted Method
+* https://cwe.mitre.org/data/definitions/374.html[MITRE, CWE-374] - Weakness Base Passing Mutable Objects to an Untrusted Method
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2015/php/rule.adoc
+++ b/rules/S2015/php/rule.adoc
@@ -29,7 +29,7 @@ if (authenticated($user)) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
+* https://cwe.mitre.org/data/definitions/457.html[MITRE, CWE-457] - Use of Uninitialized Variable
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2053/see.adoc
+++ b/rules/S2053/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/759[MITRE, CWE-759] - Use of a One-Way Hash without a Salt
-* https://cwe.mitre.org/data/definitions/760[MITRE, CWE-760] - Use of a One-Way Hash with a Predictable Salt
+* https://cwe.mitre.org/data/definitions/759.html[MITRE, CWE-759] - Use of a One-Way Hash without a Salt
+* https://cwe.mitre.org/data/definitions/760.html[MITRE, CWE-760] - Use of a One-Way Hash with a Predictable Salt
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2068/cfamily/rule.adoc
+++ b/rules/S2068/cfamily/rule.adoc
@@ -36,8 +36,8 @@ dbi_conn_set_option(conn, "password", password.c_str()); // Compliant
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://wiki.sei.cmu.edu/confluence/x/OjdGBQ[CERT, MSC03-J.] - Never hard code sensitive information
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#HARD_CODE_PASSWORD[Hard Coded Password]

--- a/rules/S2068/java/rule.adoc
+++ b/rules/S2068/java/rule.adoc
@@ -35,8 +35,8 @@ try {
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://wiki.sei.cmu.edu/confluence/x/OjdGBQ[CERT, MSC03-J.] - Never hard code sensitive information
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#HARD_CODE_PASSWORD[Hard Coded Password]

--- a/rules/S2068/see.adoc
+++ b/rules/S2068/see.adoc
@@ -2,7 +2,7 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#HARD_CODE_PASSWORD[Hard Coded Password]

--- a/rules/S2070/see.adoc
+++ b/rules/S2070/see.adoc
@@ -1,7 +1,7 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/328[MITRE, CWE-328] - Reversible One-Way Hash
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/328.html[MITRE, CWE-328] - Reversible One-Way Hash
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://shattered.io/[SHAttered] - The first concrete collision attack against SHA-1. 

--- a/rules/S2073/rule.adoc
+++ b/rules/S2073/rule.adoc
@@ -20,6 +20,6 @@ Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
 == See
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
-* https://cwe.mitre.org/data/definitions/780[MITRE, CWE-780] - Use of RSA Algorithm without OAEP
+* https://cwe.mitre.org/data/definitions/780.html[MITRE, CWE-780] - Use of RSA Algorithm without OAEP
 * https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration[OWASP Top Ten 2013 Category A5] - Security Misconfiguration
 

--- a/rules/S2076/see.adoc
+++ b/rules/S2076/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * OWASP OS Command Injection Defense https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html[Cheat Sheet]
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/78[MITRE, CWE-78] - Improper Neutralization of Special Elements used in an OS Command
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/78.html[MITRE, CWE-78] - Improper Neutralization of Special Elements used in an OS Command
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S2077/java/rule.adoc
+++ b/rules/S2077/java/rule.adoc
@@ -70,10 +70,10 @@ public User getUserHibernate(org.hibernate.Session session, String data) {
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/564[MITRE, CWE-564] - SQL Injection: Hibernate
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/564.html[MITRE, CWE-564] - SQL Injection: Hibernate
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * https://wiki.sei.cmu.edu/confluence/x/ITdGBQ[CERT, IDS00-J.] - Prevent SQL injection
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * Derived from FindSecBugs rules https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_JPA[Potential SQL/JPQL Injection (JPA)], https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_JDO[Potential SQL/JDOQL Injection (JDO)], https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_HIBERNATE[Potential SQL/HQL Injection (Hibernate)] 

--- a/rules/S2077/see.adoc
+++ b/rules/S2077/see.adoc
@@ -2,9 +2,9 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/564[MITRE, CWE-564] - SQL Injection: Hibernate
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/564.html[MITRE, CWE-564] - SQL Injection: Hibernate
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * Derived from FindSecBugs rules https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_JPA[Potential SQL/JPQL Injection (JPA)], https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_JDO[Potential SQL/JDOQL Injection (JDO)], https://h3xstream.github.io/find-sec-bugs/bugs.htm#SQL_INJECTION_HIBERNATE[Potential SQL/HQL Injection (Hibernate)] 

--- a/rules/S2078/cfamily/rule.adoc
+++ b/rules/S2078/cfamily/rule.adoc
@@ -6,7 +6,7 @@ include::../description.adoc[]
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.ietf.org/rfc/rfc4514.txt[RFC 4514] - LDAP: String Representation of Distinguished Names
 * https://www.ietf.org/rfc/rfc4515.txt[RFC 4515] - LDAP: String Representation of Search Filters
-* https://cwe.mitre.org/data/definitions/90[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
+* https://cwe.mitre.org/data/definitions/90.html[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
 * https://wiki.sei.cmu.edu/confluence/x/bjZGBQ[CERT, IDS54-J.] - Prevent LDAP injection
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2078/java/rule.adoc
+++ b/rules/S2078/java/rule.adoc
@@ -43,7 +43,7 @@ public boolean authenticate(javax.servlet.http.HttpServletRequest request, DirCo
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.ietf.org/rfc/rfc4514.txt[RFC 4514] - LDAP: String Representation of Distinguished Names
 * https://www.ietf.org/rfc/rfc4515.txt[RFC 4515] - LDAP: String Representation of Search Filters
-* https://cwe.mitre.org/data/definitions/90[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
+* https://cwe.mitre.org/data/definitions/90.html[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
 * https://wiki.sei.cmu.edu/confluence/x/bjZGBQ[CERT, IDS54-J.] - Prevent LDAP injection
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2078/see.adoc
+++ b/rules/S2078/see.adoc
@@ -4,5 +4,5 @@
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.ietf.org/rfc/rfc4514.txt[RFC 4514] - LDAP: String Representation of Distinguished Names
 * https://www.ietf.org/rfc/rfc4515.txt[RFC 4515] - LDAP: String Representation of Search Filters
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/90[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/90.html[MITRE, CWE-90] - Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')

--- a/rules/S2083/see.adoc
+++ b/rules/S2083/see.adoc
@@ -4,8 +4,8 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/22[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-* https://cwe.mitre.org/data/definitions/99[MITRE, CWE-99] - Improper Control of Resource Identifiers ('Resource Injection')
-* https://cwe.mitre.org/data/definitions/641[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/22.html[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+* https://cwe.mitre.org/data/definitions/99.html[MITRE, CWE-99] - Improper Control of Resource Identifiers ('Resource Injection')
+* https://cwe.mitre.org/data/definitions/641.html[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S2084/java/rule.adoc
+++ b/rules/S2084/java/rule.adoc
@@ -56,7 +56,7 @@ public class MyServlet extends HttpServlet {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/537[MITRE, CWE-537] - Information Exposure Through Java Runtime Error Message
+* https://cwe.mitre.org/data/definitions/537.html[MITRE, CWE-537] - Information Exposure Through Java Runtime Error Message
 
 
 

--- a/rules/S2085/rule.adoc
+++ b/rules/S2085/rule.adoc
@@ -44,7 +44,7 @@ protected void doGet(HttpServletRequest request, HttpServletResponse response)
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/601[MITRE, CWE-601] - URL Redirection to Untrusted Site
+* https://cwe.mitre.org/data/definitions/601.html[MITRE, CWE-601] - URL Redirection to Untrusted Site
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#UNVALIDATED_REDIRECT[Unvalidated Redirect]
 

--- a/rules/S2086/rule.adoc
+++ b/rules/S2086/rule.adoc
@@ -69,5 +69,5 @@ public User getUser(String user) {
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/652[MITRE, CWE-652] - Improper Neutralization of Data within XQuery Expressions
+* https://cwe.mitre.org/data/definitions/652.html[MITRE, CWE-652] - Improper Neutralization of Data within XQuery Expressions
 

--- a/rules/S2087/see.adoc
+++ b/rules/S2087/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/261[MITRE, CWE-261] - Weak Cryptography for Passwords
+* https://cwe.mitre.org/data/definitions/261.html[MITRE, CWE-261] - Weak Cryptography for Passwords

--- a/rules/S2089/java/rule.adoc
+++ b/rules/S2089/java/rule.adoc
@@ -23,8 +23,8 @@ public class MyServlet extends HttpServlet {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/807[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
-* https://cwe.mitre.org/data/definitions/293[MITRE, CWE-293] - Using Referer Field for Authentication
+* https://cwe.mitre.org/data/definitions/807.html[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
+* https://cwe.mitre.org/data/definitions/293.html[MITRE, CWE-293] - Using Referer Field for Authentication
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 
 

--- a/rules/S2091/cfamily/rule.adoc
+++ b/rules/S2091/cfamily/rule.adoc
@@ -4,7 +4,7 @@ include::../description.adoc[]
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/643[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
+* https://cwe.mitre.org/data/definitions/643.html[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
 * https://wiki.sei.cmu.edu/confluence/x/cDZGBQ[CERT, IDS53-J.] - Prevent XPath Injection
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2091/java/rule.adoc
+++ b/rules/S2091/java/rule.adoc
@@ -46,7 +46,7 @@ public boolean authenticate(javax.servlet.http.HttpServletRequest request, javax
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/643[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
+* https://cwe.mitre.org/data/definitions/643.html[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
 * https://wiki.sei.cmu.edu/confluence/x/cDZGBQ[CERT, IDS53-J.] - Prevent XPath Injection
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2091/see.adoc
+++ b/rules/S2091/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/643[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/643.html[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions

--- a/rules/S2092/see.adoc
+++ b/rules/S2092/see.adoc
@@ -3,7 +3,7 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
-* https://cwe.mitre.org/data/definitions/315[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
-* https://cwe.mitre.org/data/definitions/614[MITRE, CWE-614] - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/315.html[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
+* https://cwe.mitre.org/data/definitions/614.html[MITRE, CWE-614] - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2095/cfamily/rule.adoc
+++ b/rules/S2095/cfamily/rule.adoc
@@ -31,8 +31,8 @@ int fun() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
-* https://cwe.mitre.org/data/definitions/772[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/772.html[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
 * https://wiki.sei.cmu.edu/confluence/x/vjdGBQ[CERT, FIO04-J.] - Release resources when they are no longer needed
 * https://wiki.sei.cmu.edu/confluence/x/QtUxBQ[CERT, FIO42-C.] - Close files when they are no longer needed
 * https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html[Try With Resources]

--- a/rules/S2095/java/rule.adoc
+++ b/rules/S2095/java/rule.adoc
@@ -28,8 +28,8 @@ catch ( ... ) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
-* https://cwe.mitre.org/data/definitions/772[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/772.html[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
 * https://wiki.sei.cmu.edu/confluence/x/vjdGBQ[CERT, FIO04-J.] - Release resources when they are no longer needed
 * https://wiki.sei.cmu.edu/confluence/x/QtUxBQ[CERT, FIO42-C.] - Close files when they are no longer needed
 * https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html[Try With Resources]

--- a/rules/S2095/see.adoc
+++ b/rules/S2095/see.adoc
@@ -1,5 +1,5 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
-* https://cwe.mitre.org/data/definitions/772[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/772.html[MITRE, CWE-772] - Missing Release of Resource after Effective Lifetime
 * https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html[Try With Resources]

--- a/rules/S2115/see.adoc
+++ b/rules/S2115/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html[OWASP Top 10 2017 Category A2] - Broken Authentication
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/521[MITRE, CWE-521] - Weak Password Requirements
+* https://cwe.mitre.org/data/definitions/521.html[MITRE, CWE-521] - Weak Password Requirements

--- a/rules/S2142/java/rule.adoc
+++ b/rules/S2142/java/rule.adoc
@@ -45,7 +45,7 @@ public void run () {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2168/java/rule.adoc
+++ b/rules/S2168/java/rule.adoc
@@ -98,7 +98,7 @@ class ResourceFactory {
 
 * https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html[The "Double-Checked Locking is Broken" Declaration]
 * https://wiki.sei.cmu.edu/confluence/x/6zdGBQ[CERT, LCK10-J.] - Use a correct form of the double-checked locking idiom
-* https://cwe.mitre.org/data/definitions/609[MITRE, CWE-609] - Double-checked locking
+* https://cwe.mitre.org/data/definitions/609.html[MITRE, CWE-609] - Double-checked locking
 * https://docs.oracle.com/javase/specs/jls/se7/html/jls-12.html#jls-12.4[JLS 12.4] - Initialization of Classes and Interfaces
 * Wikipedia: https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java[Double-checked locking]
 

--- a/rules/S2184/cfamily/rule.adoc
+++ b/rules/S2184/cfamily/rule.adoc
@@ -32,7 +32,7 @@ void compliant2() {
 == See
 
 * MISRA {cpp}:2008, 5-0-8 - An explicit integral or floating-point conversion shall not increase the size of the underlying type of a cvalue expression.
-* https://cwe.mitre.org/data/definitions/190[MITRE, CWE-190] - Integer Overflow or Wraparound
+* https://cwe.mitre.org/data/definitions/190.html[MITRE, CWE-190] - Integer Overflow or Wraparound
 * https://wiki.sei.cmu.edu/confluence/x/AjdGBQ[CERT, NUM50-J.] - Convert integers to floating point for floating-point operations
 * https://wiki.sei.cmu.edu/confluence/x/I9cxBQ[CERT, INT18-C.] - Evaluate integer expressions in a larger size before comparing or assigning to that size
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S2184/java/rule.adoc
+++ b/rules/S2184/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/190[MITRE, CWE-190] - Integer Overflow or Wraparound
+* https://cwe.mitre.org/data/definitions/190.html[MITRE, CWE-190] - Integer Overflow or Wraparound
 * https://wiki.sei.cmu.edu/confluence/x/AjdGBQ[CERT, NUM50-J.] - Convert integers to floating point for floating-point operations
 * https://wiki.sei.cmu.edu/confluence/x/I9cxBQ[CERT, INT18-C.] - Evaluate integer expressions in a larger size before comparing or assigning to that size
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S2184/see.adoc
+++ b/rules/S2184/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/190[MITRE, CWE-190] - Integer Overflow or Wraparound
+* https://cwe.mitre.org/data/definitions/190.html[MITRE, CWE-190] - Integer Overflow or Wraparound
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S2215/rule.adoc
+++ b/rules/S2215/rule.adoc
@@ -27,7 +27,7 @@ void clear2(short *array, int count) {
 
 * https://www.securecoding.cert.org/confluence/x/6wE[CERT, ARR01-C] - Do not apply the sizeof operator to a pointer when taking the size of an array
 * https://www.securecoding.cert.org/confluence/x/9YAyAQ[CERT, CTR01-CPP] - Do not apply the sizeof operator to a pointer when taking the size of an array
-* https://cwe.mitre.org/data/definitions/467[MITRE, CWE-467] - Use of sizeof() on a Pointer Type
+* https://cwe.mitre.org/data/definitions/467.html[MITRE, CWE-467] - Use of sizeof() on a Pointer Type
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2220/rule.adoc
+++ b/rules/S2220/rule.adoc
@@ -26,5 +26,5 @@ public bool Equals (object obj) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 

--- a/rules/S2221/see.adoc
+++ b/rules/S2221/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/396[MITRE, CWE-396] - Declaration of Catch for Generic Exception
+* https://cwe.mitre.org/data/definitions/396.html[MITRE, CWE-396] - Declaration of Catch for Generic Exception

--- a/rules/S2222/see.adoc
+++ b/rules/S2222/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup

--- a/rules/S2225/java/rule.adoc
+++ b/rules/S2225/java/rule.adoc
@@ -24,7 +24,7 @@ public String toString () {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 * https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2225/see.adoc
+++ b/rules/S2225/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference

--- a/rules/S2245/cfamily/rule.adoc
+++ b/rules/S2245/cfamily/rule.adoc
@@ -52,10 +52,10 @@ void f() {
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/338[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/1241[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
+* https://cwe.mitre.org/data/definitions/338.html[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/1241.html[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
 * https://wiki.sei.cmu.edu/confluence/x/oTdGBQ[CERT, MSC02-J.] - Generate strong random numbers
 * https://wiki.sei.cmu.edu/confluence/x/UNcxBQ[CERT, MSC30-C.] - Do not use the rand() function for generating pseudorandom numbers
 * https://wiki.sei.cmu.edu/confluence/x/2ns-BQ[CERT, MSC50-CPP.] - Do not use std::rand() for generating pseudorandom numbers

--- a/rules/S2245/java/rule.adoc
+++ b/rules/S2245/java/rule.adoc
@@ -40,10 +40,10 @@ random.nextBytes(bytes);
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/338[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/1241[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
+* https://cwe.mitre.org/data/definitions/338.html[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/1241.html[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
 * https://wiki.sei.cmu.edu/confluence/x/oTdGBQ[CERT, MSC02-J.] - Generate strong random numbers
 * https://wiki.sei.cmu.edu/confluence/x/UNcxBQ[CERT, MSC30-C.] - Do not use the rand() function for generating pseudorandom numbers
 * https://wiki.sei.cmu.edu/confluence/x/2ns-BQ[CERT, MSC50-CPP.] - Do not use std::rand() for generating pseudorandom numbers

--- a/rules/S2245/see.adoc
+++ b/rules/S2245/see.adoc
@@ -4,8 +4,8 @@
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/338[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/1241[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
+* https://cwe.mitre.org/data/definitions/338.html[MITRE, CWE-338] - Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/1241.html[MITRE, CWE-1241] - Use of Predictable Algorithm in Random Number Generator
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#PREDICTABLE_RANDOM[Predictable Pseudo Random Number Generator]

--- a/rules/S2254/java/rule.adoc
+++ b/rules/S2254/java/rule.adoc
@@ -34,7 +34,7 @@ if(isActiveSession(request.getRequestedSessionId()) ){
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/807[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
+* https://cwe.mitre.org/data/definitions/807.html[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 
 

--- a/rules/S2255/java/rule.adoc
+++ b/rules/S2255/java/rule.adoc
@@ -88,8 +88,8 @@ class Play {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/312[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
-* https://cwe.mitre.org/data/definitions/315[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
+* https://cwe.mitre.org/data/definitions/312.html[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
+* https://cwe.mitre.org/data/definitions/315.html[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
 * https://wiki.sei.cmu.edu/confluence/display/java/FIO52-J.+Do+not+store+unencrypted+sensitive+information+on+the+client+side[CERT, FIO52-J.] - Do not store unencrypted sensitive information on the client side
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#COOKIE_USAGE[COOKIE_USAGE]
 

--- a/rules/S2255/see.adoc
+++ b/rules/S2255/see.adoc
@@ -1,6 +1,6 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/312[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
-* https://cwe.mitre.org/data/definitions/315[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
+* https://cwe.mitre.org/data/definitions/312.html[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
+* https://cwe.mitre.org/data/definitions/315.html[MITRE, CWE-315] - Cleartext Storage of Sensitive Information in a Cookie
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#COOKIE_USAGE[COOKIE_USAGE]

--- a/rules/S2257/python/rule.adoc
+++ b/rules/S2257/python/rule.adoc
@@ -16,7 +16,7 @@ class CustomPasswordHasher(BasePasswordHasher):  # Sensitive
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2257/see.adoc
+++ b/rules/S2257/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#CUSTOM_MESSAGE_DIGEST[MessageDigest is Custom]

--- a/rules/S2258/java/rule.adoc
+++ b/rules/S2258/java/rule.adoc
@@ -12,7 +12,7 @@ NullCipher nc = new NullCipher();
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 
 

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -40,7 +40,7 @@ if (p2 != NULL) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 * https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[CERT, EXP34-C.] - Do not dereference null pointers
 * https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
 

--- a/rules/S2259/java/rule.adoc
+++ b/rules/S2259/java/rule.adoc
@@ -54,7 +54,7 @@ void paint(Color color) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 * https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[CERT, EXP34-C.] - Do not dereference null pointers
 * https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
 

--- a/rules/S2259/see.adoc
+++ b/rules/S2259/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference

--- a/rules/S2277/see.adoc
+++ b/rules/S2277/see.adoc
@@ -3,7 +3,7 @@
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/780[MITRE, CWE-780] - Use of RSA Algorithm without OAEP
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/780.html[MITRE, CWE-780] - Use of RSA Algorithm without OAEP
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#RSA_NO_PADDING[RSA NoPadding Unsafe]

--- a/rules/S2278/cfamily/rule.adoc
+++ b/rules/S2278/cfamily/rule.adoc
@@ -23,8 +23,8 @@ include::../compliant.adoc[]
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#DES_USAGE[DES / DESede Unsafe]

--- a/rules/S2278/java/rule.adoc
+++ b/rules/S2278/java/rule.adoc
@@ -8,8 +8,8 @@ include::../compliant.adoc[]
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#DES_USAGE[DES / DESede Unsafe]

--- a/rules/S2278/see.adoc
+++ b/rules/S2278/see.adoc
@@ -2,7 +2,7 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * Derived from FindSecBugs rule https://h3xstream.github.io/find-sec-bugs/bugs.htm#DES_USAGE[DES / DESede Unsafe]

--- a/rules/S2384/cfamily/rule.adoc
+++ b/rules/S2384/cfamily/rule.adoc
@@ -6,8 +6,8 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/374[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
-* https://cwe.mitre.org/data/definitions/375[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller
+* https://cwe.mitre.org/data/definitions/374.html[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
+* https://cwe.mitre.org/data/definitions/375.html[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller
 * https://wiki.sei.cmu.edu/confluence/x/OTdGBQ[CERT, OBJ05-J.] - Do not return references to private mutable class members
 * https://wiki.sei.cmu.edu/confluence/x/HTdGBQ[CERT, OBJ06-J.] - Defensively copy mutable inputs and mutable internal components
 * https://wiki.sei.cmu.edu/confluence/x/VzZGBQ[CERT, OBJ13-J.] - Ensure that references to mutable objects are not exposed

--- a/rules/S2384/java/rule.adoc
+++ b/rules/S2384/java/rule.adoc
@@ -6,8 +6,8 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/374[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
-* https://cwe.mitre.org/data/definitions/375[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller
+* https://cwe.mitre.org/data/definitions/374.html[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
+* https://cwe.mitre.org/data/definitions/375.html[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller
 * https://wiki.sei.cmu.edu/confluence/x/OTdGBQ[CERT, OBJ05-J.] - Do not return references to private mutable class members
 * https://wiki.sei.cmu.edu/confluence/x/HTdGBQ[CERT, OBJ06-J.] - Defensively copy mutable inputs and mutable internal components
 * https://wiki.sei.cmu.edu/confluence/x/VzZGBQ[CERT, OBJ13-J.] - Ensure that references to mutable objects are not exposed

--- a/rules/S2384/see.adoc
+++ b/rules/S2384/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/374[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
-* https://cwe.mitre.org/data/definitions/375[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller
+* https://cwe.mitre.org/data/definitions/374.html[MITRE, CWE-374] - Passing Mutable Objects to an Untrusted Method
+* https://cwe.mitre.org/data/definitions/375.html[MITRE, CWE-375] - Returning a Mutable Object to an Untrusted Caller

--- a/rules/S2385/rule.adoc
+++ b/rules/S2385/rule.adoc
@@ -41,8 +41,8 @@ public class A {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/582[MITRE, CWE-582] - Array Declared Public, Final, and Static
-* https://cwe.mitre.org/data/definitions/607[MITRE, CWE-607] - Public Static Final Field References Mutable Object
+* https://cwe.mitre.org/data/definitions/582.html[MITRE, CWE-582] - Array Declared Public, Final, and Static
+* https://cwe.mitre.org/data/definitions/607.html[MITRE, CWE-607] - Public Static Final Field References Mutable Object
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2386/java/rule.adoc
+++ b/rules/S2386/java/rule.adoc
@@ -4,8 +4,8 @@ include::../noncompliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/582[MITRE, CWE-582] - Array Declared Public, Final, and Static
-* https://cwe.mitre.org/data/definitions/607[MITRE, CWE-607] - Public Static Final Field References Mutable Object
+* https://cwe.mitre.org/data/definitions/582.html[MITRE, CWE-582] - Array Declared Public, Final, and Static
+* https://cwe.mitre.org/data/definitions/607.html[MITRE, CWE-607] - Public Static Final Field References Mutable Object
 * https://wiki.sei.cmu.edu/confluence/x/LjdGBQ[CERT, OBJ01-J.] - Limit accessibility of fields
 * https://wiki.sei.cmu.edu/confluence/x/VzZGBQ[CERT, OBJ13-J.] - Ensure that references to mutable objects are not exposed
 

--- a/rules/S2386/see.adoc
+++ b/rules/S2386/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/582[MITRE, CWE-582] - Array Declared Public, Final, and Static
-* https://cwe.mitre.org/data/definitions/607[MITRE, CWE-607] - Public Static Final Field References Mutable Object
+* https://cwe.mitre.org/data/definitions/582.html[MITRE, CWE-582] - Array Declared Public, Final, and Static
+* https://cwe.mitre.org/data/definitions/607.html[MITRE, CWE-607] - Public Static Final Field References Mutable Object

--- a/rules/S2435/cfamily/rule.adoc
+++ b/rules/S2435/cfamily/rule.adoc
@@ -5,7 +5,7 @@ include::../rule-except-see.adoc[]
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
-* https://cwe.mitre.org/data/definitions/91[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
+* https://cwe.mitre.org/data/definitions/91.html[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2435/java/rule.adoc
+++ b/rules/S2435/java/rule.adoc
@@ -5,7 +5,7 @@ include::../rule-except-see.adoc[]
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
-* https://cwe.mitre.org/data/definitions/91[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
+* https://cwe.mitre.org/data/definitions/91.html[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
 * https://wiki.sei.cmu.edu/confluence/x/7jdGBQ[CERT, IDS51-J.] - Properly encode or escape output
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2435/see.adoc
+++ b/rules/S2435/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
-* https://cwe.mitre.org/data/definitions/91[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
+* https://cwe.mitre.org/data/definitions/91.html[MITRE, CWE-91] - XML Injection (aka Blind XPath Injection)
 

--- a/rules/S2441/java/rule.adoc
+++ b/rules/S2441/java/rule.adoc
@@ -21,7 +21,7 @@ session.setAttribute("address", new Address());  // Noncompliant; Address isn't 
 == See
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cwe.mitre.org/data/definitions/579[MITRE, CWE-579] - J2EE Bad Practices: Non-serializable Object Stored in Session
+* https://cwe.mitre.org/data/definitions/579.html[MITRE, CWE-579] - J2EE Bad Practices: Non-serializable Object Stored in Session
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2445/java/see.adoc
+++ b/rules/S2445/java/see.adoc
@@ -1,5 +1,5 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/412[MITRE, CWE-412] - Unrestricted Externally Accessible Lock
-* https://cwe.mitre.org/data/definitions/413[MITRE, CWE-413] - Improper Resource Locking
+* https://cwe.mitre.org/data/definitions/412.html[MITRE, CWE-412] - Unrestricted Externally Accessible Lock
+* https://cwe.mitre.org/data/definitions/413.html[MITRE, CWE-413] - Improper Resource Locking
 * https://wiki.sei.cmu.edu/confluence/x/djdGBQ[CERT, LCK00-J.] - Use private final lock objects to synchronize classes that may interact with untrusted code

--- a/rules/S2445/see.adoc
+++ b/rules/S2445/see.adoc
@@ -1,5 +1,5 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/412[MITRE, CWE-412] - Unrestricted Externally Accessible Lock
-* https://cwe.mitre.org/data/definitions/413[MITRE, CWE-413] - Improper Resource Locking
+* https://cwe.mitre.org/data/definitions/412.html[MITRE, CWE-412] - Unrestricted Externally Accessible Lock
+* https://cwe.mitre.org/data/definitions/413.html[MITRE, CWE-413] - Improper Resource Locking
 

--- a/rules/S2447/java/rule.adoc
+++ b/rules/S2447/java/rule.adoc
@@ -14,7 +14,7 @@ public Boolean isUsable() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 * https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2486/see.adoc
+++ b/rules/S2486/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
-* https://cwe.mitre.org/data/definitions/390[MITRE, CWE-390] - Detection of Error Condition Without Action
+* https://cwe.mitre.org/data/definitions/390.html[MITRE, CWE-390] - Detection of Error Condition Without Action

--- a/rules/S2575/see.adoc
+++ b/rules/S2575/see.adoc
@@ -2,7 +2,7 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/80[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/80.html[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S2578/html/rule.adoc
+++ b/rules/S2578/html/rule.adoc
@@ -37,8 +37,8 @@ This rule checks that values are not written directly into ``++application/json+
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md[OWASP XSS (Cross Site Scripting) Prevention Cheat Sheet]
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 
 

--- a/rules/S2583/cfamily/rule.adoc
+++ b/rules/S2583/cfamily/rule.adoc
@@ -6,8 +6,8 @@ include::../noncompliant.adoc[]
 
 * MISRA C:2004, 13.7 - Boolean operations whose results are invariant shall not be permitted.
 * MISRA C:2012, 14.3 - Controlling expressions shall not be invariant
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True
 * https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[CERT, MSC12-C.] - Detect and remove code that has no effect or is never executed
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2583/java/rule.adoc
+++ b/rules/S2583/java/rule.adoc
@@ -28,8 +28,8 @@ In these cases it is obvious the code is as intended.
 
 == See
 
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True
 * https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[CERT, MSC12-C.] - Detect and remove code that has no effect or is never executed
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2583/see.adoc
+++ b/rules/S2583/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True

--- a/rules/S2589/cfamily/rule.adoc
+++ b/rules/S2589/cfamily/rule.adoc
@@ -8,8 +8,8 @@ include::../compliant.adoc[]
 
 * MISRA C:2004, 13.7 - Boolean operations whose results are invariant shall not be permitted.
 * MISRA C:2012, 14.3 - Controlling expressions shall not be invariant
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False
 * https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[CERT, MSC12-C.] - Detect and remove code that has no effect or is never executed
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2589/see.adoc
+++ b/rules/S2589/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
-* https://cwe.mitre.org/data/definitions/570[MITRE, CWE-570] - Expression is Always False
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/570.html[MITRE, CWE-570] - Expression is Always False

--- a/rules/S2598/see.adoc
+++ b/rules/S2598/see.adoc
@@ -1,7 +1,7 @@
 == See
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cwe.mitre.org/data/definitions/434[MITRE, CWE-434] - Unrestricted Upload of File with Dangerous Type
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption
+* https://cwe.mitre.org/data/definitions/434.html[MITRE, CWE-434] - Unrestricted Upload of File with Dangerous Type
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption
 * https://www.owasp.org/index.php/Unrestricted_File_Upload[OWASP Unrestricted File Upload] - Unrestricted File Upload
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S2608/rule.adoc
+++ b/rules/S2608/rule.adoc
@@ -19,6 +19,6 @@ public void doPost(HttpServletRequest request, HttpServletResponse response) thr
 == See
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cwe.mitre.org/data/definitions/807[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
+* https://cwe.mitre.org/data/definitions/807.html[MITRE, CWE-807] - Reliance on Untrusted Inputs in a Security Decision
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S2609/rule.adoc
+++ b/rules/S2609/rule.adoc
@@ -3,6 +3,6 @@ The use of random, single-use nonce values in forms is an effective way to preve
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S2610/rule.adoc
+++ b/rules/S2610/rule.adoc
@@ -14,6 +14,6 @@ chdir("/"); // Noncompliant
 
 == See
 
-* https://cwe.mitre.org/data/definitions/250[MITRE, CWE-250] - Execution with Unnecessary Privileges
+* https://cwe.mitre.org/data/definitions/250.html[MITRE, CWE-250] - Execution with Unnecessary Privileges
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S2611/javascript/rule.adoc
+++ b/rules/S2611/javascript/rule.adoc
@@ -17,7 +17,7 @@ include("http://hackers.com/steal.js")  // Noncompliant
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/829[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
+* https://cwe.mitre.org/data/definitions/829.html[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 

--- a/rules/S2612/cfamily/rule.adoc
+++ b/rules/S2612/cfamily/rule.adoc
@@ -61,8 +61,8 @@ umask(S_IRWXO); // Compliant: further created files or directories will not have
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.owasp.org/index.php/Test_File_Permission_(OTG-CONFIG-009)[OWASP File Permission]
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] -  Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] -  Incorrect Privilege Assignment
 * https://wiki.sei.cmu.edu/confluence/display/java/FIO01-J.+Create+files+with+appropriate+access+permissions[CERT, FIO01-J.] - Create files with appropriate access permissions
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO06-C.+Create+files+with+appropriate+access+permissions[CERT, FIO06-C.] - Create files with appropriate access permissions
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2612/java/rule.adoc
+++ b/rules/S2612/java/rule.adoc
@@ -68,8 +68,8 @@ On operating systems that implement POSIX standard. This will throw a ``++Unsupp
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.owasp.org/index.php/Test_File_Permission_(OTG-CONFIG-009)[OWASP File Permission]
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] -  Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] -  Incorrect Privilege Assignment
 * https://wiki.sei.cmu.edu/confluence/display/java/FIO01-J.+Create+files+with+appropriate+access+permissions[CERT, FIO01-J.] - Create files with appropriate access permissions
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO06-C.+Create+files+with+appropriate+access+permissions[CERT, FIO06-C.] - Create files with appropriate access permissions
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2612/see.adoc
+++ b/rules/S2612/see.adoc
@@ -4,6 +4,6 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.owasp.org/index.php/Test_File_Permission_(OTG-CONFIG-009)[OWASP File Permission]
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] -  Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] -  Incorrect Privilege Assignment
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2613/cfamily/rule.adoc
+++ b/rules/S2613/cfamily/rule.adoc
@@ -20,7 +20,7 @@ char** addOne(char ** cpp, int len) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/131[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
+* https://cwe.mitre.org/data/definitions/131.html[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2614/rule.adoc
+++ b/rules/S2614/rule.adoc
@@ -16,6 +16,6 @@ DirContext ctx = new InitialDirContext(env);  // Noncompliant
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/307[MITRE, CWE-307] - Improper Restriction of Excessive Authentication Attempts
+* https://cwe.mitre.org/data/definitions/307.html[MITRE, CWE-307] - Improper Restriction of Excessive Authentication Attempts
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S2615/cfamily/rule.adoc
+++ b/rules/S2615/cfamily/rule.adoc
@@ -3,7 +3,7 @@ include::../rule.adoc[]
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/134[MITRE, CWE-134] - Use of Externally-Controlled Format String
+* https://cwe.mitre.org/data/definitions/134.html[MITRE, CWE-134] - Use of Externally-Controlled Format String
 * https://wiki.sei.cmu.edu/confluence/x/RdYxBQ[CERT, FIO30-C.] - Exclude user input from format strings
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 

--- a/rules/S2615/java/rule.adoc
+++ b/rules/S2615/java/rule.adoc
@@ -3,7 +3,7 @@ include::../rule.adoc[]
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/134[MITRE, CWE-134] - Use of Externally-Controlled Format String
+* https://cwe.mitre.org/data/definitions/134.html[MITRE, CWE-134] - Use of Externally-Controlled Format String
 * https://wiki.sei.cmu.edu/confluence/x/RdYxBQ[CERT, FIO30-C.] - Exclude user input from format strings
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 

--- a/rules/S2615/see.adoc
+++ b/rules/S2615/see.adoc
@@ -1,6 +1,6 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/134[MITRE, CWE-134] - Use of Externally-Controlled Format String
+* https://cwe.mitre.org/data/definitions/134.html[MITRE, CWE-134] - Use of Externally-Controlled Format String
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 

--- a/rules/S2631/see.adoc
+++ b/rules/S2631/see.adoc
@@ -2,7 +2,7 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption
-* https://cwe.mitre.org/data/definitions/1333[MITRE, CWE-1333] - Inefficient Regular Expression Complexity
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption
+* https://cwe.mitre.org/data/definitions/1333.html[MITRE, CWE-1333] - Inefficient Regular Expression Complexity
 * https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS[OWASP Regular expression Denial of Service - ReDoS]

--- a/rules/S2637/see.adoc
+++ b/rules/S2637/see.adoc
@@ -1,4 +1,4 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference
 * https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required

--- a/rules/S2647/see.adoc
+++ b/rules/S2647/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://cheatsheetseries.owasp.org/cheatsheets/Web_Service_Security_Cheat_Sheet.html#user-authentication[OWASP Web Service Security Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/522[MITRE, CWE-522] - Insufficiently Protected Credentials
+* https://cwe.mitre.org/data/definitions/522.html[MITRE, CWE-522] - Insufficiently Protected Credentials
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S2652/java/rule.adoc
+++ b/rules/S2652/java/rule.adoc
@@ -40,7 +40,7 @@ public class MyBean implements BeanInterface {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/576[MITRE, CWE-576] - EJB Bad Practices: Use of Java I/O
+* https://cwe.mitre.org/data/definitions/576.html[MITRE, CWE-576] - EJB Bad Practices: Use of Java I/O
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2653/java/rule.adoc
+++ b/rules/S2653/java/rule.adoc
@@ -25,7 +25,7 @@ public class MyServlet extends HttpServlet {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
 * https://wiki.sei.cmu.edu/confluence/x/qzVGBQ[CERT, ENV06-J.] - Production code must not contain debugging entry points
 
 

--- a/rules/S2654/java/rule.adoc
+++ b/rules/S2654/java/rule.adoc
@@ -22,8 +22,8 @@ public void doGet(HttpServletRequest request, HttpServletResponse response) thro
 
 == See
 
-* https://cwe.mitre.org/data/definitions/383[MITRE, CWE-383] - J2EE Bad Practices: Direct Use of Threads
-* https://cwe.mitre.org/data/definitions/574[MITRE, CWE-574] - EJB Bad Practices: Use of Synchronization Primitives
+* https://cwe.mitre.org/data/definitions/383.html[MITRE, CWE-383] - J2EE Bad Practices: Direct Use of Threads
+* https://cwe.mitre.org/data/definitions/574.html[MITRE, CWE-574] - EJB Bad Practices: Use of Synchronization Primitives
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2655/java/rule.adoc
+++ b/rules/S2655/java/rule.adoc
@@ -48,7 +48,7 @@ throws ServletException, IOException  {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/245[MITRE, CWE-245] - J2EE Bad Practices: Direct Management of Connections
+* https://cwe.mitre.org/data/definitions/245.html[MITRE, CWE-245] - J2EE Bad Practices: Direct Management of Connections
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2656/java/rule.adoc
+++ b/rules/S2656/java/rule.adoc
@@ -39,8 +39,8 @@ public void doGet(HttpServletRequest request, HttpServletResponse response) thro
 
 == See
 
-* https://cwe.mitre.org/data/definitions/246[MITRE, CWE-246] - J2EE Bad Practices: Direct Use of Sockets
-* https://cwe.mitre.org/data/definitions/577[MITRE, CWE-577] - EJB Bad Practices: Use of Sockets
+* https://cwe.mitre.org/data/definitions/246.html[MITRE, CWE-246] - J2EE Bad Practices: Direct Use of Sockets
+* https://cwe.mitre.org/data/definitions/577.html[MITRE, CWE-577] - EJB Bad Practices: Use of Sockets
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2657/java/rule.adoc
+++ b/rules/S2657/java/rule.adoc
@@ -19,7 +19,7 @@ ClassLoader loader = new MyClassLoader();  // Noncompliant
 
 == See
 
-* https://cwe.mitre.org/data/definitions/578[MITRE, CWE-578] - EJB Bad Practices: Use of Class Loader
+* https://cwe.mitre.org/data/definitions/578.html[MITRE, CWE-578] - EJB Bad Practices: Use of Class Loader
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2658/see.adoc
+++ b/rules/S2658/see.adoc
@@ -1,4 +1,4 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/470[MITRE, CWE-470] - Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
+* https://cwe.mitre.org/data/definitions/470.html[MITRE, CWE-470] - Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')

--- a/rules/S2669/cfamily/rule.adoc
+++ b/rules/S2669/cfamily/rule.adoc
@@ -18,7 +18,7 @@ int b = a +1; //What's the value of 'a' and so what's the value of 'b' ?
 
 == See
 
-* https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
+* https://cwe.mitre.org/data/definitions/457.html[MITRE, CWE-457] - Use of Uninitialized Variable
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2681/cfamily/rule.adoc
+++ b/rules/S2681/cfamily/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/483[MITRE, CWE-483] - Incorrect Block Delimitation
+* https://cwe.mitre.org/data/definitions/483.html[MITRE, CWE-483] - Incorrect Block Delimitation
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2681/java/rule.adoc
+++ b/rules/S2681/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/483[MITRE, CWE-483] - Incorrect Block Delimitation
+* https://cwe.mitre.org/data/definitions/483.html[MITRE, CWE-483] - Incorrect Block Delimitation
 * https://wiki.sei.cmu.edu/confluence/x/MzZGBQ[CERT, EXP52-J.] - Use braces for the body of an if, for, or while statement
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2681/javascript/rule.adoc
+++ b/rules/S2681/javascript/rule.adoc
@@ -47,7 +47,7 @@ for (let i = 0; i < array.length; i++) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/483[MITRE, CWE-483] - Incorrect Block Delimitation
+* https://cwe.mitre.org/data/definitions/483.html[MITRE, CWE-483] - Incorrect Block Delimitation
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2681/see.adoc
+++ b/rules/S2681/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/483[MITRE, CWE-483] - Incorrect Block Delimitation
+* https://cwe.mitre.org/data/definitions/483.html[MITRE, CWE-483] - Incorrect Block Delimitation

--- a/rules/S2755/cfamily/rule.adoc
+++ b/rules/S2755/cfamily/rule.adoc
@@ -96,8 +96,8 @@ xmlDocPtr doc = xmlReadFile(xmlFile, nullptr, 0); // Compliant: safe by default 
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#libxerces-c[OWASP XXE Prevention Cheat Sheet for Xerces]
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#libxml2[OWASP XXE Prevention Cheat Sheet for LibXML2]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* https://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2755/csharp/rule.adoc
+++ b/rules/S2755/csharp/rule.adoc
@@ -118,8 +118,8 @@ string xml = nav.InnerXml.ToString();
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#net[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* https://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2755/java/rule.adoc
+++ b/rules/S2755/java/rule.adoc
@@ -106,8 +106,8 @@ builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 * https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-8CD65EF5-D113-4D5C-A564-B875C8625FAC[Oracle Java Documentation] - XML External Entity Injection Attack
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* https://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2755/php/rule.adoc
+++ b/rules/S2755/php/rule.adoc
@@ -59,8 +59,8 @@ $reader->setParserProperty(XMLReader::SUBST_ENTITIES, false); // Compliant (SUBS
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#php[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* https://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2755/see.adoc
+++ b/rules/S2755/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* https://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition

--- a/rules/S2773/rule.adoc
+++ b/rules/S2773/rule.adoc
@@ -17,5 +17,5 @@ public void doGet(HttpServletRequest request, HttpServletResponse response) {
 
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/117[MITRE, CWE-117] - Improper Output Neutralization for Logs
+* https://cwe.mitre.org/data/definitions/117.html[MITRE, CWE-117] - Improper Output Neutralization for Logs
 

--- a/rules/S2774/see.adoc
+++ b/rules/S2774/see.adoc
@@ -1,4 +1,4 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/615[MITRE, CWE-615] - Information Exposure Through Comments
+* https://cwe.mitre.org/data/definitions/615.html[MITRE, CWE-615] - Information Exposure Through Comments

--- a/rules/S2776/rule.adoc
+++ b/rules/S2776/rule.adoc
@@ -35,5 +35,5 @@ END-EXEC
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/114[MITRE, CWE-114] - Process Control
+* https://cwe.mitre.org/data/definitions/114.html[MITRE, CWE-114] - Process Control
 

--- a/rules/S2778/cobol/rule.adoc
+++ b/rules/S2778/cobol/rule.adoc
@@ -16,7 +16,7 @@ END-EXEC.
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/497[MITRE, CWE-497] - Exposure of System Data to an Unauthorized Control Sphere
+* https://cwe.mitre.org/data/definitions/497.html[MITRE, CWE-497] - Exposure of System Data to an Unauthorized Control Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2809/abap/rule.adoc
+++ b/rules/S2809/abap/rule.adoc
@@ -75,8 +75,8 @@ No issue will be raised when ``++CALL TRANSACTION++`` is followed by ``++WITHOUT
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/285[MITRE, CWE-285] - Improper Authorization
-* https://cwe.mitre.org/data/definitions/862[MITRE, CWE-862] - Missing Authorization
+* https://cwe.mitre.org/data/definitions/285.html[MITRE, CWE-285] - Improper Authorization
+* https://cwe.mitre.org/data/definitions/862.html[MITRE, CWE-862] - Missing Authorization
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 
 

--- a/rules/S2930/csharp/rule.adoc
+++ b/rules/S2930/csharp/rule.adoc
@@ -111,7 +111,7 @@ public void ReadFromStream(Stream s)
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2931/rule.adoc
+++ b/rules/S2931/rule.adoc
@@ -51,5 +51,5 @@ public class ResourceHolder : IDisposable
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 

--- a/rules/S2952/csharp/rule.adoc
+++ b/rules/S2952/csharp/rule.adoc
@@ -59,7 +59,7 @@ public class ResourceHolder : IDisposable
 
 == See
 
-* https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
+* https://cwe.mitre.org/data/definitions/459.html[MITRE, CWE-459] - Incomplete Cleanup
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2998/rule.adoc
+++ b/rules/S2998/rule.adoc
@@ -3,7 +3,7 @@ A statement without side effects, such as creating an object without assigning i
 
 == See
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+* https://cwe.mitre.org/data/definitions/482.html[MITRE, CWE-482] - Comparing instead of Assigning
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3041/rule.adoc
+++ b/rules/S3041/rule.adoc
@@ -24,5 +24,5 @@ for (int i = 0; i <= iArray.length; i++) {  // Noncompliant; loop will go beyond
 
 == See
 
-* https://cwe.mitre.org/data/definitions/129[MITRE, CWE-129] - Improper Validation of Array Index
+* https://cwe.mitre.org/data/definitions/129.html[MITRE, CWE-129] - Improper Validation of Array Index
 

--- a/rules/S3135/cfamily/rule.adoc
+++ b/rules/S3135/cfamily/rule.adoc
@@ -72,7 +72,7 @@ void fun(int array[10]) {
 * https://wiki.sei.cmu.edu/confluence/x/CdYxBQ[CERT, ARR01-C.] - Do not apply the ``++sizeof++`` operator to a pointer when taking the size of an array
 * https://wiki.sei.cmu.edu/confluence/x/_NYxBQ[CERT, EXP44-C.] - Do not rely on side effects in operands to ``++sizeof++``, ``++_Alignof++``, or ``++_Generic++``
 * https://wiki.sei.cmu.edu/confluence/x/oXs-BQ[CERT, EXP52-CPP.] - Do not rely on side effects in unevaluated operands
-* https://cwe.mitre.org/data/definitions/467[MITRE, CWE-467] - Use of sizeof() on a Pointer Type
+* https://cwe.mitre.org/data/definitions/467.html[MITRE, CWE-467] - Use of sizeof() on a Pointer Type
 
 
 

--- a/rules/S3223/rule.adoc
+++ b/rules/S3223/rule.adoc
@@ -15,7 +15,7 @@ if ("foo") { // Noncompliant - always evaluates to true
 
 == See
 
-* https://cwe.mitre.org/data/definitions/571[MITRE, CWE-571] - Expression is Always True
+* https://cwe.mitre.org/data/definitions/571.html[MITRE, CWE-571] - Expression is Always True
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3272/rule.adoc
+++ b/rules/S3272/rule.adoc
@@ -12,7 +12,7 @@ This rule raises an issue on each file in which ``++WebSocket++``s are used.
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
 * https://dl.packetstormsecurity.net/papers/attack/HTML5AttackVectors_RafayBaloch_UPDATED.pdf[Packet Storm Security] - HTML 5 Modern Day Attack And Defence Vectors
 
 

--- a/rules/S3274/html/see.adoc
+++ b/rules/S3274/html/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/829[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
+* https://cwe.mitre.org/data/definitions/829.html[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere

--- a/rules/S3275/rule.adoc
+++ b/rules/S3275/rule.adoc
@@ -48,6 +48,6 @@ public void cbcEncrypt(String strKey, String plainText) {
 == See
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
-* https://cwe.mitre.org/data/definitions/329[MITRE, CWE-329] - Not Using a Random IV with CBC Mode
+* https://cwe.mitre.org/data/definitions/329.html[MITRE, CWE-329] - Not Using a Random IV with CBC Mode
 * OWASP Top 10 2017 Category A6 - Security Misconfiguration
 

--- a/rules/S3318/rule.adoc
+++ b/rules/S3318/rule.adoc
@@ -17,5 +17,5 @@ session.setAttribute("login", login);  // Noncompliant
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/501[MITRE, CWE-501] - Trust Boundary Violation
+* https://cwe.mitre.org/data/definitions/501.html[MITRE, CWE-501] - Trust Boundary Violation
 

--- a/rules/S3329/apex/rule.adoc
+++ b/rules/S3329/apex/rule.adoc
@@ -23,8 +23,8 @@ Blob encryptedData = Crypto.encryptWithManagedIV('AES256', key, data);
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/329[MITRE, CWE-329] - CWE-329: Not Using an Unpredictable IV with CBC Mode
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/329.html[MITRE, CWE-329] - CWE-329: Not Using an Unpredictable IV with CBC Mode
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf[NIST, SP-800-38A] - Recommendation for Block  Cipher Modes of Operation 
 * https://developer.salesforce.com/page/Apex_Crypto_Class[Using the Apex Crypto Class]
 

--- a/rules/S3329/java/rule.adoc
+++ b/rules/S3329/java/rule.adoc
@@ -53,8 +53,8 @@ public class MyCbcClass {
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/329[MITRE, CWE-329] - CWE-329: Not Using an Unpredictable IV with CBC Mode
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/329.html[MITRE, CWE-329] - CWE-329: Not Using an Unpredictable IV with CBC Mode
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf[NIST, SP-800-38A] - Recommendation for Block  Cipher Modes of Operation 
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#STATIC_IV[STATIC_IV]
 

--- a/rules/S3329/see.adoc
+++ b/rules/S3329/see.adoc
@@ -4,8 +4,8 @@
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/329[MITRE, CWE-329] - Not Using an Unpredictable IV with CBC Mode
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/340[MITRE, CWE-340] - Generation of Predictable Numbers or Identifiers
-* https://cwe.mitre.org/data/definitions/1204[MITRE, CWE-1204] - Generation of Weak Initialization Vector (IV)
+* https://cwe.mitre.org/data/definitions/329.html[MITRE, CWE-329] - Not Using an Unpredictable IV with CBC Mode
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/340.html[MITRE, CWE-340] - Generation of Predictable Numbers or Identifiers
+* https://cwe.mitre.org/data/definitions/1204.html[MITRE, CWE-1204] - Generation of Weak Initialization Vector (IV)
 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf[NIST, SP-800-38A] - Recommendation for Block  Cipher Modes of Operation 

--- a/rules/S3330/see.adoc
+++ b/rules/S3330/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/HttpOnly[OWASP HttpOnly]
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/1004[MITRE, CWE-1004] - Sensitive Cookie Without 'HttpOnly' Flag
+* https://cwe.mitre.org/data/definitions/1004.html[MITRE, CWE-1004] - Sensitive Cookie Without 'HttpOnly' Flag
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#HTTPONLY_COOKIE[HTTPONLY_COOKIE]

--- a/rules/S3333/php/rule.adoc
+++ b/rules/S3333/php/rule.adoc
@@ -33,8 +33,8 @@ open_basedir="${USER}/scripts/data"
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/23[MITRE, CWE-23] - Relative Path Traversal
-* https://cwe.mitre.org/data/definitions/36[MITRE, CWE-36] - Absolute Path Traversal
+* https://cwe.mitre.org/data/definitions/23.html[MITRE, CWE-23] - Relative Path Traversal
+* https://cwe.mitre.org/data/definitions/36.html[MITRE, CWE-36] - Absolute Path Traversal
 
 
 

--- a/rules/S3334/php/rule.adoc
+++ b/rules/S3334/php/rule.adoc
@@ -28,7 +28,7 @@ allow_url_include=0
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/829[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
+* https://cwe.mitre.org/data/definitions/829.html[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 

--- a/rules/S3335/php/rule.adoc
+++ b/rules/S3335/php/rule.adoc
@@ -17,7 +17,7 @@ cgi.force_redirect=0  ; Noncompliant
 
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/305[MITRE, CWE-305] - Authentication Bypass by Primary Weakness
+* https://cwe.mitre.org/data/definitions/305.html[MITRE, CWE-305] - Authentication Bypass by Primary Weakness
 
 
 

--- a/rules/S3337/php/rule.adoc
+++ b/rules/S3337/php/rule.adoc
@@ -27,8 +27,8 @@ enable_dl=0
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/23[MITRE, CWE-23] - Relative Path Traversal
-* https://cwe.mitre.org/data/definitions/36[MITRE, CWE-36] - Absolute Path Traversal
+* https://cwe.mitre.org/data/definitions/23.html[MITRE, CWE-23] - Relative Path Traversal
+* https://cwe.mitre.org/data/definitions/36.html[MITRE, CWE-36] - Absolute Path Traversal
 
 
 

--- a/rules/S3338/php/rule.adoc
+++ b/rules/S3338/php/rule.adoc
@@ -25,7 +25,7 @@ file_uploads=0
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/434[MITRE, CWE-434] - Unrestricted Upload of File with Dangerous Type
+* https://cwe.mitre.org/data/definitions/434.html[MITRE, CWE-434] - Unrestricted Upload of File with Dangerous Type
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 
 

--- a/rules/S3361/rule.adoc
+++ b/rules/S3361/rule.adoc
@@ -51,6 +51,6 @@ public class MySessionListener implements HttpSessionListener{
 == See
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
-* https://cwe.mitre.org/data/definitions/613[MITRE, CWE-613] - Insufficient Session Expiration
+* https://cwe.mitre.org/data/definitions/613.html[MITRE, CWE-613] - Insufficient Session Expiration
 * https://www.owasp.org/index.php/Session_Management_Cheat_Sheet[OWASP, Session Management Cheat Sheet]
 

--- a/rules/S3367/java/rule.adoc
+++ b/rules/S3367/java/rule.adoc
@@ -27,7 +27,7 @@ public class MyForm extends org.apache.struts.validator.ValidatorForm {
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/104[MITRE, CWE-104] - Struts: Form Bean Does Not Extend Validation Class
+* https://cwe.mitre.org/data/definitions/104.html[MITRE, CWE-104] - Struts: Form Bean Does Not Extend Validation Class
 
 
 

--- a/rules/S3369/java/rule.adoc
+++ b/rules/S3369/java/rule.adoc
@@ -7,7 +7,7 @@ This rule raises an issue when a _web.xml_ file has no ``++<security-constraint>
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3371/java/rule.adoc
+++ b/rules/S3371/java/rule.adoc
@@ -25,10 +25,10 @@ PreparedStatement stmt = null;
 == See
 
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/564[MITRE, CWE-564] - SQL Injection: Hibernate
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/564.html[MITRE, CWE-564] - SQL Injection: Hibernate
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * https://www.owasp.org/index.php/Top_10_2013-A1-Injection[OWASP Top Ten 2013 Category A1] - Injection
 
 

--- a/rules/S3374/xml/rule.adoc
+++ b/rules/S3374/xml/rule.adoc
@@ -35,7 +35,7 @@ In such a case, it is likely that the two forms should be combined. At the very 
 
 == See
 
-* https://cwe.mitre.org/data/definitions/102[MITRE, CWE-102] - Struts: Duplicate Validation Forms
+* https://cwe.mitre.org/data/definitions/102.html[MITRE, CWE-102] - Struts: Duplicate Validation Forms
 * https://owasp.org/www-community/vulnerabilities/Improper_Data_Validation[OWASP, Improper Data Validation] - Struts: Duplicate Validation Forms
 
 

--- a/rules/S3510/java/rule.adoc
+++ b/rules/S3510/java/rule.adoc
@@ -49,7 +49,7 @@ Client client = ClientBuilder.newBuilder().sslContext(sslcontext).hostnameVerifi
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#WEAK_HOSTNAME_VERIFIER[WEAK_HOSTNAME_VERIFIER]
 
 

--- a/rules/S3518/cfamily/rule.adoc
+++ b/rules/S3518/cfamily/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/369[MITRE, CWE-369] - Divide by zero
+* https://cwe.mitre.org/data/definitions/369.html[MITRE, CWE-369] - Divide by zero
 * https://wiki.sei.cmu.edu/confluence/x/CTZGBQ[CERT, NUM02-J.] - Ensure that division and remainder operations do not result in divide-by-zero errors
 * https://wiki.sei.cmu.edu/confluence/x/ftYxBQ[CERT, INT33-C.] - Ensure that division and remainder operations do not result in divide-by-zero errors
 

--- a/rules/S3518/java/rule.adoc
+++ b/rules/S3518/java/rule.adoc
@@ -12,7 +12,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/369[MITRE, CWE-369] - Divide by zero
+* https://cwe.mitre.org/data/definitions/369.html[MITRE, CWE-369] - Divide by zero
 * https://wiki.sei.cmu.edu/confluence/x/CTZGBQ[CERT, NUM02-J.] - Ensure that division and remainder operations do not result in divide-by-zero errors
 * https://wiki.sei.cmu.edu/confluence/x/ftYxBQ[CERT, INT33-C.] - Ensure that division and remainder operations do not result in divide-by-zero errors
 

--- a/rules/S3518/see.adoc
+++ b/rules/S3518/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/369[MITRE, CWE-369] - Divide by zero
+* https://cwe.mitre.org/data/definitions/369.html[MITRE, CWE-369] - Divide by zero

--- a/rules/S3519/cfamily/rule.adoc
+++ b/rules/S3519/cfamily/rule.adoc
@@ -29,9 +29,9 @@ memcpy(buffer2, buffer1, 50);
 
 == See
 
-* https://cwe.mitre.org/data/definitions/119[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
-* https://cwe.mitre.org/data/definitions/131[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
-* https://cwe.mitre.org/data/definitions/788[MITRE, CWE-788] - Access of Memory Location After End of Buffer
+* https://cwe.mitre.org/data/definitions/119.html[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
+* https://cwe.mitre.org/data/definitions/131.html[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
+* https://cwe.mitre.org/data/definitions/788.html[MITRE, CWE-788] - Access of Memory Location After End of Buffer
 * https://wiki.sei.cmu.edu/confluence/x/wtYxBQ[CERT, ARR30-C.] - Do not form or use out-of-bounds pointers or array subscripts
 * https://wiki.sei.cmu.edu/confluence/x/i3w-BQ[CERT, STR50-CPP.] - Guarantee that storage for strings has sufficient space for character data and the null terminator
 

--- a/rules/S3520/cfamily/rule.adoc
+++ b/rules/S3520/cfamily/rule.adoc
@@ -42,7 +42,7 @@ void doSomething(int size) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/415[MITRE, CWE-415] - Double Free
+* https://cwe.mitre.org/data/definitions/415.html[MITRE, CWE-415] - Double Free
 * https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory[OWASP, Doubly freeing memory]
 
 

--- a/rules/S3529/cfamily/rule.adoc
+++ b/rules/S3529/cfamily/rule.adoc
@@ -16,7 +16,7 @@ cp[9] = 0;  // Noncompliant
 
 == See
 
-* https://cwe.mitre.org/data/definitions/416[MITRE, CWE-416] - Use After Free
+* https://cwe.mitre.org/data/definitions/416.html[MITRE, CWE-416] - Use After Free
 * https://wiki.sei.cmu.edu/confluence/x/GdYxBQ[CERT, MEM30-C.] - Do not access freed memory
 * https://wiki.sei.cmu.edu/confluence/x/onw-BQ[CERT, MEM50-CPP.] - Do not access freed memory
 * https://wiki.sei.cmu.edu/confluence/x/OXw-BQ[CERT, EXP54-CPP.] - Do not access an object outside of its lifetime

--- a/rules/S3584/cfamily/rule.adoc
+++ b/rules/S3584/cfamily/rule.adoc
@@ -37,7 +37,7 @@ int fun() {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/401[MITRE, CWE-401] - Improper Release of Memory Before Removing Last Reference ('Memory Leak')
+* https://cwe.mitre.org/data/definitions/401.html[MITRE, CWE-401] - Improper Release of Memory Before Removing Last Reference ('Memory Leak')
 * https://wiki.sei.cmu.edu/confluence/x/FtYxBQ[MEM00-C.] - Allocate and free memory in the same module, at the same level of abstraction
 * https://wiki.sei.cmu.edu/confluence/x/GNYxBQ[CERT, MEM31-C.] - Free dynamically allocated memory when no longer needed
 

--- a/rules/S3649/csharp/see.adoc
+++ b/rules/S3649/csharp/see.adoc
@@ -2,9 +2,9 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/564[MITRE, CWE-564] - SQL Injection: Hibernate
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/564.html[MITRE, CWE-564] - SQL Injection: Hibernate
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * OWASP SQL Injection Prevention https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html[Cheat Sheet]
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S3649/java/see.adoc
+++ b/rules/S3649/java/see.adoc
@@ -2,10 +2,10 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/564[MITRE, CWE-564] - SQL Injection: Hibernate
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/564.html[MITRE, CWE-564] - SQL Injection: Hibernate
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * OWASP SQL Injection Prevention https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html[Cheat Sheet]
 * https://wiki.sei.cmu.edu/confluence/x/ITdGBQ[CERT, IDS00-J.] - Prevent SQL injection
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S3649/see.adoc
+++ b/rules/S3649/see.adoc
@@ -2,8 +2,8 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/89[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/89.html[MITRE, CWE-89] - Improper Neutralization of Special Elements used in an SQL Command
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * OWASP SQL Injection Prevention https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html[Cheat Sheet]
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S3655/see.adoc
+++ b/rules/S3655/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
+* https://cwe.mitre.org/data/definitions/476.html[MITRE, CWE-476] - NULL Pointer Dereference

--- a/rules/S3752/python/rule.adoc
+++ b/rules/S3752/python/rule.adoc
@@ -81,7 +81,7 @@ def view():
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://owasp.org/www-community/attacks/csrf[OWASP: Cross-Site Request Forgery]
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://docs.djangoproject.com/en/3.1/topics/http/decorators/#allowed-http-methods[Django] - Allowed HTTP Methods

--- a/rules/S3752/see.adoc
+++ b/rules/S3752/see.adoc
@@ -3,7 +3,7 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://owasp.org/www-community/attacks/csrf[OWASP: Cross-Site Request Forgery]
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/csrf.html#csrf-use-proper-verbs[Spring Security Official Documentation: Use proper HTTP verbs (CSRF protection)]

--- a/rules/S3884/see.adoc
+++ b/rules/S3884/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/648[MITRE, CWE-648] - Incorrect Use of Privileged APIs
+* https://cwe.mitre.org/data/definitions/648.html[MITRE, CWE-648] - Incorrect Use of Privileged APIs

--- a/rules/S3921/cobol/rule.adoc
+++ b/rules/S3921/cobol/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 
 === See Also
 

--- a/rules/S3921/see.adoc
+++ b/rules/S3921/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast

--- a/rules/S4036/see.adoc
+++ b/rules/S4036/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/426[MITRE, CWE-426] - Untrusted Search Path
-* https://cwe.mitre.org/data/definitions/427[MITRE, CWE-427] - Uncontrolled Search Path Element
+* https://cwe.mitre.org/data/definitions/426.html[MITRE, CWE-426] - Untrusted Search Path
+* https://cwe.mitre.org/data/definitions/427.html[MITRE, CWE-427] - Uncontrolled Search Path Element

--- a/rules/S4347/see.adoc
+++ b/rules/S4347/see.adoc
@@ -2,8 +2,8 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/332[MITRE, CWE-332] - Insufficient Entropy in PRNG
-* https://cwe.mitre.org/data/definitions/336[MITRE, CWE-336] - Same Seed in Pseudo-Random Number Generator (PRNG)
-* https://cwe.mitre.org/data/definitions/337[MITRE, CWE-337] - Predictable Seed in Pseudo-Random Number Generator (PRNG)
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/332.html[MITRE, CWE-332] - Insufficient Entropy in PRNG
+* https://cwe.mitre.org/data/definitions/336.html[MITRE, CWE-336] - Same Seed in Pseudo-Random Number Generator (PRNG)
+* https://cwe.mitre.org/data/definitions/337.html[MITRE, CWE-337] - Predictable Seed in Pseudo-Random Number Generator (PRNG)
 * https://wiki.sei.cmu.edu/confluence/display/java/MSC63-J.+Ensure+that+SecureRandom+is+properly+seeded[CERT, MSC63J.] - Ensure that SecureRandom is properly seeded

--- a/rules/S4423/csharp/rule.adoc
+++ b/rules/S4423/csharp/rule.adoc
@@ -52,8 +52,8 @@ new HttpClientHandler
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-327] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-327] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols[SSL and TLS Deployment Best Practices - Use secure protocols]
 * https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls[Transport Layer Security (TLS) best practices with the .NET Framework]

--- a/rules/S4423/java/rule.adoc
+++ b/rules/S4423/java/rule.adoc
@@ -42,8 +42,8 @@ ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-327] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-327] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://blogs.oracle.com/java-platform-group/diagnosing-tls,-ssl,-and-https[Diagnosing TLS, SSL, and HTTPS]
 * https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols[SSL and TLS Deployment Best Practices - Use secure protocols]

--- a/rules/S4423/see.adoc
+++ b/rules/S4423/see.adoc
@@ -6,7 +6,7 @@
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x10-v5-network_communication_requirements[Mobile AppSec Verification Standard] - Network Communication Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication[OWASP Mobile Top 10 2016 Category M3] - Insecure Communication
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-327] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-327] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols[SSL and TLS Deployment Best Practices - Use secure protocols]

--- a/rules/S4423/vbnet/rule.adoc
+++ b/rules/S4423/vbnet/rule.adoc
@@ -42,8 +42,8 @@ Dim HandlerB As New HttpClientHandler With {.SslProtocols = SslProtocols.None}  
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-327] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-327] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-326] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols[SSL and TLS Deployment Best Practices - Use secure protocols]
 * https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls[Transport Layer Security (TLS) best practices with the .NET Framework]

--- a/rules/S4424/java/rule.adoc
+++ b/rules/S4424/java/rule.adoc
@@ -30,7 +30,7 @@ class TrustAllManager implements X509TrustManager {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4425/java/rule.adoc
+++ b/rules/S4425/java/rule.adoc
@@ -36,7 +36,7 @@ for (byte b : bytes) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/704[MITRE, CWE-704] - Incorrect Type Conversion or Cast
+* https://cwe.mitre.org/data/definitions/704.html[MITRE, CWE-704] - Incorrect Type Conversion or Cast
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#BAD_HEXA_CONVERSION[BAD_HEXA_CONVERSION] 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4426/python/rule.adoc
+++ b/rules/S4426/python/rule.adoc
@@ -42,7 +42,7 @@ ec.generate_private_key(curve=ec.SECT409R1, backend=backend) # Compliant
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://www.ssi.gouv.fr/uploads/2014/11/RGS_v-2-0_B1.pdf[ANSSI RGSv2] - Référentiel Général de Sécurité version 2
 * https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf[NIST FIPS 186-4] - Digital Signature Standard (DSS)
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4426/see.adoc
+++ b/rules/S4426/see.adoc
@@ -6,4 +6,4 @@
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
 * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf[NIST 800-131A] - Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength

--- a/rules/S4432/java/rule.adoc
+++ b/rules/S4432/java/rule.adoc
@@ -26,7 +26,7 @@ Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf[Recommendation for Block Cipher Modes of Operation]

--- a/rules/S4432/see.adoc
+++ b/rules/S4432/see.adoc
@@ -1,7 +1,7 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf[Recommendation for Block Cipher Modes of Operation]
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#ECB_MODE[ECB_MODE]

--- a/rules/S4433/see.adoc
+++ b/rules/S4433/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/521[MITRE, CWE-521] - Weak Password Requirements
+* https://cwe.mitre.org/data/definitions/521.html[MITRE, CWE-521] - Weak Password Requirements
 * https://ldapwiki.com/wiki/Simple%20Authentication[ldapwiki.com]- Simple Authentication

--- a/rules/S4434/java/rule.adoc
+++ b/rules/S4434/java/rule.adoc
@@ -44,7 +44,7 @@ ctx.search(query, filter,
 == See
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
 * https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE-wp.pdf[BlackHat presentation]
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#LDAP_ENTRY_POISONING[LDAP_ENTRY_POISONING]

--- a/rules/S4435/java/rule.adoc
+++ b/rules/S4435/java/rule.adoc
@@ -47,7 +47,7 @@ transformer.transform(input, result);
 
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#transformerfactory[OWASP XXE Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Improper Restriction of XML External Entity Reference ('XXE')
+* https://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Improper Restriction of XML External Entity Reference ('XXE')
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#XXE_DTD_TRANSFORM_FACTORY[XXE_DTD_TRANSFORM_FACTORY]
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#XXE_XSLT_TRANSFORM_FACTORY[XXE_XSLT_TRANSFORM_FACTORY]
 

--- a/rules/S4487/cfamily/rule.adoc
+++ b/rules/S4487/cfamily/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
 * https://wiki.sei.cmu.edu/confluence/x/39UxBQ[CERT, MSC13-C.] - Detect and remove unused values
 * https://wiki.sei.cmu.edu/confluence/x/9DZGBQ[CERT, MSC56-J.] - Detect and remove superfluous code and values
 

--- a/rules/S4487/java/rule.adoc
+++ b/rules/S4487/java/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
 * https://wiki.sei.cmu.edu/confluence/x/39UxBQ[CERT, MSC13-C.] - Detect and remove unused values
 * https://wiki.sei.cmu.edu/confluence/x/9DZGBQ[CERT, MSC56-J.] - Detect and remove superfluous code and values
 

--- a/rules/S4487/see.adoc
+++ b/rules/S4487/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/563[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')
+* https://cwe.mitre.org/data/definitions/563.html[MITRE, CWE-563] - Assignment to Variable without Use ('Unused Variable')

--- a/rules/S4499/java/rule.adoc
+++ b/rules/S4499/java/rule.adoc
@@ -62,7 +62,7 @@ Session session = Session.getDefaultInstance(props, new javax.mail.Authenticator
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/297[MITRE, CWE-297] - Improper Validation of Certificate with Host Mismatch
+* https://cwe.mitre.org/data/definitions/297.html[MITRE, CWE-297] - Improper Validation of Certificate with Host Mismatch
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4502/see.adoc
+++ b/rules/S4502/see.adoc
@@ -1,7 +1,7 @@
 == See
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-community/attacks/csrf[OWASP: Cross-Site Request Forgery]
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S4507/see.adoc
+++ b/rules/S4507/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/489[MITRE, CWE-489] - Active Debug Code
-* https://cwe.mitre.org/data/definitions/215[MITRE, CWE-215] - Information Exposure Through Debug Information
+* https://cwe.mitre.org/data/definitions/489.html[MITRE, CWE-489] - Active Debug Code
+* https://cwe.mitre.org/data/definitions/215.html[MITRE, CWE-215] - Information Exposure Through Debug Information

--- a/rules/S4507/xml/rule.adoc
+++ b/rules/S4507/xml/rule.adoc
@@ -50,7 +50,7 @@ In ``++AndroidManifest.xml++`` the android debuggable property is set to ``++fal
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x12-v7-code_quality_and_build_setting_requirements[Mobile AppSec Verification Standard] - Code Quality and Build Setting Requirements
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M10-Extraneous_Functionality[OWASP Mobile Top 10 2016 Category M10] - Extraneous Functionality
-* https://cwe.mitre.org/data/definitions/215[MITRE, CWE-215] - Information Exposure Through Debug Information
+* https://cwe.mitre.org/data/definitions/215.html[MITRE, CWE-215] - Information Exposure Through Debug Information
 * https://developer.android.com/studio/publish/preparing[developer.android.com] - Prepare for release
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4508/see.adoc
+++ b/rules/S4508/see.adoc
@@ -2,5 +2,5 @@
 
 * https://www.owasp.org/index.php/Deserialization_of_untrusted_data[OWASP - Deserialization of untrusted data]
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#OBJECT_DESERIALIZATION[OBJECT_DESERIALIZATION ]

--- a/rules/S4510/java/rule.adoc
+++ b/rules/S4510/java/rule.adoc
@@ -40,7 +40,7 @@ public void decode(InputStream in) {
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://www.owasp.org/index.php/Deserialization_of_untrusted_data[OWASP Deserialization of untrusted data]
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#XML_DECODER[XML_DECODER ]
 

--- a/rules/S4512/java/see.adoc
+++ b/rules/S4512/java/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/915[MITRE, CWE-915] - Improperly Controlled Modification of Dynamically-Determined Object Attributes
+* https://cwe.mitre.org/data/definitions/915.html[MITRE, CWE-915] - Improperly Controlled Modification of Dynamically-Determined Object Attributes
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#BEAN_PROPERTY_INJECTION[BEAN_PROPERTY_INJECTION]

--- a/rules/S4529/see.adoc
+++ b/rules/S4529/see.adoc
@@ -3,10 +3,10 @@
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation 
-* https://cwe.mitre.org/data/definitions/352[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/22[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation 
+* https://cwe.mitre.org/data/definitions/352.html[MITRE, CWE-352] - Cross-Site Request Forgery (CSRF)
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/22.html[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4530/java/rule.adoc
+++ b/rules/S4530/java/rule.adoc
@@ -48,7 +48,7 @@ public final class CashTransferAction extends Action {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/105[MITRE, CWE-105] - Struts Form Field Without Validator
+* https://cwe.mitre.org/data/definitions/105.html[MITRE, CWE-105] - Struts Form Field Without Validator
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4544/java/rule.adoc
+++ b/rules/S4544/java/rule.adoc
@@ -46,7 +46,7 @@ abstract class PhoneNumber {
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
 * OWASP - https://www.owasp.org/index.php/Deserialization_of_untrusted_data[Deserialization of untrusted data]
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062[On Jackson CVEs: Don’t Panic]
 * https://nvd.nist.gov/vuln/detail/CVE-2017-15095[CVE-2017-1509]
 * https://nvd.nist.gov/vuln/detail/CVE-2017-7525[CVE-2017-7525]

--- a/rules/S4564/csharp/rule.adoc
+++ b/rules/S4564/csharp/rule.adoc
@@ -50,7 +50,7 @@ Parameterless methods marked with ``++System.Web.Mvc.HttpPostAttribute++`` will 
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://www.owasp.org/index.php/ASP.NET_Request_Validation[OWASP ASP.NET Request Validation]
 

--- a/rules/S4639/java/rule.adoc
+++ b/rules/S4639/java/rule.adoc
@@ -46,7 +46,7 @@ public static void sanitizeAgainstZipFlipVulnerability(String fileName, String c
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://wiki.sei.cmu.edu/confluence/display/java/IDS04-J.+Safely+extract+files+from+ZipInputStream[CERT, IDS04-J.] - Safely extract files from ZipInputStream
 * Snyk Research Team: https://snyk.io/research/zip-slip-vulnerability[Zip Slip Vulnerability]
 * https://nvd.nist.gov/vuln/detail/CVE-2016-0709

--- a/rules/S4639/see.adoc
+++ b/rules/S4639/see.adoc
@@ -2,7 +2,7 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * Snyk Research Team: https://snyk.io/research/zip-slip-vulnerability[Zip Slip Vulnerability]
 * https://nvd.nist.gov/vuln/detail/CVE-2016-0709
 * https://nvd.nist.gov/vuln/detail/CVE-2017-5946

--- a/rules/S4684/java/rule.adoc
+++ b/rules/S4684/java/rule.adoc
@@ -95,7 +95,7 @@ No issue is reported when the parameter is annotated with ``++@PathVariable++`` 
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/915[MITRE, CWE-915] - Improperly Controlled Modification of Dynamically-Determined Object Attributes
+* https://cwe.mitre.org/data/definitions/915.html[MITRE, CWE-915] - Improperly Controlled Modification of Dynamically-Determined Object Attributes
 * https://o2platform.files.wordpress.com/2011/07/ounce_springframework_vulnerabilities.pdf[Two Security Vulnerabilities in the Spring Framework’s MVC by Ryan Berg and Dinis Cruz]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4721/see.adoc
+++ b/rules/S4721/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/78[MITRE, CWE-78] - Improper Neutralization of Special Elements used in an OS Command
+* https://cwe.mitre.org/data/definitions/78.html[MITRE, CWE-78] - Improper Neutralization of Special Elements used in an OS Command
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S4787/see.adoc
+++ b/rules/S4787/see.adoc
@@ -2,11 +2,11 @@
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/321[MITRE, CWE-321] - Use of Hard-coded Cryptographic Key
-* https://cwe.mitre.org/data/definitions/322[MITRE, CWE-322] - Key Exchange without Entity Authentication
-* https://cwe.mitre.org/data/definitions/323[MITRE, CWE-323] - Reusing a Nonce, Key Pair in Encryption
-* https://cwe.mitre.org/data/definitions/324[MITRE, CWE-324] - Use of a Key Past its Expiration Date
-* https://cwe.mitre.org/data/definitions/325[MITRE, CWE-325] - Missing Required Cryptographic Step
-* https://cwe.mitre.org/data/definitions/326[MITRE, CWE-326] - Inadequate Encryption Strength
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/321.html[MITRE, CWE-321] - Use of Hard-coded Cryptographic Key
+* https://cwe.mitre.org/data/definitions/322.html[MITRE, CWE-322] - Key Exchange without Entity Authentication
+* https://cwe.mitre.org/data/definitions/323.html[MITRE, CWE-323] - Reusing a Nonce, Key Pair in Encryption
+* https://cwe.mitre.org/data/definitions/324.html[MITRE, CWE-324] - Use of a Key Past its Expiration Date
+* https://cwe.mitre.org/data/definitions/325.html[MITRE, CWE-325] - Missing Required Cryptographic Step
+* https://cwe.mitre.org/data/definitions/326.html[MITRE, CWE-326] - Inadequate Encryption Strength
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4790/see.adoc
+++ b/rules/S4790/see.adoc
@@ -5,5 +5,5 @@
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/1240[MITRE, CWE-1240] - Use of a Risky Cryptographic Primitive
+* https://cwe.mitre.org/data/definitions/1240.html[MITRE, CWE-1240] - Use of a Risky Cryptographic Primitive
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4792/see.adoc
+++ b/rules/S4792/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
-* https://cwe.mitre.org/data/definitions/117[MITRE, CWE-117] - Improper Output Neutralization for Logs
-* https://cwe.mitre.org/data/definitions/532[MITRE, CWE-532] - Information Exposure Through Log Files
+* https://cwe.mitre.org/data/definitions/117.html[MITRE, CWE-117] - Improper Output Neutralization for Logs
+* https://cwe.mitre.org/data/definitions/532.html[MITRE, CWE-532] - Information Exposure Through Log Files
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4797/java/rule.adoc
+++ b/rules/S4797/java/rule.adoc
@@ -135,13 +135,13 @@ For example we highlight new ``++File(String parent, String child)++`` but not n
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/73[MITRE, CWE-73] - External Control of File Name or Path
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation		
-* https://cwe.mitre.org/data/definitions/22[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
-* https://cwe.mitre.org/data/definitions/538[MITRE, CWE-538] - File and Directory Information Exposure
-* https://cwe.mitre.org/data/definitions/403[MITRE, CWE-403] - Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/73.html[MITRE, CWE-73] - External Control of File Name or Path
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation		
+* https://cwe.mitre.org/data/definitions/22.html[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
+* https://cwe.mitre.org/data/definitions/538.html[MITRE, CWE-538] - File and Directory Information Exposure
+* https://cwe.mitre.org/data/definitions/403.html[MITRE, CWE-403] - Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
 * https://wiki.sei.cmu.edu/confluence/x/qDZGBQ[CERT, FIO01-J.] - Create files with appropriate access permissions
 * https://wiki.sei.cmu.edu/confluence/x/B9cxBQ[CERT, FIO06-C.] - Create files with appropriate access permissions
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO22-C.+Close+files+before+spawning+processes[CERT, FIO22-C.] Close files before spawning processes

--- a/rules/S4797/see.adoc
+++ b/rules/S4797/see.adoc
@@ -1,12 +1,12 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/73[MITRE, CWE-73] - External Control of File Name or Path
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation		
-* https://cwe.mitre.org/data/definitions/22[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
-* https://cwe.mitre.org/data/definitions/538[MITRE, CWE-538] - File and Directory Information Exposure
-* https://cwe.mitre.org/data/definitions/403[MITRE, CWE-403] - Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/73.html[MITRE, CWE-73] - External Control of File Name or Path
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation		
+* https://cwe.mitre.org/data/definitions/22.html[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
+* https://cwe.mitre.org/data/definitions/538.html[MITRE, CWE-538] - File and Directory Information Exposure
+* https://cwe.mitre.org/data/definitions/403.html[MITRE, CWE-403] - Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4817/java/rule.adoc
+++ b/rules/S4817/java/rule.adoc
@@ -93,7 +93,7 @@ abstract class A extends JXPathContext{
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/643[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
+* https://cwe.mitre.org/data/definitions/643.html[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
 * https://wiki.sei.cmu.edu/confluence/x/cDZGBQ[CERT, IDS53-J.] - Prevent XPath Injection
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4817/see.adoc
+++ b/rules/S4817/see.adoc
@@ -1,4 +1,4 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/643[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions
+* https://cwe.mitre.org/data/definitions/643.html[MITRE, CWE-643] - Improper Neutralization of Data within XPath Expressions

--- a/rules/S4818/see.adoc
+++ b/rules/S4818/see.adoc
@@ -1,8 +1,8 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] -  Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] -  Exposure of Sensitive Information to an Unauthorized Actor
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S4823/see.adoc
+++ b/rules/S4823/see.adoc
@@ -1,6 +1,6 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
-* https://cwe.mitre.org/data/definitions/214[MITRE, CWE-214] - Information Exposure Through Process Environment
+* https://cwe.mitre.org/data/definitions/88.html[MITRE, CWE-88] - Argument Injection or Modification
+* https://cwe.mitre.org/data/definitions/214.html[MITRE, CWE-214] - Information Exposure Through Process Environment
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S4825/see.adoc
+++ b/rules/S4825/see.adoc
@@ -1,6 +1,6 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation		
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation		
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption ('Resource Exhaustion')
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor

--- a/rules/S4828/see.adoc
+++ b/rules/S4828/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/283[MITRE, CWE-283] - Unverified Ownership
+* https://cwe.mitre.org/data/definitions/283.html[MITRE, CWE-283] - Unverified Ownership

--- a/rules/S4829/see.adoc
+++ b/rules/S4829/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation

--- a/rules/S4830/java/rule.adoc
+++ b/rules/S4830/java/rule.adoc
@@ -36,7 +36,7 @@ class TrustAllManager implements X509TrustManager {
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4830/see.adoc
+++ b/rules/S4830/see.adoc
@@ -7,4 +7,4 @@
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x10-v5-network_communication_requirements[Mobile AppSec Verification Standard] - Network Communication Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication[OWASP Mobile Top 10 2016 Category M3] - Insecure Communication
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation

--- a/rules/S4834/see.adoc
+++ b/rules/S4834/see.adoc
@@ -2,7 +2,7 @@
 
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
-* https://cwe.mitre.org/data/definitions/276[MITRE, CWE-276] - Incorrect Default Permissions
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
-* https://cwe.mitre.org/data/definitions/277[MITRE, CWE-277] - Insecure Inherited Permissions
+* https://cwe.mitre.org/data/definitions/276.html[MITRE, CWE-276] - Incorrect Default Permissions
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/277.html[MITRE, CWE-277] - Insecure Inherited Permissions

--- a/rules/S4973/java/rule.adoc
+++ b/rules/S4973/java/rule.adoc
@@ -25,8 +25,8 @@ if (firstName != null && firstName.equals(lastName)) { ... };
 
 == See
 
-* https://cwe.mitre.org/data/definitions/595[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
-* https://cwe.mitre.org/data/definitions/597[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
+* https://cwe.mitre.org/data/definitions/595.html[MITRE, CWE-595] - Comparison of Object References Instead of Object Contents
+* https://cwe.mitre.org/data/definitions/597.html[MITRE, CWE-597] - Use of Wrong Operator in String Comparison
 * https://wiki.sei.cmu.edu/confluence/x/UjdGBQ[CERT, EXP03-J.] - Do not use the equality operators when comparing values of boxed primitives
 * https://wiki.sei.cmu.edu/confluence/x/yDdGBQ[CERT, EXP50-J.] - Do not confuse abstract object equality with reference equality
 

--- a/rules/S5042/cfamily/rule.adoc
+++ b/rules/S5042/cfamily/rule.adoc
@@ -106,7 +106,7 @@ int f(const char *filename, int flags) {
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://wiki.sei.cmu.edu/confluence/display/java/IDS04-J.+Safely+extract+files+from+ZipInputStream[CERT, IDS04-J.] - Safely extract files from ZipInputStream
 * https://www.bamsoftware.com/hacks/zipbomb/[bamsoftware.com] - A better Zip Bomb
 

--- a/rules/S5042/java/rule.adoc
+++ b/rules/S5042/java/rule.adoc
@@ -74,7 +74,7 @@ while(entries.hasMoreElements()) {
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://wiki.sei.cmu.edu/confluence/display/java/IDS04-J.+Safely+extract+files+from+ZipInputStream[CERT, IDS04-J.] - Safely extract files from ZipInputStream
 * https://www.bamsoftware.com/hacks/zipbomb/[bamsoftware.com] - A better Zip Bomb
 

--- a/rules/S5042/javascript/rule.adoc
+++ b/rules/S5042/javascript/rule.adoc
@@ -287,7 +287,7 @@ main();
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://www.bamsoftware.com/hacks/zipbomb/[bamsoftware.com] - A better Zip Bomb
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5042/php/rule.adoc
+++ b/rules/S5042/php/rule.adoc
@@ -159,7 +159,7 @@ zip_close($zip);
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://www.bamsoftware.com/hacks/zipbomb/[bamsoftware.com] - A better Zip Bomb
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5042/see.adoc
+++ b/rules/S5042/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/409[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
+* https://cwe.mitre.org/data/definitions/409.html[MITRE, CWE-409] - Improper Handling of Highly Compressed Data (Data Amplification)
 * https://www.bamsoftware.com/hacks/zipbomb/[bamsoftware.com] - A better Zip Bomb

--- a/rules/S5122/see.adoc
+++ b/rules/S5122/see.adoc
@@ -6,6 +6,6 @@
 * https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy[developer.mozilla.org] - Same origin policy
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing[OWASP HTML5 Security Cheat Sheet] - Cross Origin Resource Sharing
-* https://cwe.mitre.org/data/definitions/346[MITRE, CWE-346] - Origin Validation Error
-* https://cwe.mitre.org/data/definitions/942[MITRE, CWE-942] - Overly Permissive Cross-domain Whitelist
+* https://cwe.mitre.org/data/definitions/346.html[MITRE, CWE-346] - Origin Validation Error
+* https://cwe.mitre.org/data/definitions/942.html[MITRE, CWE-942] - Overly Permissive Cross-domain Whitelist
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S5131/see.adoc
+++ b/rules/S5131/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html[OWASP Cheat Sheet] - XSS Prevention Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5135/csharp/rule.adoc
+++ b/rules/S5135/csharp/rule.adoc
@@ -43,8 +43,8 @@ public class XmlSerializerTestCase : Controller
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/134[MITRE, CWE-134] - Use of Externally-Controlled Format String
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/134.html[MITRE, CWE-134] - Use of Externally-Controlled Format String
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5135/see.adoc
+++ b/rules/S5135/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S5144/see.adoc
+++ b/rules/S5144/see.adoc
@@ -3,7 +3,7 @@
 * https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/[OWASP Top 10 2021 Category A10] - Server-Side Request Forgery (SSRF)
 * https://www.owasp.org/index.php/Server_Side_Request_Forgery[OWASP Attack Category] - Server Side Request Forgery
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/641[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
-* https://cwe.mitre.org/data/definitions/918[MITRE, CWE-918] - Server-Side Request Forgery (SSRF)
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/641.html[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
+* https://cwe.mitre.org/data/definitions/918.html[MITRE, CWE-918] - Server-Side Request Forgery (SSRF)
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S5145/see.adoc
+++ b/rules/S5145/see.adoc
@@ -4,6 +4,6 @@
 * https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html[OWASP Cheat Sheet] - Logging
 * https://www.owasp.org/index.php/Log_Injection[OWASP Attack Category] - Log Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/117[MITRE, CWE-117] - Improper Output Neutralization for Logs
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/117.html[MITRE, CWE-117] - Improper Output Neutralization for Logs
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5146/csharp/rule.adoc
+++ b/rules/S5146/csharp/rule.adoc
@@ -51,7 +51,7 @@ public class HomeController : Controller
 * https://docs.microsoft.com/en-us/aspnet/core/security/preventing-open-redirects?view=aspnetcore-3.1[Microsoft Documentation ASP.NET Core] - Prevent Open Redirect Attacks in ASP.NET Core
 * https://docs.microsoft.com/en-us/aspnet/mvc/overview/security/preventing-open-redirection-attacks[Microsoft Documentation ASP.NET MVC] - Preventing Open Redirection Attacks
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/601[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
+* https://cwe.mitre.org/data/definitions/601.html[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5146/see.adoc
+++ b/rules/S5146/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/601[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/601.html[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S5147/see.adoc
+++ b/rules/S5147/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5148/see.adoc
+++ b/rules/S5148/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-community/attacks/Reverse_Tabnabbing[Reverse Tabnabbing]
-* https://cwe.mitre.org/data/definitions/1022[MITRE, CWE-1022] - Use of Web Link to Untrusted Target with window.opener Access
+* https://cwe.mitre.org/data/definitions/1022.html[MITRE, CWE-1022] - Use of Web Link to Untrusted Target with window.opener Access
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mathiasbynens.github.io/rel-noopener/

--- a/rules/S5167/see.adoc
+++ b/rules/S5167/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/HTTP_Response_Splitting[OWASP Attack Category] - HTTP Response Splitting
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/113[MITRE, CWE-113] - Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/113.html[MITRE, CWE-113] - Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5247/see.adoc
+++ b/rules/S5247/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md[OWASP Cheat Sheet] - XSS Prevention Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S5300/see.adoc
+++ b/rules/S5300/see.adoc
@@ -2,6 +2,6 @@
 
 * https://www.damonkohler.com/2008/12/email-injection.html[Email Injection]
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/93[MITRE, CWE-93] - Improper Neutralization of CRLF Sequences ('CRLF Injection')
-* https://cwe.mitre.org/data/definitions/80[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
+* https://cwe.mitre.org/data/definitions/93.html[MITRE, CWE-93] - Improper Neutralization of CRLF Sequences ('CRLF Injection')
+* https://cwe.mitre.org/data/definitions/80.html[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5301/java/rule.adoc
+++ b/rules/S5301/java/rule.adoc
@@ -29,7 +29,7 @@ factory.setTrustedPackages(Arrays.asList("org.mypackage1", "org.mypackage2"));
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://activemq.apache.org/objectmessage.html[ActiveMQ ObjectMessage Security Advisory]
 * https://activemq.apache.org/security-advisories.data/CVE-2015-5254-announcement.txt[CVE-2015-5254]
 

--- a/rules/S5304/java/rule.adoc
+++ b/rules/S5304/java/rule.adoc
@@ -55,8 +55,8 @@ public class Main {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/526[MITRE, CWE-526] - Information Exposure Through Environmental Variables
-* https://cwe.mitre.org/data/definitions/74[MITRE, CWE-74] - Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
+* https://cwe.mitre.org/data/definitions/526.html[MITRE, CWE-526] - Information Exposure Through Environmental Variables
+* https://cwe.mitre.org/data/definitions/74.html[MITRE, CWE-74] - Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5320/see.adoc
+++ b/rules/S5320/see.adoc
@@ -2,5 +2,5 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/927[MITRE, CWE-927] - Use of Implicit Intent for Sensitive Communication
+* https://cwe.mitre.org/data/definitions/927.html[MITRE, CWE-927] - Use of Implicit Intent for Sensitive Communication
 * https://developer.android.com/guide/components/broadcasts.html#restricting_broadcasts_with_permissions[Android documentation] - Broadcast Overview - Security considerations and best practices

--- a/rules/S5322/see.adoc
+++ b/rules/S5322/see.adoc
@@ -2,7 +2,7 @@
 
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/925[MITRE, CWE-925] - Improper Verification of Intent by Broadcast Receiver
-* https://cwe.mitre.org/data/definitions/926[MITRE, CWE-926] - Improper Export of Android Application Components
+* https://cwe.mitre.org/data/definitions/925.html[MITRE, CWE-925] - Improper Verification of Intent by Broadcast Receiver
+* https://cwe.mitre.org/data/definitions/926.html[MITRE, CWE-926] - Improper Export of Android Application Components
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://developer.android.com/guide/components/broadcasts.html#restricting_broadcasts_with_permissions[Android documentation] - Broadcast Overview - Security considerations and best practices

--- a/rules/S5324/see.adoc
+++ b/rules/S5324/see.adoc
@@ -4,6 +4,6 @@
 * https://developer.android.com/training/articles/security-tips#ExternalStorage[Android Security tips on external file storage]
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x07-v2-data_storage_and_privacy_requirements[Mobile AppSec Verification Standard] - Data Storage and Privacy Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
-* https://cwe.mitre.org/data/definitions/312[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
+* https://cwe.mitre.org/data/definitions/312.html[MITRE, CWE-312] - Cleartext Storage of Sensitive Information
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S5326/java/rule.adoc
+++ b/rules/S5326/java/rule.adoc
@@ -63,7 +63,7 @@ public class SSLTLSValidation extends WebViewClient {
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 
 

--- a/rules/S5328/php/rule.adoc
+++ b/rules/S5328/php/rule.adoc
@@ -39,8 +39,8 @@ session_id(bin2hex(random_bytes(16))); // Compliant
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://www.owasp.org/index.php/Session_fixation[OWASP Sesssion Fixation]
-* https://cwe.mitre.org/data/definitions/330[MITRE, CWE-330] - Use of Insufficiently Random Values
-* https://cwe.mitre.org/data/definitions/340[MITRE, CWE-340] - Generation of Predictable Numbers or Identifiers
+* https://cwe.mitre.org/data/definitions/330.html[MITRE, CWE-330] - Use of Insufficiently Random Values
+* https://cwe.mitre.org/data/definitions/340.html[MITRE, CWE-340] - Generation of Predictable Numbers or Identifiers
 * https://www.php.net/random-bytes[PHP: random_bytes()]
 * https://www.php.net/session-regenerate-id[PHP: session_regenerate_id()] 
 

--- a/rules/S5332/apex/rule.adoc
+++ b/rules/S5332/apex/rule.adoc
@@ -35,7 +35,7 @@ include::../exceptions.adoc[]
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Information Exposure
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Information Exposure
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S5332/see.adoc
+++ b/rules/S5332/see.adoc
@@ -4,7 +4,7 @@
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure 
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x10-v5-network_communication_requirements[Mobile AppSec Verification Standard] - Network Communication Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication[OWASP Mobile Top 10 2016 Category M3] - Insecure Communication
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
-* https://cwe.mitre.org/data/definitions/319[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/319.html[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
 * https://security.googleblog.com/2016/09/moving-towards-more-secure-web.html[Google, Moving towards more secure web]
 * https://blog.mozilla.org/security/2015/04/30/deprecating-non-secure-http/[Mozilla, Deprecating non secure http]

--- a/rules/S5334/see.adoc
+++ b/rules/S5334/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/95[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/95.html[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S5335/php/see.adoc
+++ b/rules/S5335/php/see.adoc
@@ -3,8 +3,8 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/97[MITRE, CWE-97] - Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-* https://cwe.mitre.org/data/definitions/98[MITRE, CWE-98] - Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-* https://cwe.mitre.org/data/definitions/829[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/97.html[MITRE, CWE-97] - Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
+* https://cwe.mitre.org/data/definitions/98.html[MITRE, CWE-98] - Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
+* https://cwe.mitre.org/data/definitions/829.html[MITRE, CWE-829] - Inclusion of Functionality from Untrusted Control Sphere
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S5344/see.adoc
+++ b/rules/S5344/see.adoc
@@ -4,6 +4,6 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html[OWASP CheatSheet] - Password Storage Cheat Sheet
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/256[MITRE, CWE-256] - Plaintext Storage of a Password
-* https://cwe.mitre.org/data/definitions/916[MITRE, CWE-916] - Use of Password Hash With Insufficient Computational Effort
+* https://cwe.mitre.org/data/definitions/256.html[MITRE, CWE-256] - Plaintext Storage of a Password
+* https://cwe.mitre.org/data/definitions/916.html[MITRE, CWE-916] - Use of Password Hash With Insufficient Computational Effort
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S5392/apex/rule.adoc
+++ b/rules/S5392/apex/rule.adoc
@@ -54,8 +54,8 @@ public class My {
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://trailhead.salesforce.com/en/content/learn/modules/secure-serverside-development/mitigate-soql-injection[Prevent SOQL Injection in Your Code]
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/943[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/943.html[MITRE, CWE-943] - Improper Neutralization of Special Elements in Data Query Logic
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5435/python/rule.adoc
+++ b/rules/S5435/python/rule.adoc
@@ -30,7 +30,7 @@ You are at risk if you answered yes to all those questions.
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * https://www.python.org/dev/peps/pep-0476/[PEP-476]
 * https://www.youtube.com/watch?v=4o-xqqidvKA[Benjamin Peterson - A Dive into TLS - PyCon 2015]
 * https://wiki.openstack.org/wiki/OSSN/OSSN-0033[OSSN/OSSN-0033]

--- a/rules/S5439/python/rule.adoc
+++ b/rules/S5439/python/rule.adoc
@@ -43,15 +43,15 @@ env = Environment(autoescape=True) # Compliant
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md[OWASP Cheat Sheet] - XSS Prevention Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/80[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-* https://cwe.mitre.org/data/definitions/81[MITRE, CWE-81] - Improper Neutralization of Script in an Error Message Web Page
-* https://cwe.mitre.org/data/definitions/82[MITRE, CWE-82] - Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-* https://cwe.mitre.org/data/definitions/83[MITRE, CWE-83] - Improper Neutralization of Script in Attributes in a Web Page
-* https://cwe.mitre.org/data/definitions/84[MITRE, CWE-84] - Improper Neutralization of Encoded URI Schemes in a Web Page
-* https://cwe.mitre.org/data/definitions/85[MITRE, CWE-85] - Doubled Character XSS Manipulations
-* https://cwe.mitre.org/data/definitions/86[MITRE, CWE-86] - Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-* https://cwe.mitre.org/data/definitions/87[MITRE, CWE-87] - Improper Neutralization of Alternate XSS Syntax
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/80.html[MITRE, CWE-80] - Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
+* https://cwe.mitre.org/data/definitions/81.html[MITRE, CWE-81] - Improper Neutralization of Script in an Error Message Web Page
+* https://cwe.mitre.org/data/definitions/82.html[MITRE, CWE-82] - Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
+* https://cwe.mitre.org/data/definitions/83.html[MITRE, CWE-83] - Improper Neutralization of Script in Attributes in a Web Page
+* https://cwe.mitre.org/data/definitions/84.html[MITRE, CWE-84] - Improper Neutralization of Encoded URI Schemes in a Web Page
+* https://cwe.mitre.org/data/definitions/85.html[MITRE, CWE-85] - Doubled Character XSS Manipulations
+* https://cwe.mitre.org/data/definitions/86.html[MITRE, CWE-86] - Improper Neutralization of Invalid Characters in Identifiers in Web Pages
+* https://cwe.mitre.org/data/definitions/87.html[MITRE, CWE-87] - Improper Neutralization of Alternate XSS Syntax
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components 
 
 

--- a/rules/S5443/python/rule.adoc
+++ b/rules/S5443/python/rule.adoc
@@ -29,8 +29,8 @@ file = tempfile.TemporaryFile(dir="/tmp/my_subdirectory", mode='"w+") # Complian
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/377[MITRE, CWE-377] - Insecure Temporary File
-* https://cwe.mitre.org/data/definitions/379[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
+* https://cwe.mitre.org/data/definitions/377.html[MITRE, CWE-377] - Insecure Temporary File
+* https://cwe.mitre.org/data/definitions/379.html[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
 * https://www.owasp.org/index.php/Insecure_Temporary_File[OWASP, Insecure Temporary File]
 * https://docs.python.org/3/library/tempfile.html[Python tempfile module]
 

--- a/rules/S5443/see.adoc
+++ b/rules/S5443/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/377[MITRE, CWE-377] - Insecure Temporary File
-* https://cwe.mitre.org/data/definitions/379[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
+* https://cwe.mitre.org/data/definitions/377.html[MITRE, CWE-377] - Insecure Temporary File
+* https://cwe.mitre.org/data/definitions/379.html[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
 * https://www.owasp.org/index.php/Insecure_Temporary_File[OWASP, Insecure Temporary File]

--- a/rules/S5445/python/rule.adoc
+++ b/rules/S5445/python/rule.adoc
@@ -24,8 +24,8 @@ tmp_file2 = tempfile.NamedTemporaryFile() # Compliant; Created file will be auto
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/377[MITRE, CWE-377] - Insecure Temporary File
-* https://cwe.mitre.org/data/definitions/379[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
+* https://cwe.mitre.org/data/definitions/377.html[MITRE, CWE-377] - Insecure Temporary File
+* https://cwe.mitre.org/data/definitions/379.html[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
 * https://www.owasp.org/index.php/Insecure_Temporary_File[OWASP, Insecure Temporary File]
 * https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables[Python tempfile module]
 * https://docs.python.org/2.7/library/os.html[Python 2.7 os module]

--- a/rules/S5445/see.adoc
+++ b/rules/S5445/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/377[MITRE, CWE-377] - Insecure Temporary File
-* https://cwe.mitre.org/data/definitions/379[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
+* https://cwe.mitre.org/data/definitions/377.html[MITRE, CWE-377] - Insecure Temporary File
+* https://cwe.mitre.org/data/definitions/379.html[MITRE, CWE-379] - Creation of Temporary File in Directory with Incorrect Permissions
 * https://www.owasp.org/index.php/Insecure_Temporary_File[OWASP, Insecure Temporary File]

--- a/rules/S5496/python/rule.adoc
+++ b/rules/S5496/python/rule.adoc
@@ -44,7 +44,7 @@ def hello():
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/94[MITRE, CWE-94] - Improper Control of Generation of Code
+* https://cwe.mitre.org/data/definitions/94.html[MITRE, CWE-94] - Improper Control of Generation of Code
 * https://medium.com/@nyomanpradipta120/ssti-in-flask-jinja2-20b068fdaeee[SSTI in Flask/Jinja2]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5527/java/rule.adoc
+++ b/rules/S5527/java/rule.adoc
@@ -103,7 +103,7 @@ Session session = Session.getDefaultInstance(props, new javax.mail.Authenticator
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/295[MITRE, CWE-295] - Improper Certificate Validation
+* https://cwe.mitre.org/data/definitions/295.html[MITRE, CWE-295] - Improper Certificate Validation
 * Derived from FindSecBugs rule https://find-sec-bugs.github.io/bugs.htm#WEAK_HOSTNAME_VERIFIER[WEAK_HOSTNAME_VERIFIER]
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5527/see.adoc
+++ b/rules/S5527/see.adoc
@@ -7,4 +7,4 @@
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x10-v5-network_communication_requirements[Mobile AppSec Verification Standard] - Network Communication Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m3-insecure-communication[OWASP Mobile Top 10 2016 Category M3] - Insecure Communication
-* https://cwe.mitre.org/data/definitions/297[MITRE, CWE-297] - Improper Validation of Certificate with Host Mismatch
+* https://cwe.mitre.org/data/definitions/297.html[MITRE, CWE-297] - Improper Validation of Certificate with Host Mismatch

--- a/rules/S5542/java/rule.adoc
+++ b/rules/S5542/java/rule.adoc
@@ -29,7 +29,7 @@ Cipher c3 = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING"); // Comp
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S5542/kotlin/rule.adoc
+++ b/rules/S5542/kotlin/rule.adoc
@@ -29,7 +29,7 @@ val c3 = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING"); // Complia
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S5542/see.adoc
+++ b/rules/S5542/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S5547/java/rule.adoc
+++ b/rules/S5547/java/rule.adoc
@@ -56,7 +56,7 @@ public class test {
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S5547/kotlin/rule.adoc
+++ b/rules/S5547/kotlin/rule.adoc
@@ -52,7 +52,7 @@ class test {
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x08-v3-cryptography_verification_requirements[Mobile AppSec Verification Standard] - Cryptography Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m5-insufficient-cryptography[OWASP Mobile Top 10 2016 Category M5] - Insufficient Cryptography
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://wiki.sei.cmu.edu/confluence/x/hDdGBQ[CERT, MSC61-J.] - Do not use insecure or weak cryptographic algorithms
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
 

--- a/rules/S5547/see.adoc
+++ b/rules/S5547/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S5594/xml/rule.adoc
+++ b/rules/S5594/xml/rule.adoc
@@ -77,7 +77,7 @@ Otherwise, implement permissions (``++protectionLevel++`` https://developer.andr
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage[OWASP Mobile Top 10 2016 Category M1] - Improper platform usage
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M2-Insecure_Data_Storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
-* https://cwe.mitre.org/data/definitions/926[MITRE, CWE-926] - Improper Export of Android Application Components
+* https://cwe.mitre.org/data/definitions/926.html[MITRE, CWE-926] - Improper Export of Android Application Components
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5604/javascript/rule.adoc
+++ b/rules/S5604/javascript/rule.adoc
@@ -52,8 +52,8 @@ If geolocation is required, always explain to the user why the application needs
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Web Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/250[MITRE, CWE-250] - Execution with Unnecessary Privileges
-* https://cwe.mitre.org/data/definitions/359[MITRE, CWE-359] - Exposure of Private Information
+* https://cwe.mitre.org/data/definitions/250.html[MITRE, CWE-250] - Execution with Unnecessary Privileges
+* https://cwe.mitre.org/data/definitions/359.html[MITRE, CWE-359] - Exposure of Private Information
 * https://www.w3.org/TR/permissions/[W3C] - Permissions
 * https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites[Mozilla] - Does Firefox share my location with websites?
 ifdef::env-github,rspecator-view[]

--- a/rules/S5604/xml/rule.adoc
+++ b/rules/S5604/xml/rule.adoc
@@ -32,7 +32,7 @@ In AndroidManifest.xml:
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/250[MITRE, CWE-250] - Execution with Unnecessary Privileges
+* https://cwe.mitre.org/data/definitions/250.html[MITRE, CWE-250] - Execution with Unnecessary Privileges
 * https://developer.android.com/training/permissions/usage-notes[developer.android.com] - App permissions best practices
 * https://play.google.com/about/privacy-security-deception/permissions/[Google Play] - Privacy, Security, and Deception - Permissions
 ifdef::env-github,rspecator-view[]

--- a/rules/S5659/see.adoc
+++ b/rules/S5659/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/347[MITRE, CWE-347] - Improper Verification of Cryptographic Signature
+* https://cwe.mitre.org/data/definitions/347.html[MITRE, CWE-347] - Improper Verification of Cryptographic Signature

--- a/rules/S5689/see.adoc
+++ b/rules/S5689/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework.html[OWASP  Testing Guide - OTG-INFO-008] - Fingerprint Web Application Framework
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Information Exposure
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Information Exposure

--- a/rules/S5691/see.adoc
+++ b/rules/S5691/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://github.com/mtojek/go-url-fuzzer[github.com/mtojek/go-url-fuzzer] - Discover hidden files and directories on a web server.
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Web Top 10 2017 Category A6] - Security Misconfiguration.
-* https://cwe.mitre.org/data/definitions/538[MITRE, CWE-538] - File and Directory Information Exposure
+* https://cwe.mitre.org/data/definitions/538.html[MITRE, CWE-538] - File and Directory Information Exposure

--- a/rules/S5693/see.adoc
+++ b/rules/S5693/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html[Owasp Cheat Sheet] - Owasp Denial of Service Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/770[MITRE, CWE-770] - Allocation of Resources Without Limits or Throttling
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption
+* https://cwe.mitre.org/data/definitions/770.html[MITRE, CWE-770] - Allocation of Resources Without Limits or Throttling
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption

--- a/rules/S5696/javascript/rule.adoc
+++ b/rules/S5696/javascript/rule.adoc
@@ -34,7 +34,7 @@ rootDiv.innerText = hash;
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md[OWASP Cheat Sheet] - XSS Prevention Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
 * http://www.webappsec.org/projects/articles/071105.shtml[webappsec.org] -  DOM Based Cross Site Scripting or XSS of the Third Kind
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5725/see.adoc
+++ b/rules/S5725/see.adoc
@@ -1,6 +1,6 @@
 == See
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
-* https://cwe.mitre.org/data/definitions/353[MITRE, CWE-353] - Missing Support for Integrity Check
+* https://cwe.mitre.org/data/definitions/353.html[MITRE, CWE-353] - Missing Support for Integrity Check
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A6-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity[developer.mozilla.org] - Subresource Integrity

--- a/rules/S5732/see.adoc
+++ b/rules/S5732/see.adoc
@@ -6,5 +6,5 @@
 * https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html[OWASP Cheat Sheets] - Clickjacking Defense Cheat Sheet
 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors[developer.mozilla.org] - Frame-ancestors
 * https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP[developer.mozilla.org] - Content Security Policy (CSP)
-* https://cwe.mitre.org/data/definitions/451[MITRE, CWE-451] - User Interface (UI) Misrepresentation of Critical Information
+* https://cwe.mitre.org/data/definitions/451.html[MITRE, CWE-451] - User Interface (UI) Misrepresentation of Critical Information
 * https://www.w3.org/TR/CSP3/[w3.org] - Content Security Policy Level 3

--- a/rules/S5736/see.adoc
+++ b/rules/S5736/see.adoc
@@ -4,4 +4,4 @@
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy[developer.mozilla.org] - Referrer-Policy
 * https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns[developer.mozilla.org] - Referer header: privacy and security concerns
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor

--- a/rules/S5738/java/rule.adoc
+++ b/rules/S5738/java/rule.adoc
@@ -56,7 +56,7 @@ public class Bar extends Foo {  // Noncompliant; Foo is deprecated and will be r
 
 == See
 
-* https://cwe.mitre.org/data/definitions/477[MITRE, CWE-477] - Use of Obsolete Functions
+* https://cwe.mitre.org/data/definitions/477.html[MITRE, CWE-477] - Use of Obsolete Functions
 * https://wiki.sei.cmu.edu/confluence/x/6TdGBQ[CERT, MET02-J.] - Do not use deprecated or obsolete classes or methods
 * RSPEC-1874 for standard deprecation use
 

--- a/rules/S5750/see.adoc
+++ b/rules/S5750/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/525[MITRE, CWE-525]
+* https://cwe.mitre.org/data/definitions/525.html[MITRE, CWE-525]
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure.html[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control[developer.mozilla.org] - Cache-Control

--- a/rules/S5753/see.adoc
+++ b/rules/S5753/see.adoc
@@ -5,4 +5,4 @@
 * https://owasp.org/www-community/ASP-NET_Request_Validation[OWASP ASP.NET Request Validation]
 * https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html[OWASP Cheat Sheet] - XSS Prevention Cheat Sheet
 * https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S5754/python/rule.adoc
+++ b/rules/S5754/python/rule.adoc
@@ -66,7 +66,7 @@ except FileNotFoundError:
 * PEP 352 - https://www.python.org/dev/peps/pep-0352/#id5[Required Superclass for Exceptions]
 * Python Documentation - https://docs.python.org/3/library/exceptions.html[Built-in exceptions]
 * Python Documentation - https://docs.python.org/3/reference/compound_stmts.html#the-try-statement[The ``++try++`` statement]
-* https://cwe.mitre.org/data/definitions/391[MITRE, CWE-391] - Unchecked Error Condition
+* https://cwe.mitre.org/data/definitions/391.html[MITRE, CWE-391] - Unchecked Error Condition
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5757/see.adoc
+++ b/rules/S5757/see.adoc
@@ -1,5 +1,5 @@
 == See
 
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
-* https://cwe.mitre.org/data/definitions/532[MITRE, CWE-532] - Insertion of Sensitive Information into Log File
+* https://cwe.mitre.org/data/definitions/532.html[MITRE, CWE-532] - Insertion of Sensitive Information into Log File
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure.html[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure

--- a/rules/S5766/see.adoc
+++ b/rules/S5766/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
 * https://docs.microsoft.com/en-us/dotnet/framework/misc/security-and-serialization[docs.microsoft.com] - security-and-serialization
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data

--- a/rules/S5773/csharp/rule.adoc
+++ b/rules/S5773/csharp/rule.adoc
@@ -91,8 +91,8 @@ formatter.Deserialize(fs);
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide?s=03[docs.microsoft.com] - BinaryFormatter security guide
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/134[MITRE, CWE-134] - Use of Externally-Controlled Format String
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/134.html[MITRE, CWE-134] - Use of Externally-Controlled Format String
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Deserialization_Cheat_Sheet.md[OWASP Deserialization Cheat Sheet] 
 

--- a/rules/S5773/see.adoc
+++ b/rules/S5773/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://www.owasp.org/index.php/Top_10-2017_A8-Insecure_Deserialization[OWASP Top 10 2017 Category A8] - Insecure Deserialization
-* https://cwe.mitre.org/data/definitions/502[MITRE, CWE-502] - Deserialization of Untrusted Data
+* https://cwe.mitre.org/data/definitions/502.html[MITRE, CWE-502] - Deserialization of Untrusted Data
 * https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Deserialization_Cheat_Sheet.md[OWASP Deserialization Cheat Sheet] 

--- a/rules/S5782/cfamily/rule.adoc
+++ b/rules/S5782/cfamily/rule.adoc
@@ -34,9 +34,9 @@ Functions related to sockets using the type ``++socklen_t++`` are not checked. T
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/119[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
-* https://cwe.mitre.org/data/definitions/131[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
-* https://cwe.mitre.org/data/definitions/788[MITRE, CWE-788] - Access of Memory Location After End of Buffer
+* https://cwe.mitre.org/data/definitions/119.html[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
+* https://cwe.mitre.org/data/definitions/131.html[MITRE, CWE-131] - Incorrect Calculation of Buffer Size
+* https://cwe.mitre.org/data/definitions/788.html[MITRE, CWE-788] - Access of Memory Location After End of Buffer
 * https://wiki.sei.cmu.edu/confluence/x/wtYxBQ[CERT, ARR30-C.] - Do not form or use out-of-bounds pointers or array subscripts
 * https://wiki.sei.cmu.edu/confluence/x/i3w-BQ[CERT, STR50-CPP.] - Guarantee that storage for strings has sufficient space for character data and the null terminator
 

--- a/rules/S5798/cfamily/rule.adoc
+++ b/rules/S5798/cfamily/rule.adoc
@@ -41,7 +41,7 @@ void f(char *password, size_t bufferSize) {
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/14[MITRE, CWE-14] - Compiler Removal of Code to Clear Buffers
+* https://cwe.mitre.org/data/definitions/14.html[MITRE, CWE-14] - Compiler Removal of Code to Clear Buffers
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5801/cfamily/rule.adoc
+++ b/rules/S5801/cfamily/rule.adoc
@@ -52,7 +52,7 @@ int f(char *src) {
 
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://wiki.sei.cmu.edu/confluence/x/HdcxBQ[CERT, STR07-C.] - Use the bounds-checking interfaces for string manipulation
 
 

--- a/rules/S5802/see.adoc
+++ b/rules/S5802/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/243[MITRE, CWE-243] - Creation of chroot Jail Without Changing Working Directory
+* https://cwe.mitre.org/data/definitions/243.html[MITRE, CWE-243] - Creation of chroot Jail Without Changing Working Directory
 * https://man7.org/linux/man-pages/man2/chdir.2.html[man7.org] - chdir
 * https://man7.org/linux/man-pages/man2/chroot.2.html[man7.org] - chroot

--- a/rules/S5804/see.adoc
+++ b/rules/S5804/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor

--- a/rules/S5808/see.adoc
+++ b/rules/S5808/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/285[MITRE, CWE-285] - Improper Authorization
+* https://cwe.mitre.org/data/definitions/285.html[MITRE, CWE-285] - Improper Authorization

--- a/rules/S5813/cfamily/rule.adoc
+++ b/rules/S5813/cfamily/rule.adoc
@@ -45,7 +45,7 @@ int f(char *src) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://wiki.sei.cmu.edu/confluence/x/HdcxBQ[CERT, STR07-C.] - Use the bounds-checking interfaces for string manipulation
 
 

--- a/rules/S5814/cfamily/rule.adoc
+++ b/rules/S5814/cfamily/rule.adoc
@@ -55,7 +55,7 @@ int f(char *src) {
 
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://wiki.sei.cmu.edu/confluence/x/HdcxBQ[CERT, STR07-C.] - Use the bounds-checking interfaces for string manipulation
 
 

--- a/rules/S5815/cfamily/rule.adoc
+++ b/rules/S5815/cfamily/rule.adoc
@@ -53,7 +53,7 @@ int f(char *src) {
 
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://wiki.sei.cmu.edu/confluence/x/HdcxBQ[CERT, STR07-C.] - Use the bounds-checking interfaces for string manipulation
 
 

--- a/rules/S5816/cfamily/rule.adoc
+++ b/rules/S5816/cfamily/rule.adoc
@@ -65,7 +65,7 @@ int f(char *src) {
 
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
+* https://cwe.mitre.org/data/definitions/120.html[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
 * https://wiki.sei.cmu.edu/confluence/x/HdcxBQ[CERT, STR07-C.] - Use the bounds-checking interfaces for string manipulation
 
 

--- a/rules/S5824/cfamily/rule.adoc
+++ b/rules/S5824/cfamily/rule.adoc
@@ -55,7 +55,7 @@ int f(char *tempData) {
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/377[MITRE, CWE-377] - Insecure Temporary File
+* https://cwe.mitre.org/data/definitions/377.html[MITRE, CWE-377] - Insecure Temporary File
 * https://wiki.sei.cmu.edu/confluence/display/c/CON33-C.+Avoid+race+conditions+when+using+library+functions[CERT, CON33-C.] - Avoid race conditions when using library functions
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO21-C.+Do+not+create+temporary+files+in+shared+directories[CERT, FIO21-C.] - Do not create temporary files in shared directories
 

--- a/rules/S5832/cfamily/rule.adoc
+++ b/rules/S5832/cfamily/rule.adoc
@@ -54,7 +54,7 @@ int valid(pam_handle_t *pamh) {
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/304[MITRE, CWE-304] - Missing Critical Step in Authentication
+* https://cwe.mitre.org/data/definitions/304.html[MITRE, CWE-304] - Missing Critical Step in Authentication
 
 
 

--- a/rules/S5847/cfamily/rule.adoc
+++ b/rules/S5847/cfamily/rule.adoc
@@ -60,7 +60,7 @@ void open_without_toctou(const char *file) {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/367[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition
+* https://cwe.mitre.org/data/definitions/367.html[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO45-C.+Avoid+TOCTOU+race+conditions+while+accessing+files[CERT, FIO45-C.] - Avoid TOCTOU race conditions while accessing files
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5847/java/rule.adoc
+++ b/rules/S5847/java/rule.adoc
@@ -4,7 +4,7 @@ include::../description.adoc[]
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/367[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition
+* https://cwe.mitre.org/data/definitions/367.html[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition
 * https://wiki.sei.cmu.edu/confluence/display/c/FIO45-C.+Avoid+TOCTOU+race+conditions+while+accessing+files[CERT, FIO45-C.] - Avoid TOCTOU race conditions while accessing files
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5847/see.adoc
+++ b/rules/S5847/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/367[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition
+* https://cwe.mitre.org/data/definitions/367.html[MITRE, CWE-367] - Time-of-check Time-of-use (TOCTOU) Race Condition

--- a/rules/S5849/cfamily/rule.adoc
+++ b/rules/S5849/cfamily/rule.adoc
@@ -49,8 +49,8 @@ fchmod(fd, S_ISUID|S_ISGID); // Sensitive
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/250[MITRE, CWE-250] - Execution with Unnecessary Privileges
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] -  Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/250.html[MITRE, CWE-250] - Execution with Unnecessary Privileges
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] -  Incorrect Privilege Assignment
 * https://forums.grsecurity.net/viewtopic.php?f=7&t=2522[False Boundaries and Arbitrary Code Execution]
 
 

--- a/rules/S5852/see.adoc
+++ b/rules/S5852/see.adoc
@@ -1,8 +1,8 @@
 == See
 
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption
-* https://cwe.mitre.org/data/definitions/1333[MITRE, CWE-1333] - Inefficient Regular Expression Complexity
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption
+* https://cwe.mitre.org/data/definitions/1333.html[MITRE, CWE-1333] - Inefficient Regular Expression Complexity
 * https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS[owasp.org] - OWASP Regular expression Denial of Service - ReDoS
 * https://stackstatus.net/post/147710624694/outage-postmortem-july-20-2016[stackstatus.net] -  Outage Postmortem - July 20, 2016
 * https://www.regular-expressions.info/catastrophic.html[regular-expressions.info] - Runaway Regular Expressions: Catastrophic Backtracking

--- a/rules/S5876/see.adoc
+++ b/rules/S5876/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
 * https://www.owasp.org/index.php/Session_fixation[OWASP Sesssion Fixation]
-* https://cwe.mitre.org/data/definitions/384[MITRE, CWE-384] - Session Fixation
+* https://cwe.mitre.org/data/definitions/384.html[MITRE, CWE-384] - Session Fixation

--- a/rules/S5883/php/see.adoc
+++ b/rules/S5883/php/see.adoc
@@ -3,6 +3,6 @@
 * OWASP OS Command Injection Defense https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html[Cheat Sheet]
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
+* http://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
 * https://blog.sonarsource.com/why-mail-is-dangerous-in-php[blog.sonarsource.com] - Why mail() is dangerous in PHP
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5883/see.adoc
+++ b/rules/S5883/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * OWASP OS Command Injection Defense https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html[Cheat Sheet]
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/88.html[MITRE, CWE-88] - Argument Injection or Modification
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components

--- a/rules/S5982/cfamily/rule.adoc
+++ b/rules/S5982/cfamily/rule.adoc
@@ -50,7 +50,7 @@ if(fchdir(fd) == -1) {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/252[MITRE, CWE-252] - Unchecked Return Value
+* https://cwe.mitre.org/data/definitions/252.html[MITRE, CWE-252] - Unchecked Return Value
 * https://man7.org/linux/man-pages/man2/chdir.2.html[man7.org] - chdir
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6069/cfamily/rule.adoc
+++ b/rules/S6069/cfamily/rule.adoc
@@ -51,8 +51,8 @@ sprintf(buf, "%s", message);{code}
 
 * https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[OWASP Top 10 2021 Category A6] - Vulnerable and Outdated Components
 * https://www.owasp.org/index.php/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/676[MITRE, CWE-676] - Use of Potentially Dangerous Function
-* https://cwe.mitre.org/data/definitions/119[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
+* https://cwe.mitre.org/data/definitions/676.html[MITRE, CWE-676] - Use of Potentially Dangerous Function
+* https://cwe.mitre.org/data/definitions/119.html[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management
 
 

--- a/rules/S6096/see.adoc
+++ b/rules/S6096/see.adoc
@@ -4,8 +4,8 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://snyk.io/research/zip-slip-vulnerability[snyk] - Zip Slip Vulnerability
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/22[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-* https://cwe.mitre.org/data/definitions/99[MITRE, CWE-99] - Improper Control of Resource Identifiers ('Resource Injection')
-* https://cwe.mitre.org/data/definitions/641[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/22.html[MITRE, CWE-22] - Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+* https://cwe.mitre.org/data/definitions/99.html[MITRE, CWE-99] - Improper Control of Resource Identifiers ('Resource Injection')
+* https://cwe.mitre.org/data/definitions/641.html[MITRE, CWE-641] - Improper Restriction of Names for Files and Other Resources
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S6105/javascript/see.adoc
+++ b/rules/S6105/javascript/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/601[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/601.html[MITRE, CWE-601] - URL Redirection to Untrusted Site ('Open Redirect')
 * https://www.sans.org/top25-software-errors/#cat2[SANS Top 25] - Risky Resource Management

--- a/rules/S6108/javascript/rule.adoc
+++ b/rules/S6108/javascript/rule.adoc
@@ -109,5 +109,5 @@ function for_set(target, path, value) {
 == See
 
 * https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf[Prototype pollution attack in NodeJS application - Olivier Arteau]
-* https://cwe.mitre.org/data/definitions/1321[MITRE, CWE-1321] - Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
+* https://cwe.mitre.org/data/definitions/1321.html[MITRE, CWE-1321] - Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
 

--- a/rules/S6109/javascript/rule.adoc
+++ b/rules/S6109/javascript/rule.adoc
@@ -105,5 +105,5 @@ for_set(req.query.path, req.query.val); // Compliant
 == See
 
 * https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf[Prototype pollution attack in NodeJS application - Olivier Arteau]
-* https://cwe.mitre.org/data/definitions/1321[MITRE, CWE-1321] - Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
+* https://cwe.mitre.org/data/definitions/1321.html[MITRE, CWE-1321] - Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
 

--- a/rules/S6173/see.adoc
+++ b/rules/S6173/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/470[MITRE, CWE-470] - Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
+* https://cwe.mitre.org/data/definitions/470.html[MITRE, CWE-470] - Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')

--- a/rules/S6245/see.adoc
+++ b/rules/S6245/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html[AWS documentation] - Protecting data using server-side encryption
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration

--- a/rules/S6249/see.adoc
+++ b/rules/S6249/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit[AWS documentation] - Enforce encryption of data in transit
-* https://cwe.mitre.org/data/definitions/319[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
+* https://cwe.mitre.org/data/definitions/319.html[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration

--- a/rules/S6255/terraform/rule.adoc
+++ b/rules/S6255/terraform/rule.adoc
@@ -54,7 +54,7 @@ resource "aws_s3_bucket" "example" { # Compliant
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html[AWS documentation] - Configuring MFA delete
-* https://cwe.mitre.org/data/definitions/308[MITRE, CWE-308] - Use of Single-factor Authentication
+* https://cwe.mitre.org/data/definitions/308.html[MITRE, CWE-308] - Use of Single-factor Authentication
 * https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6258/see.adoc
+++ b/rules/S6258/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/[OWASP Top 10 2021 Category A9] - Security Logging and Monitoring Failures
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html[AWS Documentation] - Logging requests using server access logging
-* https://cwe.mitre.org/data/definitions/778[MITRE, CWE-778] - Insufficient Logging
+* https://cwe.mitre.org/data/definitions/778.html[MITRE, CWE-778] - Insufficient Logging
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring

--- a/rules/S6265/see.adoc
+++ b/rules/S6265/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl[AWS Documentation] - Access control list (ACL) overview (canned ACLs)
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/walkthrough1.html[AWS Documentation] - Controlling access to a bucket with user policies
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6268/javascript/see.adoc
+++ b/rules/S6268/javascript/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
 * https://angular.io/guide/security[Angular - Best Practices - Security]

--- a/rules/S6270/see.adoc
+++ b/rules/S6270/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege[AWS Documentation] - Grant least privilege
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6275/see.adoc
+++ b/rules/S6275/see.adoc
@@ -5,4 +5,4 @@
 * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html[Amazon EBS encryption]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6281/see.adoc
+++ b/rules/S6281/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html[AWS Documentation] - Blocking public access to your Amazon S3 storage
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6287/see.adoc
+++ b/rules/S6287/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/384[MITRE, CWE-384] - Session Fixation
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/384.html[MITRE, CWE-384] - Session Fixation

--- a/rules/S6288/see.adoc
+++ b/rules/S6288/see.adoc
@@ -5,4 +5,4 @@
 * https://developer.android.com/training/articles/keystore#UserAuthentication[developer.android.com] - Require user authentication for key use
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x07-v2-data_storage_and_privacy_requirements[Mobile AppSec Verification Standard] - Authentication and Session Management Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication[OWASP Mobile Top 10 2016 Category M4] - Insecure Authentication
-* https://cwe.mitre.org/data/definitions/522[MITRE, CWE-522] - Insufficiently Protected Credentials
+* https://cwe.mitre.org/data/definitions/522.html[MITRE, CWE-522] - Insufficiently Protected Credentials

--- a/rules/S6290/see.adoc
+++ b/rules/S6290/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6291/see.adoc
+++ b/rules/S6291/see.adoc
@@ -7,4 +7,4 @@
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6292/see.adoc
+++ b/rules/S6292/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6293/see.adoc
+++ b/rules/S6293/see.adoc
@@ -4,4 +4,4 @@
 * https://developer.android.com/training/sign-in/biometric-auth[developer.android.com] - Use a cryptographic solution that depends on authentication
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m4-insecure-authentication[OWASP Mobile Top 10 Category M4] -  Insecure Authentication
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x09-v4-authentication_and_session_management_requirements[OWASP MASVS] - Authentication and Session Management Requirements
-* https://cwe.mitre.org/data/definitions/287[MITRE, CWE-287] - Improper Authentication
+* https://cwe.mitre.org/data/definitions/287.html[MITRE, CWE-287] - Improper Authentication

--- a/rules/S6299/javascript/see.adoc
+++ b/rules/S6299/javascript/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
 * https://vuejs.org/v2/guide/security.html#Injecting-HTML[Vue.js - Security - Injecting HTML]

--- a/rules/S6300/see.adoc
+++ b/rules/S6300/see.adoc
@@ -5,4 +5,4 @@
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6301/see.adoc
+++ b/rules/S6301/see.adoc
@@ -6,5 +6,5 @@
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
-* https://cwe.mitre.org/data/definitions/321[MITRE, CWE-321] - Use of Hard-coded Cryptographic Key
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/321.html[MITRE, CWE-321] - Use of Hard-coded Cryptographic Key

--- a/rules/S6302/see.adoc
+++ b/rules/S6302/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege[AWS Documentation] - Grant least privilege
 * https://cloud.google.com/iam/docs/understanding-roles[Google Cloud Documentation] - Understanding roles
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6303/see.adoc
+++ b/rules/S6303/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html[Encrypting Amazon RDS resources]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6304/see.adoc
+++ b/rules/S6304/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege[AWS Documentation] - Grant least privilege
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6308/see.adoc
+++ b/rules/S6308/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/encryption-at-rest.html[Encryption of data at rest for Amazon Elasticsearch Service]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6317/see.adoc
+++ b/rules/S6317/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/[Rhino Security Labs] - AWS IAM Privilege Escalation – Methods and Mitigation
 * https://www.owasp.org/index.php/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-269] - Improper Privilege Management
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-269] - Improper Privilege Management

--- a/rules/S6319/see.adoc
+++ b/rules/S6319/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/sagemaker/latest/dg/encryption-at-rest.html[Protect Data at Rest Using Encryption]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6321/see.adoc
+++ b/rules/S6321/see.adoc
@@ -1,6 +1,6 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html[AWS Documentation] - Security groups for your VPC

--- a/rules/S6327/see.adoc
+++ b/rules/S6327/see.adoc
@@ -7,4 +7,4 @@
 * https://aws.amazon.com/blogs/compute/encrypting-messages-published-to-amazon-sns-with-aws-kms/[Encrypting messages published to Amazon SNS with AWS KMS]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6329/see.adoc
+++ b/rules/S6329/see.adoc
@@ -4,6 +4,6 @@
 * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html[AWS Documentation] - Amazon EC2 instance IP addressing
 * https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.PublicPrivate.html[AWS Documentation] - Public and private replication instances
 * https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html[AWS Documentation] - VPC Peering
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6330/see.adoc
+++ b/rules/S6330/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html[Encryption at rest]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6332/see.adoc
+++ b/rules/S6332/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/efs/latest/ug/encryption.html[Data encryption in Amazon EFS]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6333/see.adoc
+++ b/rules/S6333/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-to-api.html[AWS Documentation] - Controlling and managing access to a REST API in API Gateway
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control

--- a/rules/S6334/see.adoc
+++ b/rules/S6334/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://cloud.google.com/docs/authentication/api-keys[Google Cloud] - Using API keys
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6335/see.adoc
+++ b/rules/S6335/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://cloud.google.com/iam/docs/creating-managing-service-account-keys[Google Cloud] - Creating and managing service account keys
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6336/see.adoc
+++ b/rules/S6336/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6337/see.adoc
+++ b/rules/S6337/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6338/see.adoc
+++ b/rules/S6338/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal[docs.microsoft.com] - Manage storage account access keys
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/798[MITRE, CWE-798] - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE, CWE-259] - Use of Hard-coded Password
+* https://cwe.mitre.org/data/definitions/798.html[MITRE, CWE-798] - Use of Hard-coded Credentials
+* https://cwe.mitre.org/data/definitions/259.html[MITRE, CWE-259] - Use of Hard-coded Password
 * https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses

--- a/rules/S6341/php/rule.adoc
+++ b/rules/S6341/php/rule.adoc
@@ -47,6 +47,6 @@ define( 'DISALLOW_FILE_EDIT', true );
 * https://owasp.org/www-project-top-ten/2017/A1_2017-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/94[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
-* https://cwe.mitre.org/data/definitions/95[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/94.html[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
+* https://cwe.mitre.org/data/definitions/95.html[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')

--- a/rules/S6342/php/rule.adoc
+++ b/rules/S6342/php/rule.adoc
@@ -43,6 +43,6 @@ define( 'DISALLOW_FILE_MODS', true );
 * https://owasp.org/www-project-top-ten/2017/A1_2017-Injection[OWASP Top 10 2017 Category A1] - Injection
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-* https://cwe.mitre.org/data/definitions/94[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
-* https://cwe.mitre.org/data/definitions/95[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/94.html[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
+* https://cwe.mitre.org/data/definitions/95.html[MITRE, CWE-95] - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')

--- a/rules/S6345/php/rule.adoc
+++ b/rules/S6345/php/rule.adoc
@@ -40,4 +40,4 @@ define( 'WP_ACCESSIBLE_HOSTS', 'api.wordpress.org' );
 * https://wordpress.org/support/article/editing-wp-config-php/#block-external-url-requestsl[wordpress.org] - Block External URL Requests
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-community/attacks/Server_Side_Request_Forgery[OWASP Attack Category] - Server Side Request Forgery
-* https://cwe.mitre.org/data/definitions/918[MITRE, CWE-918] - Server-Side Request Forgery (SSRF)
+* https://cwe.mitre.org/data/definitions/918.html[MITRE, CWE-918] - Server-Side Request Forgery (SSRF)

--- a/rules/S6348/php/rule.adoc
+++ b/rules/S6348/php/rule.adoc
@@ -33,4 +33,4 @@ define( 'DISALLOW_UNFILTERED_HTML', true );
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S6350/see.adoc
+++ b/rules/S6350/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
+* http://cwe.mitre.org/data/definitions/88[MITRE, CWE-88] - Argument Injection or Modification
 * https://www.sans.org/top25-software-errors/#cat1[SANS Top 25] - Insecure Interaction Between Components
 * https://blog.sonarsource.com/php-supply-chain-attack-on-composer[CVE-2021-29472] - PHP Supply Chain Attack on Composer

--- a/rules/S6358/see.adoc
+++ b/rules/S6358/see.adoc
@@ -7,4 +7,4 @@
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m2-insecure-data-storage[OWASP Mobile Top 10 2016 Category M2] - Insecure Data Storage
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/312[MITRE, CWE-922] - Insecure Storage of Sensitive Information
+* https://cwe.mitre.org/data/definitions/312.html[MITRE, CWE-922] - Insecure Storage of Sensitive Information

--- a/rules/S6359/see.adoc
+++ b/rules/S6359/see.adoc
@@ -2,6 +2,6 @@
 
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://www.owasp.org/index.php/Mobile_Top_10_2016-M1-Improper_Platform_Usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/265[MITRE, CWE-265] - Privilege Issues
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
+* https://cwe.mitre.org/data/definitions/265.html[MITRE, CWE-265] - Privilege Issues
+* https://cwe.mitre.org/data/definitions/732.html[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
 * https://developer.android.com/guide/topics/permissions/defining[developer.android.com] - Define a Custom App Permission

--- a/rules/S6361/see.adoc
+++ b/rules/S6361/see.adoc
@@ -4,4 +4,4 @@
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage[OWASP Mobile Top 10 2016 Category M1] - Improper platform usage
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m6-insecure-authorization[OWASP Mobile Top 10 2016 Category M6] - Insecure Authorization
-* https://cwe.mitre.org/data/definitions/1220[MITRE, CWE-1220] - Insufficient Granularity of Access Control
+* https://cwe.mitre.org/data/definitions/1220.html[MITRE, CWE-1220] - Insufficient Granularity of Access Control

--- a/rules/S6362/see.adoc
+++ b/rules/S6362/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S6363/see.adoc
+++ b/rules/S6363/see.adoc
@@ -3,4 +3,4 @@
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S6373/java/rule.adoc
+++ b/rules/S6373/java/rule.adoc
@@ -99,8 +99,8 @@ factory.setXMLResolver(new MySafeEntityResolver());
 * https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-8CD65EF5-D113-4D5C-A564-B875C8625FAC[Oracle Java Documentation] - XML External Entity Injection Attack
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* http://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* http://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6373/see.adoc
+++ b/rules/S6373/see.adoc
@@ -2,5 +2,5 @@
 
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* http://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* http://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition

--- a/rules/S6374/java/rule.adoc
+++ b/rules/S6374/java/rule.adoc
@@ -85,8 +85,8 @@ builder.setEntityResolver(new EntityResolver());
 * https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-8CD65EF5-D113-4D5C-A564-B875C8625FAC[Oracle Java Documentation] - XML External Entity Injection Attack
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* http://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* http://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6374/see.adoc
+++ b/rules/S6374/see.adoc
@@ -2,5 +2,5 @@
 
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/611[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
-* https://cwe.mitre.org/data/definitions/827[MITRE, CWE-827] - Improper Control of Document Type Definition
+* http://cwe.mitre.org/data/definitions/611.html[MITRE, CWE-611] - Information Exposure Through XML External Entity Reference
+* http://cwe.mitre.org/data/definitions/827.html[MITRE, CWE-827] - Improper Control of Document Type Definition

--- a/rules/S6375/see.adoc
+++ b/rules/S6375/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-266] - Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-266] - Incorrect Privilege Assignment
 * https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference[Azure AD Documentation] - Azure AD built-in roles
 * https://docs.microsoft.com/en-us/azure/active-directory/roles/best-practices[Azure AD Documentation] - Best practices for Azure AD roles

--- a/rules/S6376/java/rule.adoc
+++ b/rules/S6376/java/rule.adoc
@@ -76,7 +76,7 @@ builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 * https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-8CD65EF5-D113-4D5C-A564-B875C8625FAC[Oracle Java Documentation] - XML External Entity Injection Attack
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/776[MITRE, CWE-776] - Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
+* http://cwe.mitre.org/data/definitions/776.html[MITRE, CWE-776] - Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6376/see.adoc
+++ b/rules/S6376/see.adoc
@@ -2,4 +2,4 @@
 
 * https://www.owasp.org/index.php/Top_10-2017_A4-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html[OWASP XXE Prevention Cheat Sheet]
-* https://cwe.mitre.org/data/definitions/776[MITRE, CWE-776] - Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
+* http://cwe.mitre.org/data/definitions/776.html[MITRE, CWE-776] - Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')

--- a/rules/S6377/java/rule.adoc
+++ b/rules/S6377/java/rule.adoc
@@ -24,7 +24,7 @@ valContext.setProperty("org.jcp.xml.dsig.secureValidation", Boolean.TRUE);
 
 * https://docs.oracle.com/en/java/javase/14/security/java-xml-digital-signature-api-overview-and-tutorial.html#GUID-DB46A001-6DBD-4571-BDBC-1BBC394BF61E[Oracle Java Documentation] - XML Digital Signature API Overview and Tutorial
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/347[MITRE, CWE-347] - Improper Verification of Cryptographic Signature
+* http://cwe.mitre.org/data/definitions/347.html[MITRE, CWE-347] - Improper Verification of Cryptographic Signature
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6377/see.adoc
+++ b/rules/S6377/see.adoc
@@ -1,5 +1,5 @@
 == See
 
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/347[MITRE, CWE-347] - Improper Verification of Cryptographic Signature
+* http://cwe.mitre.org/data/definitions/347.html[MITRE, CWE-347] - Improper Verification of Cryptographic Signature
 

--- a/rules/S6379/terraform/rule.adoc
+++ b/rules/S6379/terraform/rule.adoc
@@ -86,7 +86,7 @@ resource "azurerm_container_registry" "exemple" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6380/terraform/rule.adoc
+++ b/rules/S6380/terraform/rule.adoc
@@ -169,7 +169,7 @@ resource "azurerm_redis_cache" "example" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6381/see.adoc
+++ b/rules/S6381/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-266] - Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-266] - Incorrect Privilege Assignment
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles[Azure Documentation] - Azure built-in roles
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/best-practices[Azure Documentation] - Best practices for Azure RBAC

--- a/rules/S6382/terraform/rule.adoc
+++ b/rules/S6382/terraform/rule.adoc
@@ -118,7 +118,7 @@ resource "azurerm_linux_web_app" "exemple" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6383/terraform/rule.adoc
+++ b/rules/S6383/terraform/rule.adoc
@@ -94,7 +94,7 @@ resource "azurerm_key_vault" "example" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6384/see.adoc
+++ b/rules/S6384/see.adoc
@@ -3,4 +3,4 @@
 * https://support.google.com/faqs/answer/9267555?hl=en[support.google.com] - Remediation for Intent Redirection Vulnerability
 * https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
 * https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation

--- a/rules/S6385/see.adoc
+++ b/rules/S6385/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] - Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] - Incorrect Privilege Assignment
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles[Azure Documentation] - Azure custom roles
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/best-practices[Azure Documentation] - Best practices for Azure RBAC

--- a/rules/S6387/see.adoc
+++ b/rules/S6387/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] - Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] - Incorrect Privilege Assignment
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/scope-overview[Azure Documentation] - Understand scope for Azure RBAC
 * https://docs.microsoft.com/en-us/azure/role-based-access-control/best-practices[Azure Documentation] - Best practices for Azure RBAC

--- a/rules/S6388/see.adoc
+++ b/rules/S6388/see.adoc
@@ -6,4 +6,4 @@
 * https://docs.aws.amazon.com/efs/latest/ug/encryption.html[Data encryption in Amazon EFS]
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data

--- a/rules/S6389/see.adoc
+++ b/rules/S6389/see.adoc
@@ -4,5 +4,5 @@
 * https://en.wikipedia.org/wiki/Bidirectional_text[Wikipedia] - Bidirectional Text
 * https://www.trojansource.codes/trojan-source.pdf[Trojan Source Report]
 * https://www.trojansource.codes/trojan-source.pdf#page=15[Trojan Source Report] - IDEs revealing hidden characters
-* https://cwe.mitre.org/data/definitions/94[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
+* https://cwe.mitre.org/data/definitions/94.html[MITRE, CWE-94] - Improper Control of Generation of Code ('Code Injection')
 

--- a/rules/S6390/see.adoc
+++ b/rules/S6390/see.adoc
@@ -2,4 +2,4 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/400[MITRE, CWE-400] - Uncontrolled Resource Consumption
+* https://cwe.mitre.org/data/definitions/400.html[MITRE, CWE-400] - Uncontrolled Resource Consumption

--- a/rules/S6398/see.adoc
+++ b/rules/S6398/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/76[MITRE, CWE-76] - Improper Neutralization of Equivalent Special Elements
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/76.html[MITRE, CWE-76] - Improper Neutralization of Equivalent Special Elements

--- a/rules/S6399/see.adoc
+++ b/rules/S6399/see.adoc
@@ -2,5 +2,5 @@
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
 * https://www.owasp.org/index.php/Top_10-2017_A1-Injection[OWASP Top 10 2017 Category A1] - Injection
-* https://cwe.mitre.org/data/definitions/20[MITRE, CWE-20] - Improper Input Validation
-* https://cwe.mitre.org/data/definitions/76[MITRE, CWE-76] - Improper Neutralization of Equivalent Special Elements
+* https://cwe.mitre.org/data/definitions/20.html[MITRE, CWE-20] - Improper Input Validation
+* https://cwe.mitre.org/data/definitions/76.html[MITRE, CWE-76] - Improper Neutralization of Equivalent Special Elements

--- a/rules/S6400/terraform/rule.adoc
+++ b/rules/S6400/terraform/rule.adoc
@@ -125,7 +125,7 @@ resource "google_cloud_run_service_iam_member" "example" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/284[MITRE, CWE-284] - Improper Access Control
+* https://cwe.mitre.org/data/definitions/284.html[MITRE, CWE-284] - Improper Access Control
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6402/see.adoc
+++ b/rules/S6402/see.adoc
@@ -3,5 +3,5 @@
 * https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/[OWASP Top 10 2021 Category A8] - Software and Data Integrity Failures
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
 * https://cloud.google.com/dns/docs/dnssec-config[GCP Documentation] - Manage DNSSEC configuration
-* https://cwe.mitre.org/data/definitions/345[MITRE, CWE-345] - Insufficient Verification of Data Authenticity
-* https://cwe.mitre.org/data/definitions/353[MITRE, CWE-353] - Missing Support for Integrity Check
+* https://cwe.mitre.org/data/definitions/345.html[MITRE, CWE-345] - Insufficient Verification of Data Authenticity
+* https://cwe.mitre.org/data/definitions/353.html[MITRE, CWE-353] - Missing Support for Integrity Check

--- a/rules/S6403/see.adoc
+++ b/rules/S6403/see.adoc
@@ -2,6 +2,6 @@
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/311[MITRE, CWE-311] - Missing Encryption of Sensitive Data
-* https://cwe.mitre.org/data/definitions/79[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
+* https://cwe.mitre.org/data/definitions/311.html[MITRE, CWE-311] - Missing Encryption of Sensitive Data
+* https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
 * https://cloud.google.com/sql/docs/mysql/authorize-ssl[GCP Documentation] - Cloud SQL: Authorizing with SSL/TLS certificates

--- a/rules/S6404/terraform/rule.adoc
+++ b/rules/S6404/terraform/rule.adoc
@@ -121,7 +121,7 @@ resource "google_container_cluster" "example" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6405/see.adoc
+++ b/rules/S6405/see.adoc
@@ -2,8 +2,8 @@
 
 * https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
 * https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://cwe.mitre.org/data/definitions/266[MITRE, CWE-266] - Incorrect Privilege Assignment
-* https://cwe.mitre.org/data/definitions/269[MITRE, CWE-269] - Improper Privilege Management
-* https://cwe.mitre.org/data/definitions/272[MITRE, CWE-272] - Least Privilege Violation
+* https://cwe.mitre.org/data/definitions/266.html[MITRE, CWE-266] - Incorrect Privilege Assignment
+* https://cwe.mitre.org/data/definitions/269.html[MITRE, CWE-269] - Improper Privilege Management
+* https://cwe.mitre.org/data/definitions/272.html[MITRE, CWE-272] - Least Privilege Violation
 * https://cloud.google.com/compute/docs/connect/restrict-ssh-keys#remove-metadata-key[GCP Documentation] - Restrict SSH keys from VMs
 * https://cloud.google.com/compute/docs/instances/access-overview#risks[GCP Documentation] - Risks of manual key management

--- a/rules/S6406/terraform/rule.adoc
+++ b/rules/S6406/terraform/rule.adoc
@@ -108,7 +108,7 @@ resource "google_project_iam_custom_role" "example" {
 * https://cloud.google.com/iam/docs/manage-policy-insights[GCP Docs] - Security Insights
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6407/see.adoc
+++ b/rules/S6407/see.adoc
@@ -3,6 +3,6 @@
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/200[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
-* https://cwe.mitre.org/data/definitions/319[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
+* https://cwe.mitre.org/data/definitions/200.html[MITRE, CWE-200] - Exposure of Sensitive Information to an Unauthorized Actor
+* https://cwe.mitre.org/data/definitions/319.html[MITRE, CWE-319] - Cleartext Transmission of Sensitive Information
 * https://cloud.google.com/appengine/docs/standard/nodejs/application-security[GCP Documentation] - Overview of App Security

--- a/rules/S6408/terraform/rule.adoc
+++ b/rules/S6408/terraform/rule.adoc
@@ -149,7 +149,7 @@ resource "google_project_iam_custom_role" "example" {
 * https://cloud.google.com/iam/docs/manage-policy-insights[GCP Docs] - Security Insights
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6409/terraform/rule.adoc
+++ b/rules/S6409/terraform/rule.adoc
@@ -40,7 +40,7 @@ resource "google_container_cluster" "example" {
 
 * https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Boken Access Control
 * https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Boken Access Control
-* https://cwe.mitre.org/data/definitions/668[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
+* https://cwe.mitre.org/data/definitions/668.html[MITRE, CWE-668] - Exposure of Resource to Wrong Sphere
 * https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#leave_abac_disabled[Google Cloud Documentation] - Hardening your cluster's security
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6410/terraform/see.adoc
+++ b/rules/S6410/terraform/see.adoc
@@ -4,6 +4,6 @@
 * https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
 * https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://www.owasp.org/index.php/Top_10-2017_A6-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
-* https://cwe.mitre.org/data/definitions/327[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
+* https://cwe.mitre.org/data/definitions/327.html[MITRE, CWE-327] - Use of a Broken or Risky Cryptographic Algorithm
 * https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#23-use-secure-cipher-suites[SSL and TLS Deployment Best Practices] - Use Secure Cipher Suites
 * https://cloud.google.com/load-balancing/docs/ssl-policies-concepts#defining_an_ssl_policy[Google Cloud Load Balancing] - Defining an SSL policy

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -6,7 +6,7 @@ include::../compliant.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
+* https://cwe.mitre.org/data/definitions/457.html[MITRE, CWE-457] - Use of Uninitialized Variable
 * MISRA C:2004, 9.1 - All automatic variables shall have been assigned a value before being used.
 * MISRA {cpp}:2008, 8-5-1 - All variables shall have a defined value before they are used.
 

--- a/rules/S836/see.adoc
+++ b/rules/S836/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
+* https://cwe.mitre.org/data/definitions/457.html[MITRE, CWE-457] - Use of Uninitialized Variable

--- a/rules/S864/cfamily/rule.adoc
+++ b/rules/S864/cfamily/rule.adoc
@@ -60,7 +60,7 @@ if ( (a = f(b,c)) == true) { ... }
 * MISRA C:2012, 12.1 - The precedence of operators within expressions should be made explicit
 * https://wiki.sei.cmu.edu/confluence/x/YdYxBQ[CERT, EXP00-C.] - Use parentheses for precedence of operation
 * https://wiki.sei.cmu.edu/confluence/x/ZzZGBQ[CERT, EXP53-J.] - Use parentheses for precedence of operation
-* https://cwe.mitre.org/data/definitions/783[MITRE, CWE-783] - Operator Precedence Logic Error
+* https://cwe.mitre.org/data/definitions/783.html[MITRE, CWE-783] - Operator Precedence Logic Error
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S864/java/rule.adoc
+++ b/rules/S864/java/rule.adoc
@@ -8,7 +8,7 @@ include::../compliant.adoc[]
 
 * https://wiki.sei.cmu.edu/confluence/x/YdYxBQ[CERT, EXP00-C.] - Use parentheses for precedence of operation
 * https://wiki.sei.cmu.edu/confluence/x/ZzZGBQ[CERT, EXP53-J.] - Use parentheses for precedence of operation
-* https://cwe.mitre.org/data/definitions/783[MITRE, CWE-783] - Operator Precedence Logic Error
+* https://cwe.mitre.org/data/definitions/783.html[MITRE, CWE-783] - Operator Precedence Logic Error
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S864/see.adoc
+++ b/rules/S864/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/783[MITRE, CWE-783] - Operator Precedence Logic Error
+* https://cwe.mitre.org/data/definitions/783.html[MITRE, CWE-783] - Operator Precedence Logic Error

--- a/rules/S874/cfamily/rule.adoc
+++ b/rules/S874/cfamily/rule.adoc
@@ -59,7 +59,7 @@ unsigned int f(unsigned short src) {
 * MISRA {cpp}:2008, 5-0-21 - Bitwise operators shall only be applied to operands of unsigned underlying type
 * MISRA C:2012, 10.1 - Operands shall not be of an inappropriate essential type
 * https://wiki.sei.cmu.edu/confluence/x/9tYxBQ[CERT, INT13-C.] - Use bitwise operators only on unsigned operands
-* https://cwe.mitre.org/data/definitions/682[MITRE, CWE-682] - Incorrect Calculation
+* https://cwe.mitre.org/data/definitions/682.html[MITRE, CWE-682] - Incorrect Calculation
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S888/cfamily/rule.adoc
+++ b/rules/S888/cfamily/rule.adoc
@@ -12,7 +12,7 @@ include::../exceptions.adoc[]
 == See
 
 * MISRA {cpp}:2008, 6-5-2
-* https://cwe.mitre.org/data/definitions/835[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')
+* https://cwe.mitre.org/data/definitions/835.html[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')
 * https://wiki.sei.cmu.edu/confluence/x/x9YxBQ[CERT, MSC21-C.] - Use robust loop termination conditions
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S888/java/rule.adoc
+++ b/rules/S888/java/rule.adoc
@@ -8,7 +8,7 @@ include::../exceptions.adoc[]
 
 == See
 
-* https://cwe.mitre.org/data/definitions/835[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')
+* https://cwe.mitre.org/data/definitions/835.html[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')
 * https://wiki.sei.cmu.edu/confluence/x/x9YxBQ[CERT, MSC21-C.] - Use robust loop termination conditions
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S888/see.adoc
+++ b/rules/S888/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/835[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')
+* https://cwe.mitre.org/data/definitions/835.html[MITRE, CWE-835] - Loop with Unreachable Exit Condition ('Infinite Loop')

--- a/rules/S899/cfamily/rule.adoc
+++ b/rules/S899/cfamily/rule.adoc
@@ -43,7 +43,7 @@ void func(int n, int m) {
 * https://wiki.sei.cmu.edu/confluence/x/kNYxBQ[CERT, ERR33-C.] - Detect and handle standard library errors
 * https://wiki.sei.cmu.edu/confluence/x/MdUxBQ[CERT, POS54-C.] - Detect and handle POSIX library errors
 * https://wiki.sei.cmu.edu/confluence/x/mtYxBQ[CERT, EXP12-C.] - Do not ignore values returned by functions
-* https://cwe.mitre.org/data/definitions/754[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
+* https://cwe.mitre.org/data/definitions/754.html[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S899/java/rule.adoc
+++ b/rules/S899/java/rule.adoc
@@ -30,7 +30,7 @@ public void doSomething(File file, Lock lock) {
 
 * https://wiki.sei.cmu.edu/confluence/x/xzdGBQ[CERT, EXP00-J.] - Do not ignore values returned by methods
 * https://wiki.sei.cmu.edu/confluence/x/TTZGBQ[CERT, FIO02-J.] - Detect and handle file-related errors
-* https://cwe.mitre.org/data/definitions/754[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
+* https://cwe.mitre.org/data/definitions/754.html[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S899/kotlin/rule.adoc
+++ b/rules/S899/kotlin/rule.adoc
@@ -32,7 +32,7 @@ Although these resources talk about Java, the underlying information concerning 
 
 * https://wiki.sei.cmu.edu/confluence/x/xzdGBQ[CERT, EXP00-J.] - Do not ignore values returned by methods
 * https://wiki.sei.cmu.edu/confluence/x/TTZGBQ[CERT, FIO02-J.] - Detect and handle file-related errors
-* https://cwe.mitre.org/data/definitions/754[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
+* https://cwe.mitre.org/data/definitions/754.html[MITRE, CWE-754] - Improper Check for Unusual Exceptional Conditions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S905/cfamily/rule.adoc
+++ b/rules/S905/cfamily/rule.adoc
@@ -23,7 +23,7 @@ int func(int a, int b) {
 
 == See
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+* https://cwe.mitre.org/data/definitions/482.html[MITRE, CWE-482] - Comparing instead of Assigning
 * MISRA C:2004, 14.2 - All non-null statements shall either have at least one side-effect however executed, or cause control flow to change.
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S905/see.adoc
+++ b/rules/S905/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+* https://cwe.mitre.org/data/definitions/482.html[MITRE, CWE-482] - Comparing instead of Assigning

--- a/rules/S930/cfamily/rule.adoc
+++ b/rules/S930/cfamily/rule.adoc
@@ -3,7 +3,7 @@ include::../description.adoc[]
 == See
 
 * MISRA C:2004, 16.6 - The number of arguments passed to a function shall match the number of parameters.
-* https://cwe.mitre.org/data/definitions/628[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
+* https://cwe.mitre.org/data/definitions/628.html[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
 * https://wiki.sei.cmu.edu/confluence/x/7NYxBQ[CERT, DCL07-C.] - Include the appropriate type information in function declarators
 * https://wiki.sei.cmu.edu/confluence/x/49UxBQ[CERT, EXP37-C.] - Call functions with the correct number and type of arguments
 

--- a/rules/S930/see.adoc
+++ b/rules/S930/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/628[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
+* https://cwe.mitre.org/data/definitions/628.html[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments

--- a/rules/S935/cfamily/rule.adoc
+++ b/rules/S935/cfamily/rule.adoc
@@ -28,7 +28,7 @@ and `co_return` is used for coroutine that returns a value (define `return_value
 * MISRA C:2004, 16.8 - All exit paths from a function with non-void return type shall have an explicit return statement with an expression
 * MISRA {cpp}:2008, 8-4-3 - All exit paths from a function with non-void return type shall have an explicit return statement with an expression
 * MISRA C:2012, 17.4 - All exit paths from a function with non-void return type shall have an explicit return statement with an expression
-* https://cwe.mitre.org/data/definitions/394[MITRE, CWE-394] - Unexpected Status Code or Return Value
+* https://cwe.mitre.org/data/definitions/394.html[MITRE, CWE-394] - Unexpected Status Code or Return Value
 * https://wiki.sei.cmu.edu/confluence/x/m9YxBQ[CERT, MSC37-C.] - Ensure that control never reaches the end of a non-void function
 * https://wiki.sei.cmu.edu/confluence/x/EXs-BQ[CERT, MSC52-CPP.] - Value-returning functions must return a value from all exit paths
 * https://wiki.sei.cmu.edu/confluence/x/Cns-BQ[CERT, MSC53-CPP.] - Do not return from a function declared \[[noreturn]]

--- a/rules/S935/see.adoc
+++ b/rules/S935/see.adoc
@@ -1,3 +1,3 @@
 == See
 
-* https://cwe.mitre.org/data/definitions/394[MITRE, CWE-394] - Unexpected Status Code or Return Value
+* https://cwe.mitre.org/data/definitions/394.html[MITRE, CWE-394] - Unexpected Status Code or Return Value

--- a/rules/S939/cfamily/rule.adoc
+++ b/rules/S939/cfamily/rule.adoc
@@ -52,7 +52,7 @@ void g(int val){
 
 * MISRA C:2004, 17.2
 * MISRA {cpp}:2008, 5-0-17
-* https://cwe.mitre.org/data/definitions/469[MITRE, CWE-469] - Use of Pointer Subtraction to Determine Size
+* https://cwe.mitre.org/data/definitions/469.html[MITRE, CWE-469] - Use of Pointer Subtraction to Determine Size
 * https://wiki.sei.cmu.edu/confluence/x/1dYxBQ[CERT, ARR36-C.] - Do not subtract or compare two pointers that do not refer to the same array
 
 

--- a/rules/S961/cfamily/rule.adoc
+++ b/rules/S961/cfamily/rule.adoc
@@ -4,7 +4,7 @@ This is a constraint error, but preprocessors have been known to ignore this pro
 == See
 
 * MISRA C:2004, 19.8 - A function-like macro shall not be invoked without all of its arguments.
-* https://cwe.mitre.org/data/definitions/628[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
+* https://cwe.mitre.org/data/definitions/628.html[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
Reverts SonarSource/rspec#926.

Upon further review, CWE's website defaults each rule with a .html extension, so there's no point in trying to fight what is already naturally present. Let it be. 
