### PR TITLE
Modify rules: Add "azure" tag to "Azure Functions" rules

### DIFF
--- a/rules/S6419/csharp/metadata.json
+++ b/rules/S6419/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "1h"
   },
   "tags": [
+    "azure",
     "bad-practice"
   ],
   "defaultSeverity": "Major",

--- a/rules/S6420/csharp/metadata.json
+++ b/rules/S6420/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [
+    "azure",
     "bad-practice",
     "design"
   ],

--- a/rules/S6421/csharp/metadata.json
+++ b/rules/S6421/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "1min"
   },
   "tags": [
+    "azure",
     "error-handling"
   ],
   "defaultSeverity": "Major",

--- a/rules/S6422/csharp/metadata.json
+++ b/rules/S6422/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "10min"
   },
   "tags": [
+    "azure",
     "async-await"
   ],
   "defaultSeverity": "Blocker",

--- a/rules/S6423/csharp/metadata.json
+++ b/rules/S6423/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [
+    "azure",
     "error-handling"
   ],
   "defaultSeverity": "Major",

--- a/rules/S6424/csharp/metadata.json
+++ b/rules/S6424/csharp/metadata.json
@@ -7,6 +7,7 @@
     "constantCost": "30min"
   },
   "tags": [
+    "azure",
     "design"
   ],
   "defaultSeverity": "Blocker",


### PR DESCRIPTION
The PR adds the missing "azure" tag to the rules for "Azure Functions". The list of rules is taken from
https://sonarsource.atlassian.net/browse/MMF-2699

See also https://sonarsource.slack.com/archives/C012KBFFYD6/p1661180705206739