### PR TITLE
Modify rule S1186: Add exception for empty functions.

### DIFF
--- a/rules/S1186/javascript/rule.adoc
+++ b/rules/S1186/javascript/rule.adoc
@@ -27,6 +27,23 @@ var foo = () => {
 };
 ----
 
+== Exceptions
+
+* This rule does not apply to function expressions and arrow functions as they can denote default values.
+
+----
+static defaultProps = {
+  listStyle: () => {}
+};
+----
+
+* The rule allows for empty functions with a name starting with the prefix ``++on++`` like ``++onClick++``.
+
+----
+function onClick() {
+}
+----
+
 ifdef::env-github,rspecator-view[]
 
 '''


### PR DESCRIPTION
Fixes SonarSource/SonarJS#3241