### PR TITLE
Adjust literals in styling guide to SC Design System

### DIFF
--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -1,7 +1,7 @@
 = Styling Guide
 
 This document provides styling guidelines for `+rule.adoc+` and its dependencies.
-See also the <<description.adoc#,description guidelines>> for information about the structure.
+See also the <<description.adoc#,Description Guidelines>> for information about the rule structure.
 
 
 The RSPEC styling guide is loosely based on the Associated Press Style and geared to rule descriptions.

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -103,8 +103,8 @@ Check the values:
 
 == Literals
 
-Inline literals (backtick) should be used to highlight short values inline with body text.
-Use when referencing variable names, file names, tokens, and all kinds of specific strings of text that should be visually extracted from the surrounding default text.
+Inline literals (backticks) should be used to highlight short values.
+Use it when referencing variable names, file names, tokens, and all kinds of specific strings of text that should be visually extracted from the surrounding default text.
 
 Write:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
 Avoid:: Compiling source file "src/generic_file.py" breaks an `assert` call in `pytest` framework.

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -1,6 +1,7 @@
 = Styling Guide
 
 This document provides styling guidelines for `+rule.adoc+` and its dependencies.
+
 See also the <<description.adoc#,Description Guidelines>> for information about the rule structure.
 
 
@@ -104,7 +105,6 @@ Check the values:
 
 Inline literals (backtick) should be used to highlight short values inline with body text.
 Use when referencing variable names, file names, tokens, and all kinds of specific strings of text that should be visually extracted from the surrounding default text.
-Inline literals should not be used for anything else.
 
 Write:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
 Avoid:: Compiling source file "src/generic_file.py" breaks an `assert` call in `pytest` framework.

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -1,6 +1,7 @@
 = Styling Guide
 
 This document provides styling guidelines for `+rule.adoc+` and its dependencies.
+See also the <<description.adoc#,description guidelines>> for information about the structure.
 
 
 The RSPEC styling guide is loosely based on the Associated Press Style and geared to rule descriptions.

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -99,10 +99,12 @@ Check the values:
  * size,
  * length.
 
-== Code
+== Literals
 
-Only use inline literals (backtick) for direct code references, for instance, variable names or values. Inline literals should not be used for anything else.
+Inline literals (backtick) should be used to highlight short values inline with body text.
+Use when referencing variable names, file names, tokens, and all kinds of specific strings of text that should be visually extracted from the surrounding default text.
+Inline literals should not be used for anything else.
 
-Write:: Compiling source file "src/generic_file.py" breaks an `assert` call in pytest framework.
-Avoid:: Compiling source file `src/generic_file.py` breaks an `assert` call in `pytest` framework.
+Write:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
+Avoid:: Compiling source file "src/generic_file.py" breaks an `assert` call in `pytest` framework.
 


### PR DESCRIPTION
As discussed [here](https://discuss.sonarsource.com/t/styling-guide-use-of-backticks/10331), the consent in the Languages Team seems to be that inline literals should not be as strictly limited as it was done in the first version of the styling guide. Additionally, there is already a definition of this topic in the [SonarCloud Design System](https://zeroheight.com/3f9bf5b5a/p/375241-snippets).

To avoid having a guideline that conflicts with SonarCloud and that does not match the expectations of the people writing the rules, the conditions of inline literals were changed to be looser.

Additionally, a link to the description document was added.