### PR TITLE
Modify rule S5764: Remove and replace broken link

### DIFF
--- a/rules/S5764/java/rule.adoc
+++ b/rules/S5764/java/rule.adoc
@@ -51,8 +51,7 @@ public class Compliant {
 
 == See
 
-* Java Performance Tuning Guide - http://java-performance.info/java-io-bufferedinputstream-and-java-util-zip-gzipinputstream/[java.io.BufferedInputStream and java.util.zip.GZIPInputStream]
-
+* Stackoverflow question about usage of GZIPInputStream and the BufferedInputStream - https://stackoverflow.com/questions/4438085/seeking-out-the-optimum-size-for-bufferedinputstream-in-java/4438217#4438217[GZIPInputStream and the BufferedInputStream]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
The original link talking about the rationale of the rule is no longer active. Following the discussion [here](https://sonarsource.atlassian.net/browse/RSPEC-5764) I have replaced the link.