### PR TITLE
Modify rule S3358: Add exception for JSX expressions.

### DIFF
--- a/rules/S3358/javascript/rule.adoc
+++ b/rules/S3358/javascript/rule.adoc
@@ -42,6 +42,7 @@ endif::env-github,rspecator-view[]
 
 This rule does not apply in JSX expressions to support conditional rendering and conditional attributes.
 
+[source,javascript]
 ----
 return (
 <>


### PR DESCRIPTION
Fixes SonarSource/SonarJS#3244