### PR TITLE
CPP-2907 S1199: Rule is too strict for variables in case blocks

### DIFF
--- a/rules/S1199/cfamily/rule.adoc
+++ b/rules/S1199/cfamily/rule.adoc
@@ -1,8 +1,8 @@
-Nested code blocks can be used to create a new scope: Variables declared within that block cannot be accessed from the outside, and their lifetime end at the end of the block.
+Nested code blocks can be used to create a new scope: variables declared within that block cannot be accessed from the outside, and their lifetime end at the end of the block.
 
 While this might seem convenient, using this feature in a function often indicates that it has too many responsibilities and should be refactored into smaller functions.
 
-A nested code block is acceptable when it surrounds all the statements inside a `case` of a `switch` because it prevents variable declarations from polluting other `cases`.
+A nested code block is acceptable when it surrounds all the statements inside an alternative of a `switch` (a `case xxx:` or a `default:`) because it prevents variable declarations from polluting other `cases`.
 
 == Noncompliant Code Example
 
@@ -55,7 +55,7 @@ void f(Cache &c, int data) {
 
   switch(value) {
     case 1: 
-    { // Compliant, limits the scope or result
+    { // Compliant, limits the scope of "result"
        int result = compute(value);
        save(result);
        log();

--- a/rules/S1199/cfamily/rule.adoc
+++ b/rules/S1199/cfamily/rule.adoc
@@ -1,33 +1,25 @@
-include::../description.adoc[]
+Nested code blocks can be used to create a new scope: Variables declared within that block cannot be accessed from the outside, and their lifetime end at the end of the block.
+
+While this might seem convenient, using this feature in a function often indicates that it has too many responsibilities and should be refactored into smaller functions.
+
 
 == Noncompliant Code Example
 
 [source,cpp]
 ----
-enum class OP{
-    ADD
-    /* ... */
-};
 
-class Stack{
-    public:
-    int pop();
-    void push(int i);
-    /* ... */
-};
-
-void evaluate(OP op, Stack& stack) {
-  switch (op) {
-    /* ... */
-    case OP::ADD: { // Noncompliant - nested code block '{' ... '}'
-      int a = stack.pop();
-      int b = stack.pop();
-      int result = a + b;
-      stack.push(result);
-      break;
+void f(Cache &c, int data) {
+  int value;
+  { // Noncompliant
+    std::scoped_lock l(c.getMutex());
+    if (c.hasKey(data)) {
+      value = c.get(data);
+    } else {
+      value = compute(data);
+      c.set(data, value);
     }
-    /* ... */
-  }
+  } // Releases the mutex
+  // Use value
 }
 ----
 
@@ -35,33 +27,20 @@ void evaluate(OP op, Stack& stack) {
 
 [source,cpp]
 ----
-enum class OP{
-    ADD
-    /* ... */
-};
-
-class Stack{
-    public:
-    int pop();
-    void push(int i);
-    /* ... */
-};
-
-static void evaluateAdd(Stack& stack) { 
-  int a = stack.pop();
-  int b = stack.pop();
-  int result = a + b;
-  stack.push(result); 
+int getValue(Cache &c, int data) {
+  std::scoped_lock l(c.getMutex());
+  if (c.hasKey(data)) {
+    return c.get(data);
+  } else {
+    value = compute(data);
+    c.set(data, value);
+    return value;
+  }
 }
 
-void evaluate(OP op, Stack& stack) {
-  switch (op) {
-    /* ... */
-    case OP::ADD: // Compliant
-      evaluateAdd(stack);
-      break;
-    /* ... */
-  }
+void f(Cache &c, int data) {
+  int value = getValue(c, data);
+  // Use value
 }
 ----
 

--- a/rules/S1199/cfamily/rule.adoc
+++ b/rules/S1199/cfamily/rule.adoc
@@ -2,6 +2,7 @@ Nested code blocks can be used to create a new scope: Variables declared within 
 
 While this might seem convenient, using this feature in a function often indicates that it has too many responsibilities and should be refactored into smaller functions.
 
+A nested code block is acceptable when it surrounds all the statements inside a `case` of a `switch` because it prevents variable declarations from polluting other `cases`.
 
 == Noncompliant Code Example
 
@@ -19,7 +20,18 @@ void f(Cache &c, int data) {
       c.set(data, value);
     }
   } // Releases the mutex
-  // Use value
+
+  switch(value) {
+    case 1: 
+    { // Noncompliant, some statements are outside of the block
+       int result = compute(value);
+       save(result);
+    }
+    log();
+    break;
+    case 2:
+    // ...
+  }
 }
 ----
 
@@ -40,8 +52,18 @@ int getValue(Cache &c, int data) {
 
 void f(Cache &c, int data) {
   int value = getValue(c, data);
-  // Use value
-}
+
+  switch(value) {
+    case 1: 
+    { // Compliant, limits the scope or result
+       int result = compute(value);
+       save(result);
+       log();
+    }
+    break;
+    case 2:
+    // ...
+  }
 ----
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
Make the description more C++-oriented
Change the example (the previous one is now going to be compliant)