### PR TITLE
CPP-220 S3135 "sizeof" should not be called on pointer parameters

### DIFF
--- a/rules/S1913/cfamily/metadata.json
+++ b/rules/S1913/cfamily/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "\"sizeof(sizeof(...))\" should not be used",
   "type": "BUG",
-  "status": "deprecated",
+  "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "20min"
@@ -10,9 +10,6 @@
 
   ],
   "extra": {
-    "replacementRules": [
-      "RSPEC-3135"
-    ],
     "legacyKeys": [
       "SizeofSizeof"
     ]

--- a/rules/S1913/cfamily/metadata.json
+++ b/rules/S1913/cfamily/metadata.json
@@ -19,7 +19,7 @@
   "sqKey": "S1913",
   "scope": "Main",
   "defaultQualityProfiles": [
-
+    "Sonar way"
   ],
   "quickfix": "unknown"
 }

--- a/rules/S3135/cfamily/metadata.json
+++ b/rules/S3135/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"sizeof\" should not be called on pointer parameters",
+  "title": "\"sizeof\" should not be called on pointer",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/rules/S3135/cfamily/metadata.json
+++ b/rules/S3135/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"sizeof\" should not be called on pointer",
+  "title": "\"sizeof\" should not be called on pointers",
   "type": "BUG",
   "status": "ready",
   "remediation": {
@@ -27,7 +27,7 @@
       467
     ],
     "CERT": [
-      "ARR01-C.",
+      "ARR01-C."
     ]
   },
   "defaultQualityProfiles": [

--- a/rules/S3135/cfamily/metadata.json
+++ b/rules/S3135/cfamily/metadata.json
@@ -1,14 +1,13 @@
 {
-  "title": "Valid arguments should be passed to \"sizeof\" and \"alignof\"",
+  "title": "\"sizeof\" should not be called on pointer parameters",
   "type": "BUG",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10min"
+    "constantCost": "5min"
   },
   "tags": [
     "cwe",
-    "based-on-misra",
     "cert"
   ],
   "extra": {
@@ -29,13 +28,11 @@
     ],
     "CERT": [
       "ARR01-C.",
-      "EXP44-C.",
-      "EXP52-CPP."
     ]
   },
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"
   ],
-  "quickfix": "unknown"
+  "quickfix": "covered"
 }

--- a/rules/S3135/cfamily/rule.adoc
+++ b/rules/S3135/cfamily/rule.adoc
@@ -1,40 +1,18 @@
-``++sizeof++`` returns the size in bytes of a type. ``++alignof++`` (since {cpp}-11) returns the alignment, in bytes, required for any instance of a type. Using any other kind of value with ``++sizeof++``, or ``++alignof++``, is likely a mistake - what is returned is the size, or alignment, of the operand's type.
+`sizeof` returns the size in bytes of a type. One common usage pattern, especially in C, is to use `sizeof` to determine the size of an array. However, arrays decay to pointers when passed as arguments to a function, and if `sizeof` is applied to such an argument, it will return the size of the pointer, not of the array.
 
+This rule raises issues when `sizeof` is called on a pointer passed as a function argument.
 
-This rule raises issues for the following ``++sizeof++``, and ``++alignof++`` calls:
-
-
-* with parameters that have a ``++void++`` type. That is forbidden by both the C and {cpp} standards
-* on a pointer type variable. This is typically a mistake; usually the intent is to get the size, or alignment, of the pointed-to value instead
-* when the parameter is another ``++sizeof++``, or ``++alignof++`` call. ``++sizeof(sizeof(...))++`` indicates a misuse or misunderstanding of the ``++sizeof++`` construct
-* when side effects are intended in the parameter. The side effects don't actually occur; the expression is not evaluated because ``++sizeof++`` only acts on the type of the expression
-* when there are calculations within ``++sizeof++``, or ``++alignof++``; the result will be ``++sizeof(int)++``, or ``++alignof(int)++``, assuming the calculation's operands are ``++int++``s
-* when numeric constants are used with ``++sizeof++`` or ``++alignof++``. Such calls simply return ``++sizeof(int)++`` or ``++alignof(int)++`` respectively.
-
+Note: {cpp}17 provides a `std::size` function that will correctly compute the number of elements of an array and fail to compile if provided with a pointer. It is simpler and safer to use this variant when available. {cpp}20 also provides the functions `std::ssize`, `std::ranges::size`, and `std::ranges::ssize` with similar effects.
 
 == Noncompliant Code Example
 
 [source,cpp]
 ----
