### PR TITLE
Modify rule S4524: highlight src and set quickfix to targeted

### DIFF
--- a/rules/S4524/cfamily/metadata.json
+++ b/rules/S4524/cfamily/metadata.json
@@ -7,5 +7,6 @@
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"
-  ]
+  ],
+  "quickfix": "targeted"
 }

--- a/rules/S4524/compliant.adoc
+++ b/rules/S4524/compliant.adoc
@@ -1,6 +1,6 @@
 == Compliant Solution
 
-[source,text]
+[source,cpp]
 ----
 switch (param) {
   case 0:

--- a/rules/S4524/noncompliant.adoc
+++ b/rules/S4524/noncompliant.adoc
@@ -1,6 +1,6 @@
 == Noncompliant Code Example
 
-[source,text]
+[source,cpp]
 ----
 switch (param) {
   case 0:


### PR DESCRIPTION
As part of the rule implementation - CPP-2004
Ticket for the quickfix: CPP-3690