### PR TITLE
[APPSEC-80] Modify rule S5334: Educational content (C#)

### DIFF
--- a/rules/S5334/common/fix/introduction.adoc
+++ b/rules/S5334/common/fix/introduction.adoc
@@ -5,6 +5,6 @@ Anything that can be done via dynamic code execution can usually be done via
 a language's native SDK and static code. +
 Therefore, our suggestion is to avoid executing code dynamically. +
 If the application requires the execution of dynamic code, you should make sure
-that the code does not contain any user-controlled data. Data can be passed
+that the code does not contain any concatenated user-controlled data. Data can be passed
 safely to the dynamic code as a method parameter by the application.
 

--- a/rules/S5334/common/fix/introduction.adoc
+++ b/rules/S5334/common/fix/introduction.adoc
@@ -3,7 +3,8 @@ it solves.
 
 Anything that can be done via dynamic code execution can usually be done via
 a language's native SDK and static code. +
-Therefore, our first suggestion is to avoid executing code dynamically. +
-However, if the application requires executing code with user-controlled data,
-here are some security suggestions.
+Therefore, our suggestion is to avoid executing code dynamically. +
+If the application requires the execution of dynamic code, you should make sure
+that the code does not contain any user-controlled data. Data can be passed
+safely to the dynamic code as a method parameter by the application.
 

--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -56,7 +56,7 @@ public class ExampleController : Controller
         var compilerParameters = new CompilerParameters { ReferencedAssemblies = { "System.dll", "System.Runtime.dll" } };
         var compilerResults = provider.CompileAssemblyFromSource(compilerParameters, code);
         object myInstance = compilerResults.CompiledAssembly.CreateInstance("MyClass");
-        myInstance.GetType().GetMethod("MyMethod").Invoke(myInstance, new object[]{ message });
+        myInstance.GetType().GetMethod("MyMethod").Invoke(myInstance, new object[]{ message }); // Pass message to dynamic method
     }
 }
 ----

--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -1,7 +1,5 @@
 === How to fix it in .NET
 
-include::../../common/fix/code-rationale.adoc[]
-
 [cols="a"]
 |===
 h| Non-compliant code example

--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -15,6 +15,7 @@ public class ExampleController : Controller
     public void Run(string message)
     {
         string code = @"
+            using System;
 			public class MyClass
 			{
                 public void MyMethod()
@@ -43,6 +44,7 @@ public class ExampleController : Controller
     public void Run(string message)
     {
         const string code = @"
+            using System;
 			public class MyClass
 			{
                 public void MyMethod(string input)

--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -66,5 +66,3 @@ public class ExampleController : Controller
 
 include::../../common/fix/introduction.adoc[]
 
-include::../../common/fix/pre-approved-list.adoc[]
-

--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -1,0 +1,70 @@
+=== How to fix it in .NET
+
+include::../../common/fix/code-rationale.adoc[]
+
+[cols="a"]
+|===
+h| Non-compliant code example
+|
+[source,csharp]
+----
+using System.CodeDom.Compiler;
+
+public class ExampleController : Controller
+{
+    public void Run(string message)
+    {
+        string code = @"
+			public class MyClass
+			{
+                public void MyMethod()
+                {
+                    Console.WriteLine(""" + message + @""");
+                }
+            }
+        ";
+
+        var provider = CodeDomProvider.CreateProvider("CSharp");
+        var compilerParameters = new CompilerParameters { ReferencedAssemblies = { "System.dll", "System.Runtime.dll" } };
+        var compilerResults = provider.CompileAssemblyFromSource(compilerParameters, code); // Noncompliant
+        object myInstance = compilerResults.CompiledAssembly.CreateInstance("MyClass");
+        myInstance.GetType().GetMethod("MyMethod").Invoke(myInstance, new object[0]);
+    }
+}
+----
+h| Compliant solution
+|
+[source,csharp]
+----
+using System.CodeDom.Compiler;
+
+public class ExampleController : Controller
+{
+    public void Run(string message)
+    {
+        const string code = @"
+			public class MyClass
+			{
+                public void MyMethod(string input)
+                {
+                    Console.WriteLine(input);
+                }
+            }
+        ";
+
+        var provider = CodeDomProvider.CreateProvider("CSharp");
+        var compilerParameters = new CompilerParameters { ReferencedAssemblies = { "System.dll", "System.Runtime.dll" } };
+        var compilerResults = provider.CompileAssemblyFromSource(compilerParameters, code);
+        object myInstance = compilerResults.CompiledAssembly.CreateInstance("MyClass");
+        myInstance.GetType().GetMethod("MyMethod").Invoke(myInstance, new object[]{ message });
+    }
+}
+----
+|===
+
+=== How does this work?
+
+include::../../common/fix/introduction.adoc[]
+
+include::../../common/fix/pre-approved-list.adoc[]
+

--- a/rules/S5334/csharp/rule.adoc
+++ b/rules/S5334/csharp/rule.adoc
@@ -6,7 +6,7 @@ include::../impact.adoc[]
 
 == How to fix it?
 
-
+include::how-to-fix-it/dotnet.adoc[]
 
 == Resources
 


### PR DESCRIPTION
I decided against using the "pre-approved" fix because it is not realistic. Instead I tried to come up with a way to get user input into dynamic code without making it part of the code. I will rework the Java code sample and do the same there.