### PR TITLE
Modify S5131(Multiple Languages): Education Framework

### DIFF
--- a/rules/S5131/common/fix/data_encoding.adoc
+++ b/rules/S5131/common/fix/data_encoding.adoc
@@ -85,7 +85,7 @@ HTML entity encoding: replace the following characters with HTML-safe sequences.
 <!doctype html>
 <a href="javascript:alert(1)">...</a>
 ----
-| Validate the URL by parsing the data. Make sure relative URLs start with a  ``++/++`` and that absolute URLs use ``++https++`` as a scheme.
+| Validate the URL by parsing the data. Make sure relative URLs start with a  `++/++` and that absolute URLs use `++https++` as a scheme.
 
 | In a script block
 |

--- a/rules/S5131/common/pitfalls/content-types.adoc
+++ b/rules/S5131/common/pitfalls/content-types.adoc
@@ -1,4 +1,4 @@
-Be aware that there are more content-types than `text/html` that allow to execute JavaScript code in a browser and thus are prone to Cross-Site Scripting vulnerabilities.
+Be aware that there are more content-types than `text/html` that allow to execute JavaScript code in a browser and thus are prone to cross-site scripting vulnerabilities.
 The following content-types are known to be affected:
 
  * application/mathml+xml

--- a/rules/S5131/common/resources/standards.adoc
+++ b/rules/S5131/common/resources/standards.adoc
@@ -1,5 +1,5 @@
 === Standards
 
 * https://owasp.org/Top10/A03_2021-Injection/[OWASP Top 10 2021 Category A3] - Injection
-* https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - Cross-Site Scripting (XSS)
+* https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[OWASP Top 10 2017 Category A7] - cross-site scripting (XSS)
 * https://cwe.mitre.org/data/definitions/79.html[MITRE, CWE-79] - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

--- a/rules/S5131/csharp/razor/rule.adoc
+++ b/rules/S5131/csharp/razor/rule.adoc
@@ -59,7 +59,7 @@ public class HelloController : Controller
 
 Template engines are used by web applications to build HTML content. Template files contain static HTML as well as template language instructions. These instructions allow, for example, to insert dynamic values in the document as the template is rendered. Template engines can auto-escape HTML special characters of dynamic values in order to prevent XSS vulnerabilities.
 
-In .NET applications relying on Razor, the auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected in the template and auto-escaping is disabled using ``++@Html.Raw++`` or ``++Microsoft.AspNetCore.Html.HtmlString++`` expressions. This is often the case when a piece of dynamic HTML is generated from the code and used in a template variable.
+In .NET applications relying on Razor, the auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected in the template and auto-escaping is disabled using `++@Html.Raw++` or `++Microsoft.AspNetCore.Html.HtmlString++` expressions. This is often the case when a piece of dynamic HTML is generated from the code and used in a template variable.
 
 include::../../common/fix/data_encoding.adoc[]
 

--- a/rules/S5131/csharp/razor/rule.adoc
+++ b/rules/S5131/csharp/razor/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because auto-escaping of special HTML characters has been disabled.
+The following code is vulnerable to cross-site scripting because auto-escaping of special HTML characters has been disabled.
 The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping.
 
 [cols="a,a"]

--- a/rules/S5131/csharp/system.web/rule.adoc
+++ b/rules/S5131/csharp/system.web/rule.adoc
@@ -50,7 +50,8 @@ public class HelloController : Controller
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use https://docs.microsoft.com/en-us/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c[Razor-based view templates] to generate it. A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application. It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
+If the HTTP response is HTML code, it is highly recommended to use https://docs.microsoft.com/en-us/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c[Razor-based view templates] to generate it.
+This template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
 
 include::../../common/fix/data_encoding.adoc[]

--- a/rules/S5131/csharp/system.web/rule.adoc
+++ b/rules/S5131/csharp/system.web/rule.adoc
@@ -50,7 +50,7 @@ public class HelloController : Controller
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use https://docs.microsoft.com/en-us/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c[Razor-based view templates] to generate it. A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application. It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+In case the response consists of HTML code, it is highly recommended to use https://docs.microsoft.com/en-us/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c[Razor-based view templates] to generate it. A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application. It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
 
 
 include::../../common/fix/data_encoding.adoc[]

