### PR TITLE
Update rule.adoc (typeof BigInt is "bigint", not "BigInt")

### DIFF
--- a/rules/S4125/javascript/rule.adoc
+++ b/rules/S4125/javascript/rule.adoc
@@ -9,7 +9,7 @@ The ``++typeof++`` operator returns a string indicating the type of its argument
 * "symbol" (since ECMAScript 2015)
 * "function"
 * "object" (for ``++null++`` and any other object)
-* "BigInt" (since ECMAScript 2020)
+* "bigint" (since ECMAScript 2020)
 
 Compare a ``++typeof++`` expression to anything else, and the result is predefined: ``++false++``.
 


### PR DESCRIPTION
The `typeof` return value for a BigInt is `"bigint"`, not `"BigInt"`