### PR TITLE
Modify S1117: Deprecate rule for PHP

### DIFF
--- a/rules/S1117/php/metadata.json
+++ b/rules/S1117/php/metadata.json
@@ -1,3 +1,5 @@
 {
-  "title": "Local variables should not have the same name as class fields"
+  "title": "Local variables should not have the same name as class fields",
+  "defaultQualityProfiles": [],
+  "status": "deprecated"
 }


### PR DESCRIPTION
We decided to drop the rule for PHP based on discussion triggered by https://community.sonarsource.com/t/whats-the-logic-behind-php-s1117/68963