--- a/rules/S5131/impact.adoc
+++ b/rules/S5131/impact.adoc
@@ -2,4 +2,4 @@
 
 A well-intentioned user opens a malicious link that injects data into the web application. This data can be text, but it can also be arbitrary code that can be interpreted by the target user's browser, such as HTML, CSS, or Javascript.
 
-In many cases, Cross-Site Scripting vulnerabilities can be used as a first step in exploiting more dangerous vulnerabilities or features that require higher privileges, such as a code injection vulnerability in the admin control panel of a web application.
+In many cases, cross-site scripting vulnerabilities can be used as a first step in exploiting more dangerous vulnerabilities or features that require higher privileges, such as a code injection vulnerability in the admin control panel of a web application.

--- a/rules/S5131/java/javax.servlet.http/rule.adoc
+++ b/rules/S5131/java/javax.servlet.http/rule.adoc
@@ -12,7 +12,8 @@ include::../../threats.adoc[]
 
 The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-User input embedded in HTML code should be HTML-encoded to prevent the injection of additional code. This can be done with the https://owasp.org/www-project-java-encoder/[OWASP Java Encoder] or similar libraries.
+Third-party data such as user input is to be not trusted.
+If embedded in HTML code, it should be HTML-encoded to prevent the injection of additional code. This can be done with the https://owasp.org/www-project-java-encoder/[OWASP Java Encoder] or similar libraries.
 
 [cols="a,a"]
 |===
@@ -42,7 +43,7 @@ public void endpoint(HttpServletRequest request, HttpServletResponse response) t
 ----
 |===
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving using the content-type header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response using the content-type header.
 
 For example, setting the content-type to `text/plain` using the `setContentType` function allows to safely reflect user input since browsers will not try to parse and execute the response.
 

--- a/rules/S5131/java/javax.servlet.http/rule.adoc
+++ b/rules/S5131/java/javax.servlet.http/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 User input embedded in HTML code should be HTML-encoded to prevent the injection of additional code. This can be done with the https://owasp.org/www-project-java-encoder/[OWASP Java Encoder] or similar libraries.
 

--- a/rules/S5131/java/jsp/rule.adoc
+++ b/rules/S5131/java/jsp/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because JSP does not auto-escape variables.
+The following code is vulnerable to cross-site scripting because JSP does not auto-escape variables.
 
 User input embedded in HTML code should be HTML-encoded to prevent the injection of additional code. This can be done with the https://owasp.org/www-project-java-encoder/[OWASP Java Encoder] or similar libraries.
 

--- a/rules/S5131/java/spring/rule.adoc
+++ b/rules/S5131/java/spring/rule.adoc
@@ -12,7 +12,7 @@ include::../../threats.adoc[]
 
 The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving. For example, you can use the `produces` property of the `GetMapping` annotation.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response. For example, you can use the `produces` property of the `GetMapping` annotation.
 
 [cols="a,a"]
 |===
@@ -46,11 +46,10 @@ public class ApiController
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use a template engine like https://www.thymeleaf.org/[Thymeleaf] to generate it.
-A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
+If the HTTP response is HTML code, it is highly recommended to use a template engine like https://www.thymeleaf.org/[Thymeleaf] to generate it.
+This template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
 Thus, the response is not vulnerable to reflected cross-site scripting.
 

--- a/rules/S5131/java/spring/rule.adoc
+++ b/rules/S5131/java/spring/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving. For example, you can use the `produces` property of the `GetMapping` annotation.
 
@@ -48,11 +48,11 @@ public class ApiController
 
 In case the response consists of HTML code, it is highly recommended to use a template engine like https://www.thymeleaf.org/[Thymeleaf] to generate it.
 A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
-Thus, the response is not vulnerable to reflected Cross-Site Scripting.
+Thus, the response is not vulnerable to reflected cross-site scripting.
 
 For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
 

--- a/rules/S5131/java/thymeleaf/rule.adoc
+++ b/rules/S5131/java/thymeleaf/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting.
+The following code is vulnerable to cross-site scripting.
 
 User input embedded in HTML code should be HTML-encoded to prevent the injection of additional code.
 

--- a/rules/S5131/php/laravel/rule.adoc
+++ b/rules/S5131/php/laravel/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
 For example, you can use the `json` method of the `Response` class to safely return JSON messages.
