### PR TITLE
Modify rule S1488: Remove Javascript/Typescript from the Sonar way profile

### DIFF
--- a/rules/S1488/javascript/metadata.json
+++ b/rules/S1488/javascript/metadata.json
@@ -1,6 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way"
   ],
   "scope": "Main",
   "quickfix": "covered"


### PR DESCRIPTION
Remove S1488 for Javascript/Typescript from the Sonar way profile