### PR TITLE
Modify rule S1313: Add exceptions for ranges used for documentation purposes

### DIFF
--- a/rules/S1313/csharp/rule.adoc
+++ b/rules/S1313/csharp/rule.adoc
@@ -19,7 +19,16 @@ var ip = ConfigurationManager.AppSettings["myapplication.ip"];
 var address = IPAddress.Parse(ip);
 ----
 
-include::../exceptions.adoc[]
+== Exceptions
+
+No issue is reported for the following cases because they are not considered sensitive:
+
+* Loopback addresses 127.0.0.0/8 in CIDR notation (from 127.0.0.0 to 127.255.255.255)
+* Broadcast address 255.255.255.255
+* Non-routable address 0.0.0.0
+* Strings of the form ``++2.5.<number>.<number>++`` as they http://www.oid-info.com/introduction.htm[often match Object Identifiers] (OID)
+* Addresses in the ranges 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc5737[RFC 5737]
+* Addresses in the range 2001:db8::/32, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc3849[RFC 3849]
 
 include::../see.adoc[]
 

--- a/rules/S1313/vbnet/rule.adoc
+++ b/rules/S1313/vbnet/rule.adoc
@@ -19,7 +19,16 @@ Dim ip = ConfigurationManager.AppSettings("myapplication.ip") ' Compliant
 Dim address = IPAddress.Parse(ip)
 ----
 
-include::../exceptions.adoc[]
+== Exceptions
+
+No issue is reported for the following cases because they are not considered sensitive:
+
+* Loopback addresses 127.0.0.0/8 in CIDR notation (from 127.0.0.0 to 127.255.255.255)
+* Broadcast address 255.255.255.255
+* Non-routable address 0.0.0.0
+* Strings of the form ``++2.5.<number>.<number>++`` as they http://www.oid-info.com/introduction.htm[often match Object Identifiers] (OID)
+* Addresses in the ranges 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc5737[RFC 5737]
+* Addresses in the range 2001:db8::/32, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc3849[RFC 3849]
 
 include::../see.adoc[]
 


### PR DESCRIPTION
Implementation ticket: https://github.com/SonarSource/sonar-dotnet/issues/6064

This change is separated by language because the different languages will not implement the exception at the same time.