@@ -49,11 +49,11 @@ $response = response($input, 200)->header('Content-Type', 'text/plain');
 
 In case the response consists of HTML code, it is highly recommended to use a template engine like https://laravel.com/docs/9.x/blade[Blade] to generate it.
 A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
-Thus, the response is not vulnerable to reflected Cross-Site Scripting.
+Thus, the response is not vulnerable to reflected cross-site scripting.
 
 For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
 

--- a/rules/S5131/php/laravel/rule.adoc
+++ b/rules/S5131/php/laravel/rule.adoc
@@ -12,7 +12,7 @@ include::../../threats.adoc[]
 
 The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response.
 For example, you can use the `json` method of the `Response` class to safely return JSON messages.
 
 [cols="a,a"]
@@ -47,11 +47,10 @@ $response = response($input, 200)->header('Content-Type', 'text/plain');
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use a template engine like https://laravel.com/docs/9.x/blade[Blade] to generate it.
-A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
+If the HTTP response is HTML code, it is highly recommended to use a template engine like https://laravel.com/docs/9.x/blade[Blade] to generate it.
+This template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
 Thus, the response is not vulnerable to reflected cross-site scripting.
 

--- a/rules/S5131/php/native/rule.adoc
+++ b/rules/S5131/php/native/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 User input embedded in HTML code should be HTML-encoded to prevent the injection of additional code.
 PHP provides the built-in function `htmlspecialchars` to do this.

--- a/rules/S5131/php/native/rule.adoc
+++ b/rules/S5131/php/native/rule.adoc
@@ -29,7 +29,7 @@ echo '<h1>' . htmlspecialchars($input) . '</h1>';
 ----
 |===
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving using the content-type header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response with the content-type header.
 
 For example, setting the content-type to `text/plain` using the built-in `header` function allows to safely reflect user input since browsers will not try to parse and execute the response.
 
@@ -59,7 +59,7 @@ include::../../common/pitfalls/content-types.adoc[]
 
 ==== Single quoted variables in attributes
 
-By default, `htmlspecialchars` does not encode single quotes, so if ``++$input++`` is untrusted, JavaScript code can be injected.
+By default, `htmlspecialchars` does not encode single quotes, so if `++$input++` is untrusted, JavaScript code can be injected.
 
 Make sure to set the option `ENT_QUOTES` to encode single quotes.
 

--- a/rules/S5131/php/symfony/rule.adoc
+++ b/rules/S5131/php/symfony/rule.adoc
@@ -12,8 +12,8 @@ include::../../threats.adoc[]
 
 The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
-For example, you can use the class `JsonResponse` to safely return JSON messages.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response.
+For example, you can use the class `JsonResponse` to return JSON messages safely.
 
 [cols="a,a"]
 |===
@@ -59,11 +59,10 @@ $response->setContent($input);
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use a template engine like https://twig.symfony.com/[Twig] to generate it.
-A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
+If the HTTP response is HTML code, it is highly recommended to use a template engine like https://twig.symfony.com/[Twig] to generate it.
+This template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
 Thus, the response is not vulnerable to reflected cross-site scripting.
 

--- a/rules/S5131/php/symfony/rule.adoc
+++ b/rules/S5131/php/symfony/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
 For example, you can use the class `JsonResponse` to safely return JSON messages.
@@ -61,11 +61,11 @@ $response->setContent($input);
 
 In case the response consists of HTML code, it is highly recommended to use a template engine like https://twig.symfony.com/[Twig] to generate it.
 A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
-Thus, the response is not vulnerable to reflected Cross-Site Scripting.
+Thus, the response is not vulnerable to reflected cross-site scripting.
 
 For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
 

--- a/rules/S5131/python/django/rule.adoc
+++ b/rules/S5131/python/django/rule.adoc
@@ -84,6 +84,8 @@ include::../../common/pitfalls/validation.adoc[]
 
 === Documentation
 
+* https://docs.djangoproject.com/en/4.0/ref/request-response/[Django Project, Request and response objects (Django 4.0)]
+
 include::../../common/resources/articles.adoc[]
 
 include::../../common/resources/presentations.adoc[]

--- a/rules/S5131/python/django/rule.adoc
+++ b/rules/S5131/python/django/rule.adoc
@@ -80,8 +80,6 @@ include::../../common/pitfalls/validation.adoc[]
 
 === Going the extra mile
 
