### PR TITLE
Modify rule S5768: Remove broken link

### DIFF
--- a/rules/S5768/abap/rule.adoc
+++ b/rules/S5768/abap/rule.adoc
@@ -39,7 +39,6 @@ ENDIF.
 
 == See
 
-* https://archive.sap.com/documents/docs/DOC-46714[Best Practice Guide - Considerations for Custom ABAP Code During a Migration to SAP HANA]
 * https://help.sap.com/doc/saphelp_nw70/7.0.31/en-US/aa/4734940f1c11d295380000e8353423/content.htm?no_cache=true[SAP documentation - Keep the Result Set Small]
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
The link to the document is no longer available on SAP. The document linked was probably this one:

https://fdocuments.in/document/best-practice-guidecustom-abap-code-transition-to-sap-hana.html?page=1

The document gives only high-level performance advice. The rule violation is not part of the document. The link can be removed.