### PR TITLE
Replace remediation 'mn' with 'min'

### DIFF
--- a/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
+++ b/rspec-tools/rspec_tools/validation/rule-metadata-schema.json
@@ -258,7 +258,7 @@
   "definitions": {
     "time": {
       "type": "string",
-      "pattern": "^[ ]*[0-9]+[ ]*(mn|min|h|d)$"
+      "pattern": "^[ ]*[0-9]+[ ]*(min|h|d)$"
     }
   }
 }

--- a/rules/S1008/cfamily/metadata.json
+++ b/rules/S1008/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S1021/cfamily/metadata.json
+++ b/rules/S1021/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S1076/metadata.json
+++ b/rules/S1076/metadata.json
@@ -5,7 +5,7 @@
   "remediation": {
     "func": "Linear",
     "linearDesc": null,
-    "linearFactor": "10mn"
+    "linearFactor": "10min"
   },
   "tags": [
 

--- a/rules/S110/metadata.json
+++ b/rules/S110/metadata.json
@@ -6,7 +6,7 @@
     "func": "Linear with offset",
     "linearDesc": "Number of parents above the defined threshold",
     "linearOffset": "4h",
-    "linearFactor": "30mn"
+    "linearFactor": "30min"
   },
   "tags": [
     "design"

--- a/rules/S1173/metadata.json
+++ b/rules/S1173/metadata.json
@@ -5,7 +5,7 @@
   "remediation": {
     "func": "Linear",
     "linearDesc": null,
-    "linearFactor": "10mn"
+    "linearFactor": "10min"
   },
   "tags": [
 

--- a/rules/S1230/metadata.json
+++ b/rules/S1230/metadata.json
@@ -5,7 +5,7 @@
   "remediation": {
     "func": "Linear",
     "linearDesc": null,
-    "linearFactor": "30mn"
+    "linearFactor": "30min"
   },
   "tags": [
 

--- a/rules/S137/metadata.json
+++ b/rules/S137/metadata.json
@@ -5,7 +5,7 @@
   "remediation": {
     "func": "Linear",
     "linearDesc": null,
-    "linearFactor": "10mn"
+    "linearFactor": "10min"
   },
   "tags": [
 

--- a/rules/S1613/php/metadata.json
+++ b/rules/S1613/php/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "20 mn"
+    "constantCost": "20min"
   },
   "tags": [
     "security"

--- a/rules/S1646/metadata.json
+++ b/rules/S1646/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
 

--- a/rules/S1689/cobol/metadata.json
+++ b/rules/S1689/cobol/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "15mn"
+    "constantCost": "15min"
   },
   "tags": [
 

--- a/rules/S1727/cobol/metadata.json
+++ b/rules/S1727/cobol/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "30 mn"
+    "constantCost": "30min"
   },
   "tags": [
 

--- a/rules/S1730/metadata.json
+++ b/rules/S1730/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5mn"
+    "constantCost": "5min"
   },
   "tags": [
     "convention"

--- a/rules/S1748/cobol/metadata.json
+++ b/rules/S1748/cobol/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "convention"

--- a/rules/S1847/metadata.json
+++ b/rules/S1847/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
     "performance"

--- a/rules/S1974/metadata.json
+++ b/rules/S1974/metadata.json
@@ -5,7 +5,7 @@
   "remediation": {
     "func": "Linear",
     "linearDesc": "uncovered lines to reach the threshold",
-    "linearFactor": "5mn"
+    "linearFactor": "5min"
   },
   "tags": [
     "bad-practice"

--- a/rules/S2244/abap/metadata.json
+++ b/rules/S2244/abap/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5mn"
+    "constantCost": "5min"
   },
   "tags": [
     "performance"

--- a/rules/S2662/metadata.json
+++ b/rules/S2662/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
     "bug"

--- a/rules/S2669/cfamily/metadata.json
+++ b/rules/S2669/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
     "bug"

--- a/rules/S3955/metadata.json
+++ b/rules/S3955/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
 

--- a/rules/S4084/html/metadata.json
+++ b/rules/S4084/html/metadata.json
@@ -4,7 +4,7 @@
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5mn"
+    "constantCost": "5min"
   },
   "tags": [
     "accessibility",

--- a/rules/S4517/java/metadata.json
+++ b/rules/S4517/java/metadata.json
@@ -4,7 +4,7 @@
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10 mn"
+    "constantCost": "10min"
   },
   "tags": [
 

--- a/rules/S4645/html/metadata.json
+++ b/rules/S4645/html/metadata.json
@@ -4,7 +4,7 @@
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
 

--- a/rules/S809/cfamily/metadata.json
+++ b/rules/S809/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S816/cfamily/metadata.json
+++ b/rules/S816/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5mn"
+    "constantCost": "5min"
   },
   "tags": [
     "misra"

--- a/rules/S821/cfamily/metadata.json
+++ b/rules/S821/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S827/cfamily/metadata.json
+++ b/rules/S827/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S843/cfamily/metadata.json
+++ b/rules/S843/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S852/cfamily/metadata.json
+++ b/rules/S852/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S887/cfamily/metadata.json
+++ b/rules/S887/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
     "misra"

--- a/rules/S906/cfamily/metadata.json
+++ b/rules/S906/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5mn"
+    "constantCost": "5min"
   },
   "tags": [
     "misra"

--- a/rules/S915/cfamily/metadata.json
+++ b/rules/S915/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "20mn"
+    "constantCost": "20min"
   },
   "tags": [
     "misra"

--- a/rules/S918/metadata.json
+++ b/rules/S918/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10mn"
+    "constantCost": "10min"
   },
   "tags": [
 

--- a/rules/S931/cfamily/metadata.json
+++ b/rules/S931/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "2mn"
+    "constantCost": "2min"
   },
   "tags": [
 


### PR DESCRIPTION
Some plugins contains manual workaround to replace "mn" with "min". We can fix this directly in the source now.

Most of the rules already use "min"