-include::../../common/extra-mile/csp.adoc[]
-
 == Resources
 
 === Documentation

--- a/rules/S5131/python/django/rule.adoc
+++ b/rules/S5131/python/django/rule.adoc
@@ -10,10 +10,10 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
-For example, you can use the `JsonResponse` class to return JSON messages safely.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response.
+For example, you can use the `JsonResponse` class to return JSON messages securely.
 
 [cols="a,a"]
 |===
@@ -38,7 +38,7 @@ def index(request):
 ----
 |===
 
-It is also possible to set the content-type manually using the `content_type` parameter when creating an `HttpResponse` object.
+It is also possible to set the content-type manually with the `content_type` parameter when creating an `HttpResponse` object.
 
 [cols="a,a"]
 |===
@@ -62,15 +62,14 @@ def index(request):
 
 === How does this work?
 
-If the response consists of HTML code, it is highly recommended to use a template engine like https://docs.djangoproject.com/en/4.0/topics/templates/[Django's template system] to generate it.
-A good template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+If the HTTP response consists of HTML code, it is highly recommended to use a template engine like https://docs.djangoproject.com/en/4.0/topics/templates/[Django's template system] to generate it.
+The Django template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by telling them what data they are receiving with the `content-type` HTTP header.
 This header tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
-Thus, the response is not vulnerable to reflected Cross-Site Scripting.
+Thus, the response is not vulnerable to reflected cross-site scripting.
 
-For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
+For example, setting the Content-Type HTTP header to `text/plain` allows to safely reflect user input, because browsers will not try to parse and execute the response.
 
 === Pitfalls
 

--- a/rules/S5131/python/django/rule.adoc
+++ b/rules/S5131/python/django/rule.adoc
@@ -13,7 +13,7 @@ include::../../threats.adoc[]
 The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
-For example, you can use the `JsonResponse` class to safely return JSON messages.
+For example, you can use the `JsonResponse` class to return JSON messages safely.
 
 [cols="a,a"]
 |===
@@ -62,12 +62,12 @@ def index(request):
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use a template engine like https://docs.djangoproject.com/en/4.0/topics/templates/[Django's template system] to generate it.
-A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
+If the response consists of HTML code, it is highly recommended to use a template engine like https://docs.djangoproject.com/en/4.0/topics/templates/[Django's template system] to generate it.
+A good template engine does not only separate the view from the business logic and thus results in a more maintainable application.
 It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
-This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
+This header tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
 Thus, the response is not vulnerable to reflected Cross-Site Scripting.
 
 For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.

--- a/rules/S5131/python/dtl/rule.adoc
+++ b/rules/S5131/python/dtl/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because auto-escaping of special HTML characters has been disabled. The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
+The following code is vulnerable to cross-site scripting because auto-escaping of special HTML characters has been disabled. The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
 
 [cols="a,a"]
 |===
@@ -33,7 +33,6 @@ def hello(request):
         name = request.GET.get("name")
         return render(request, 'hello.html', {'name': name})
 ----
-
 |
 [source,html]
 ----
@@ -48,20 +47,19 @@ def hello(request):
 <!doctype html>
 <h1>Hello {{ name }}</h1>
 ----
-
 |===
 
 === How does this work?
 
-Template engines are used by web applications to build HTML content. Template files contain static HTML as well as template language instructions. These instructions allow, for example, to insert dynamic values in the document as the template is rendered. Template engines can auto-escape HTML special characters of dynamic values in order to prevent XSS vulnerabilities.
+Template engines are used by web applications to build HTML content. Template files contain both static HTML and template language instructions. These instructions allow, for example, to insert dynamic values in the document as the template is rendered. Template engines can auto-escape HTML special characters of dynamic values in order to prevent XSS vulnerabilities.
 
-In Django applications, the engine's auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected in the template and auto-escaping is disabled using ``++{% autoescape false %}++`` or ``++|safe++`` filter. This is often the case when a piece of dynamic HTML is generated from the code and used in a template variable.
+In Django applications, the engine's auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected into the template and auto-escaping is disabled with the filters ``++{% autoescape false %}++`` or ``++|safe++``. tHIs is often the case when a piece of dynamic HTML is generated from code and used in a template variable.
 
 include::../../common/fix/data_encoding.adoc[]
 
