### PR TITLE
checklinks.py Fix broken Accept header

### DIFF
--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -70,7 +70,7 @@ def live_url(url: str, timeout=5):
                                                   'sec-ch-ua-mobile': '?0',
                                                   'Upgrade-Insecure-Requests': '1',
                                                   'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36',
-                                                  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3,q=0.9',
+                                                  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
                                                   'Sec-Fetch-Site':'none',
                                                   'Sec-Fetch-Mode':'navigate',
                                                   'Sec-Fetch-User':'?1',

--- a/rules/S6336/recommended.adoc
+++ b/rules/S6336/recommended.adoc
@@ -6,6 +6,6 @@ As a consequence, AccessKeys should not be stored along with the application cod
 
 AccessKeys should be stored outside of the code in a file that is never committed to your application code repository.
 
-If possible, a better alternative is to use your cloud provider's service for managing secrets. On AlibabaCloud this service is called https://www.alibabacloud.com/help/doc-detail/152001.htm[Secrets Manager].
+If possible, a better alternative is to use your cloud provider's service for managing secrets. On AlibabaCloud this service is called https://www.alibabacloud.com/help/en/key-management-service/latest/secrets-manager-overview[Secrets Manager].
 
 When credentials are disclosed in the application code, consider them as compromised and revoke them immediately.

--- a/rules/S6336/recommended.adoc
+++ b/rules/S6336/recommended.adoc
@@ -6,6 +6,6 @@ As a consequence, AccessKeys should not be stored along with the application cod
 
 AccessKeys should be stored outside of the code in a file that is never committed to your application code repository.
 
-If possible, a better alternative is to use your cloud provider's service for managing secrets. On AlibabaCloud this service is called https://www.alibabacloud.com/help/en/key-management-service/latest/secrets-manager-overview[Secrets Manager].
+If possible, a better alternative is to use your cloud provider's service for managing secrets. On AlibabaCloud this service is called https://www.alibabacloud.com/help/doc-detail/152001.htm[Secrets Manager].
 
 When credentials are disclosed in the application code, consider them as compromised and revoke them immediately.


### PR DESCRIPTION
There is a typo in the accept header of the script. Most servers seem to be fine with it, but https://www.alibabacloud.com/help/en/key-management-service/latest/secrets-manager-overview returned

`HTTP Error 406: Not Acceptable`

with the broken accept-header. I updated the header using the F12 tools from google chrome.

The status code and Accept header can be checked via curl:
```sh
curl --insecure -H "Accept:text/html" -sSL -D - https://www.alibabacloud.com/help/en/key-management-service/latest/secrets-manager-overview -o /dev/null

curl --insecure -H "Accept:broken" -sSL -D - https://www.alibabacloud.com/help/en/key-management-service/latest/secrets-manager-overview -o /dev/null
```