### PR TITLE
Modify rules S6424 and S6420: Change titles

### DIFF
--- a/rules/S6420/csharp/metadata.json
+++ b/rules/S6420/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Client instances should not be created repeatedly on each Azure Function invocation",
+  "title": "Client instances should not be recreated on each Azure Function invocation",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S6420/csharp/metadata.json
+++ b/rules/S6420/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Reuse client instances rather than creating new ones with each Azure Function invocation",
+  "title": "Client instances should not be created repeatedly on each Azure Function invocation",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S6424/csharp/metadata.json
+++ b/rules/S6424/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Azure Functions: Restrictions on entity interfaces",
+  "title": "Interfaces for durable entities should satisfy the restrictions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
Some new rules for Azure Functions don't follow the *X shou [not] Y* naming scheme.