-Django templates auto-escaping only takes care of HTML entity endcoding. It will not protect from XSS if a variable is injected in an unquoted attribute or direcly in a script block.
+Django template auto-escaping only takes care of HTML entity encoding. It does not protect from XSS when a variable is injected into an unquoted attribute or directly into a script block.
 
-Auto-escaping may be disabled at application level causing XSS vulnerabilities even if ``++{% autoescape false %}++`` or ``++|safe++`` are not being used.
+Auto-escaping can also be disabled at the application level and introduce XSS vulnerabilities even if ``++{% autoescape false %}++`` or ``++|safe++`` are not used.
 
 [cols="a,a"]
 |===
@@ -98,12 +96,14 @@ TEMPLATES = [
 
 === Pitfalls
 
-Although auto-escaping drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities, there are still specific cases where vulnerabilities can occur.
+Although auto-escaping drastically decreases the chance of introducing cross-site scripting vulnerabilities, there are still specific cases where vulnerabilities can occur.
 
 ==== Variables in script blocks
 
-As mentionned above, injecting user-contoled value inside a ``++script++`` is dangerous and the best practice, in such a case, is to add the value to an attribute.
-Another option is to use ``++json_script++`` filter to insert a data structure that can then be accessed from the JavaScript code.
+As mentioned in the section "How to fix it", injecting user-controlled values into a client-side JavaScript ``++script++`` is dangerous.
+In such a case it is better to add the value to an attribute.
+
+Another option is to use the ``++json_script++`` filter to insert a data structure that can then be accessed through the JavaScript code.
 
 [cols="a,a"]
 |===

--- a/rules/S5131/python/dtl/rule.adoc
+++ b/rules/S5131/python/dtl/rule.adoc
@@ -53,13 +53,13 @@ def hello(request):
 
 Template engines are used by web applications to build HTML content. Template files contain both static HTML and template language instructions. These instructions allow, for example, to insert dynamic values in the document as the template is rendered. Template engines can auto-escape HTML special characters of dynamic values in order to prevent XSS vulnerabilities.
 
-In Django applications, the engine's auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected into the template and auto-escaping is disabled with the filters ``++{% autoescape false %}++`` or ``++|safe++``. tHIs is often the case when a piece of dynamic HTML is generated from code and used in a template variable.
+In Django applications, the engine's auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected into the template and auto-escaping is disabled with the filters `++{% autoescape false %}++` or `++|safe++`. This is often the case when a piece of dynamic HTML is generated from code and used in a template variable.
 
 include::../../common/fix/data_encoding.adoc[]
 
 Django template auto-escaping only takes care of HTML entity encoding. It does not protect from XSS when a variable is injected into an unquoted attribute or directly into a script block.
 
-Auto-escaping can also be disabled at the application level and introduce XSS vulnerabilities even if ``++{% autoescape false %}++`` or ``++|safe++`` are not used.
+Auto-escaping can also be disabled at the application level and introduce XSS vulnerabilities even if `++{% autoescape false %}++` or `++|safe++` are not used.
 
 [cols="a,a"]
 |===
@@ -100,10 +100,10 @@ Although auto-escaping drastically decreases the chance of introducing cross-sit
 
 ==== Variables in script blocks
 
-As mentioned in the section "How to fix it", injecting user-controlled values into a client-side JavaScript ``++script++`` is dangerous.
+As mentioned in the section "How to fix it", injecting user-controlled values into a client-side JavaScript `++script++` is dangerous.
 In such a case it is better to add the value to an attribute.
 
-Another option is to use the ``++json_script++`` filter to insert a data structure that can then be accessed through the JavaScript code.
+Another option is to use the `++json_script++` filter to insert a data structure that can then be accessed through the JavaScript code.
 
 [cols="a,a"]
 |===

--- a/rules/S5131/python/flask/rule.adoc
+++ b/rules/S5131/python/flask/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because it returns an HTML response that contains user input.
+The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
 For example, you can use the `jsonify` class to safely return JSON messages.
@@ -65,11 +65,11 @@ def index(request):
 
 In case the response consists of HTML code, it is highly recommended to use a template engine like https://jinja.palletsprojects.com/[Jinja] to generate it.
 A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities.
+It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
 
 If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
 This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
-Thus, the response is not vulnerable to reflected Cross-Site Scripting.
+Thus, the response is not vulnerable to reflected cross-site scripting.
 
 For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
 
@@ -80,8 +80,6 @@ include::../../common/pitfalls/content-types.adoc[]
 include::../../common/pitfalls/validation.adoc[]
 
 === Going the extra mile
-
-include::../../common/extra-mile/csp.adoc[]
 
 == Resources
 

--- a/rules/S5131/python/flask/rule.adoc
+++ b/rules/S5131/python/flask/rule.adoc
@@ -12,8 +12,8 @@ include::../../threats.adoc[]
 
 The following code is vulnerable to cross-site scripting because it returns an HTML response that contains user input.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving.
-For example, you can use the `jsonify` class to safely return JSON messages.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response.
+For example, you can use the `jsonify` class to return JSON messages safely.
 
 [cols="a,a"]
 |===
@@ -39,7 +39,7 @@ def index(request):
 ----
 |===
 
-It is also possible to set the content-type manually using the `mimetype` parameter when calling the `make_response` function.
+It is also possible to set the content-type manually with the `mimetype` parameter when calling the `make_response` function.
 
 [cols="a,a"]
 |===
@@ -63,15 +63,14 @@ def index(request):
 
 === How does this work?
 
-In case the response consists of HTML code, it is highly recommended to use a template engine like https://jinja.palletsprojects.com/[Jinja] to generate it.
-A proper template engine does not only separate the view from the business logic and thus results in a more maintainable application.
-It also automatically encodes variable output and thus drastically decreases the chance of introducing cross-site scripting vulnerabilities.
+If the HTTP response is HTML code, it is highly recommended to use a template engine like https://jinja.palletsprojects.com/[Jinja] to generate it.
+This template engine separates the view from the business logic and automatically encodes the output of variables, drastically reducing the risk of cross-site scripting vulnerabilities.
 
-If you do not intend to send HTML code to the clients, the vulnerability can be resolved by telling them what data they are receiving with the `content-type` HTTP header.
-This tells the browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
+If you do not intend to send HTML code to clients, the vulnerability can be fixed by specifying the type of data returned in the response with the `content-type` HTTP header.
+This HTTP header tells the client browser that the response does not contain HTML code and should not be parsed and interpreted as HTML.
 Thus, the response is not vulnerable to reflected cross-site scripting.
 
-For example, setting the content-type to `text/plain` allows to safely reflect user input since browsers will not try to parse and execute the response.
+For example, setting the content-type header to `text/plain` allows to safely reflect user input because browsers will not try to parse and execute the response.
 
 === Pitfalls
 
@@ -84,6 +83,8 @@ include::../../common/pitfalls/validation.adoc[]
 == Resources
 
 === Documentation
+
+* https://flask.palletsprojects.com/en/2.1.x/security/?highlight=xss#cross-site-scripting-xss[Flask, Security Considerations]
 
 include::../../common/resources/articles.adoc[]
 

--- a/rules/S5131/python/jinja/rule.adoc
+++ b/rules/S5131/python/jinja/rule.adoc
@@ -10,7 +10,8 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to cross-site scripting because auto-escaping of special HTML characters has been disabled. The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
+The following code is vulnerable to cross-site scripting because auto-escaping of special HTML characters has been disabled.
+The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
 
 [cols="a,a"]
 |===
@@ -51,17 +52,17 @@ def hello(name=None):
 
 === How does this work?
 
-Template engines are used by web applications to build HTML content. Template files contain static HTML as well as template language instructions. These instructions allow, for example, to insert dynamic values (variables) in the document as the template is rendered. Template engines can auto escape HTML special characters of variables in order to prevent XSS vulnerabilities.
+Template engines are used by web applications to build HTML content. Template files contain static HTML as well as template language instructions. These instructions allow, for example, to insert dynamic values (variables) in the document as the template is rendered.
+Template engines can auto escape HTML special characters of variables in order to prevent XSS vulnerabilities.
 
-In Flask applications, the Jinja auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected in the template and that auto-escaping is disabled using ``++{% autoescape false %}++`` or ``++|safe++`` filter. This is often the case when a piece of dynamic HTML is generated from the Python code and used in a template variable.
+In Flask applications, Jinja's auto-escaping feature is enabled by default. XSS vulnerabilities arise when an untrusted value is injected into the template and auto-escaping is disabled with the `++{% autoescape false %}++` or `++|safe++` filters.
+This is often the case when a piece of dynamic HTML is generated from Python code and used in a template variable.
 
 === Pitfalls
 
-Although auto-escaping drastically decreases the chance of introducing cross-site scripting vulnerabilities, there are still specific cases where vulnerabilities can occur.
-
 ==== Unquoted variables in attributes
 
-If ``++color++`` is untrusted, JavaScript code can be injected by adding event-handler attributes like ``++onmouseover++``.
+In the following example, if the variable `++color++` is untrusted, JavaScript code can be injected by adding event-handler attributes such as `++onmouseover++`.
 
 Surround the attribute with double or single quotes to prevent arbitrary attributes from being added.
 
@@ -81,11 +82,11 @@ Surround the attribute with double or single quotes to prevent arbitrary attribu
 ----
 |===
 
-==== Variables in ``++href++`` attributes
+==== Variables in `++href++` attributes
 
-If ``++url++`` is untrusted, JavaScript code can be injected by using an attributes value that starts with ``++javascript:++``.
+In the following example, if the variable `++url++` is untrusted, JavaScript code can be injected by using an attributes value that starts with `++javascript:++`.
 
-Use function like ``++flask.url_for++`` to generate URLs used in ``++href++`` attributes
+Use function like `++flask.url_for++` to generate URLs used in `++href++` attributes
 
 [cols="a,a"]
 |===
@@ -105,9 +106,9 @@ Use function like ``++flask.url_for++`` to generate URLs used in ``++href++`` at
 
 ==== Variables in script blocks
 
-If ``++name++`` is untrusted, JavaScript code can be injected.
+If `++name++` is untrusted, JavaScript code can be injected.
 
-Use ``++tojson++`` filter to insert a data structure in the JavaScript code at render time.
+Use `++tojson++` filter to insert a data structure in the JavaScript code at render time.
 
 [cols="a,a"]
 |===

--- a/rules/S5131/python/jinja/rule.adoc
+++ b/rules/S5131/python/jinja/rule.adoc
@@ -10,7 +10,7 @@ include::../../threats.adoc[]
 
 == How to fix it?
 
-The following code is vulnerable to Cross-Site Scripting because auto-escaping of special HTML characters has been disabled. The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
+The following code is vulnerable to cross-site scripting because auto-escaping of special HTML characters has been disabled. The recommended way to fix this code is to move the HTML content to the template and to only inject the dynamic value. Therefore, it is not necessary to disable auto-escaping. 
 
 [cols="a,a"]
 |===
@@ -57,7 +57,7 @@ In Flask applications, the Jinja auto-escaping feature is enabled by default. XS
 
 === Pitfalls
 
-Although auto-escaping drastically decreases the chance of introducing Cross-Site Scripting vulnerabilities, there are still specific cases where vulnerabilities can occur.
+Although auto-escaping drastically decreases the chance of introducing cross-site scripting vulnerabilities, there are still specific cases where vulnerabilities can occur.
 
 ==== Unquoted variables in attributes
 

--- a/rules/S5131/rationale.adoc
+++ b/rules/S5131/rationale.adoc
@@ -1,4 +1,4 @@
-Reflected Cross-Site Scripting (XSS) occurs in a web application when the application retrieves data (e.g., parameters or headers) from an incoming HTTP request and inserts it into its HTTP response without first sanitizing it. The most common cause is the insertion of GET parameters:
+Reflected cross-site scripting (XSS) occurs in a web application when the application retrieves data (e.g., parameters or headers) from an incoming HTTP request and inserts it into its HTTP response without first sanitizing it. The most common cause is the insertion of GET parameters:
 
 image:common/images/browser.png[]
 


### PR DESCRIPTION
Big Review. This PR [is incomplete] and seeks 
- Conciseness
- Clarity
- Consistency between texts

Chunks of text are modified as suggestions.

Alignment to seek on:
- [ ] short introductions in the pitfall section
- [ ] We shouldn't use terms such as "mentioned above"
- [ ] The Jinja code contains a lot of examples, this looks not aligned with decisions about conciseness
- [ ] If the Jinja code gets to stay as is,  the Java examples using the OWASP encoders should have more sections as well
