### PR TITLE
Modify rule S6423: Swap arguments in LogError call in compliant solution

### DIFF
--- a/rules/S6423/csharp/rule.adoc
+++ b/rules/S6423/csharp/rule.adoc
@@ -42,7 +42,7 @@ public static async Task<IActionResult> Run(
 	}
 	catch (Exception ex)
 	{
-		log.LogError("Give details that will help investigations", ex);
+		log.LogError(ex, "Give details that will help investigations");
 	}
 }
 ----


### PR DESCRIPTION
The LogError call in the compliant section is compiling, but it picks the wrong overload:

`LogError(ILogger, Exception, String, Object[])` should be called, but 
`LogError(ILogger, String, Object[])` is called instead.

Fixes https://community.sonarsource.com/t/67647/2