### PR TITLE
Modify rule S1117: Remove rule for JavaScript/TypeScript from profile Sonar way

### DIFF
--- a/rules/S1117/javascript/metadata.json
+++ b/rules/S1117/javascript/metadata.json
@@ -1,6 +1,5 @@
 {
   "defaultQualityProfiles": [
-    "Sonar way"
   ],
   "scope": "Main"
 }


### PR DESCRIPTION
Modify rule S1117: Remove rule for JavaScript/TypeScript from profile Sonar way