### PR TITLE
Modify rule S6018: Clarify that constexpr variables are not inline.

### DIFF
--- a/rules/S6018/cfamily/rule.adoc
+++ b/rules/S6018/cfamily/rule.adoc
@@ -14,10 +14,6 @@ Instead, you had to resort to less readable inconvenient workarounds like variab
 
 This rule will detect these workarounds and suggest using inline variables instead.
 
-
-Note that ``++constexpr++`` variables are implicitly ``++inline++``, so you do not have to explicitly declare them as such (see S5408).
-
-
 == Noncompliant Code Example
 
 [source,cpp]


### PR DESCRIPTION
This is leftover from CPP-3035.