-void fun(int array[10]) {
-  int length = 42;
-
-  for (size_t i = 0; i < sizeof(array) / sizeof(*array); i++) { // Noncompliant, type of array decays to int *, so sizeof(array) evaluates to sizeof(int *)
-    array[i] = 0;
-  }
-
-  size_t size = sizeof(i = 1234); // Noncompliant, side effect
-  size = sizeof(i++); // Noncompliant, side effect
-
-  size = sizeof(sizeof(i)); // Noncompliant, one sizeof call was intended
-
-  char *cp = malloc(sizeof(length + 1));  // Noncompliant, calculation in parameter
-
-  size = sizeof(10); // Noncompliant, constant as parameter
-
-  void* p;
-  alignof(*p);  // Noncompliant, void type
-  alignof(void);  // Noncompliant, void type
+void fun(int *data, int array[10]) {
+  size_t const dataSize = sizeof(data) / sizeof(int); // Noncompliant, type of data is int *
+  size_t const arraySize = sizeof(array) / sizeof(int); // Noncompliant, type of array is int * too 
+  int primes[] = { 1, 2, 3, 5, 7, 13, 17, 19};
+  size_t const primesSize = sizeof(primes) / sizeof(int); // Compliant, type of primes is int[8] 
 }
 ----
 
@@ -43,35 +21,18 @@ void fun(int array[10]) {
 
 [source,cpp]
 ----
-void fun(int array[10]) {
-  int length = 42;
-
-  for (size_t i = 0; i < count; i++) {
-    array[i] = 0;
-  }
-
-  int i = 1234;
-  size_t size = sizeof( i );
-  i++;
-  size = sizeof (i);
-
-  size = sizeof(i);
-
-  char *cp = malloc((length + 1) * sizeof(char));
-
-  size = sizeof(int);
+// Computing dataSize is now the responsibility of the caller
+void fun(int *data, int dataSize int (&array)[10]) {
+  size_t const arraySize = sizeof(array) / sizeof(int); // Compliant, no decay 
+  int primes[] = { 1, 2, 3, 5, 7, 13, 17, 19};
+  size_t const primesSize = std::size(primes); // Better variant in C++17
 }
 ----
 
 
 == See
 
-* MISRA C:2004, 12.3 - The sizeof operator shall not be used on expressions that contain side effects.
-* MISRA {cpp}:2008, 5-3-4 - Evaluation of the operand to the sizeof operator shall not contain side effects.
-* MISRA C:2012, 13.6 - The operand of the sizeof operator shall not contain any expression which has potential side effects
-* https://wiki.sei.cmu.edu/confluence/x/CdYxBQ[CERT, ARR01-C.] - Do not apply the ``++sizeof++`` operator to a pointer when taking the size of an array
-* https://wiki.sei.cmu.edu/confluence/x/_NYxBQ[CERT, EXP44-C.] - Do not rely on side effects in operands to ``++sizeof++``, ``++_Alignof++``, or ``++_Generic++``
-* https://wiki.sei.cmu.edu/confluence/x/oXs-BQ[CERT, EXP52-CPP.] - Do not rely on side effects in unevaluated operands
+* https://wiki.sei.cmu.edu/confluence/x/CdYxBQ[CERT, ARR01-C.] - Do not apply the `sizeof` operator to a pointer when taking the size of an array
 * https://cwe.mitre.org/data/definitions/467[MITRE, CWE-467] - Use of sizeof() on a Pointer Type
 
 

--- a/rules/S3135/cfamily/rule.adoc
+++ b/rules/S3135/cfamily/rule.adoc
@@ -1,6 +1,6 @@
-`sizeof` returns the size in bytes of a type. One common usage pattern, especially in C, is to use `sizeof` to determine the size of an array. However, arrays decay to pointers when passed as arguments to a function, and if `sizeof` is applied to such an argument, it will return the size of the pointer, not of the array.
+`sizeof` returns the size in bytes of a type. One common usage pattern, especially in C, is to use `sizeof` to determine the size of an array. However, arrays decay to pointers when passed as arguments to a function, and if `sizeof` is applied to such an argument, it will return the size of the pointer, not of the array. A similar issue happens when the array is used in an arithmetic operation.
 
-This rule raises issues when `sizeof` is called on a pointer passed as a function argument.
+This rule raises issues when `sizeof` is used to compute the array size of a pointer passed as a function argument or used in an arithmetic operation.
 
 Note: {cpp}17 provides a `std::size` function that will correctly compute the number of elements of an array and fail to compile if provided with a pointer. It is simpler and safer to use this variant when available. {cpp}20 also provides the functions `std::ssize`, `std::ranges::size`, and `std::ranges::ssize` with similar effects.
 
@@ -9,10 +9,11 @@ Note: {cpp}17 provides a `std::size` function that will correctly compute the nu
 [source,cpp]
 ----
 void fun(int *data, int array[10]) {
-  size_t const dataSize = sizeof(data) / sizeof(int); // Noncompliant, type of data is int *
-  size_t const arraySize = sizeof(array) / sizeof(int); // Noncompliant, type of array is int * too 
+  size_t const dataSize = sizeof data / sizeof(int); // Noncompliant, type of data is int *
+  size_t const arraySize = sizeof array / sizeof(int); // Noncompliant, type of array is int * too 
   int primes[] = { 1, 2, 3, 5, 7, 13, 17, 19};
-  size_t const primesSize = sizeof(primes) / sizeof(int); // Compliant, type of primes is int[8] 
+  size_t const primesSize = sizeof primes / sizeof(int); // Compliant, type of primes is int[8] 
+  size_t const primesSize2 = sizeof(primes + 1) / sizeof(int); // Noncompliant, type of primes + 1 is int *
 }
 ----
 
@@ -23,9 +24,10 @@ void fun(int *data, int array[10]) {
 ----
 // Computing dataSize is now the responsibility of the caller
 void fun(int *data, int dataSize int (&array)[10]) {
-  size_t const arraySize = sizeof(array) / sizeof(int); // Compliant, no decay 
+  size_t const arraySize = sizeof array / sizeof(int); // Compliant, no decay 
   int primes[] = { 1, 2, 3, 5, 7, 13, 17, 19};
   size_t const primesSize = std::size(primes); // Better variant in C++17
+  size_t const primesSize2 = sizeof primes / sizeof(int) + 1;
 }
 ----
 

--- a/rules/S3135/cfamily/rule.adoc
+++ b/rules/S3135/cfamily/rule.adoc
@@ -1,6 +1,9 @@
 `sizeof` returns the size in bytes of a type. One common usage pattern, especially in C, is to use `sizeof` to determine the size of an array. However, arrays decay to pointers when passed as arguments to a function, and if `sizeof` is applied to such an argument, it will return the size of the pointer, not of the array. A similar issue happens when the array is used in an arithmetic operation.
 
-This rule raises issues when `sizeof` is used to compute the array size of a pointer passed as a function argument or used in an arithmetic operation.
+This rule raises issues when:
+
+* `sizeof` is used to compute the array size of a pointer passed as a function argument.
+* `sizeof` is called on the result of an arithmetic operation involving an array.
 
 Note: {cpp}17 provides a `std::size` function that will correctly compute the number of elements of an array and fail to compile if provided with a pointer. It is simpler and safer to use this variant when available. {cpp}20 also provides the functions `std::ssize`, `std::ranges::size`, and `std::ranges::ssize` with similar effects.
 


### PR DESCRIPTION
Undeprecate S1913