### PR TITLE
Modify rule S1186: Add exception for empty functions.

### DIFF
--- a/rules/S1186/javascript/rule.adoc
+++ b/rules/S1186/javascript/rule.adoc
@@ -31,6 +31,7 @@ var foo = () => {
 
 * This rule does not apply to function expressions and arrow functions as they can denote default values.
 
+[source,javascript]
 ----
 static defaultProps = {
   listStyle: () => {}
@@ -39,6 +40,7 @@ static defaultProps = {
 
 * The rule allows for empty functions with a name starting with the prefix ``++on++`` like ``++onClick++``.
 
+[source,javascript]
 ----
 function onClick() {
 }


### PR DESCRIPTION
Fixes SonarSource/SonarJS#3241