### PR TITLE
Modify rules S131 S3562: CPP-3692 clarify difference and purpose

### DIFF
--- a/rules/S131/cfamily/metadata.json
+++ b/rules/S131/cfamily/metadata.json
@@ -6,8 +6,6 @@
   ],
   "sqKey": "S131",
   "defaultQualityProfiles": [
-    "Sonar way",
-    "MISRA C++ 2008 recommended"
   ],
   "securityStandards": {
     "CERT": [

--- a/rules/S131/cfamily/rule.adoc
+++ b/rules/S131/cfamily/rule.adoc
@@ -1,5 +1,11 @@
 The requirement for a final ``++default++`` clause is defensive programming. The clause should either take appropriate action, or contain a suitable comment as to why no action is taken. When the ``++switch++`` covers all current values of an ``++enum++`` - and especially when it doesn't - a ``++default++`` case should still be used because there is no guarantee that the ``++enum++`` won't be extended.
 
+Note that there is a more nuanced version of this rule: S3562.
+Use S131 if you want to require a `++default++` case for every `++switch++`
+even if it already handles each value of an `++enum++`.
+Use S3562 rule if you want to ensure all reasonable cases are handled,
+and do not want to include a `++default++` case if you handle all values in an `++enum++`.
+
 == Noncompliant Code Example
 
 [source,cpp]

--- a/rules/S3562/cfamily/metadata.json
+++ b/rules/S3562/cfamily/metadata.json
@@ -22,7 +22,7 @@
   "sqKey": "S3562",
   "scope": "Main",
   "defaultQualityProfiles": [
-
+    "Sonar way"
   ],
   "quickfix": "unknown"
 }

--- a/rules/S3562/cfamily/rule.adoc
+++ b/rules/S3562/cfamily/rule.adoc
@@ -1,5 +1,10 @@
 For completeness, a ``++switch++`` over the values of an ``++enum++`` must either address each value in the ``++enum++`` or contain a ``++default++`` case. ``++switch++`` statements that are not over ``++enum++`` must end with a ``++default++`` case.
 
+Note, this a more nuanced version of S131.
+Use S131 if you want to require a `++default++` case for every `++switch++`
+even if it already handles each value of an `++enum++`.
+Use this rule if you want to ensure all reasonable cases are handled,
+and do not want to include a `++default++` case if you handle all values in an `++enum++`.
 
 == Noncompliant Code Example
 
@@ -84,6 +89,9 @@ void example(fruit f) {
 
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#enum2-use-enumerations-to-represent-sets-of-related-named-constants[{cpp} Core Guidelines - Enum.2] - Use enumerations to represent sets of related named constants
 
+=== See Also
+
+* S131
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
Clarify the difference between the scopes and purposes of S131 and S3562, replace S131 with S3562 in SonarWay