### PR TITLE
Modify rule S4421: Remove EXTRACT from the list of deprecated functions.

### DIFF
--- a/rules/S4421/plsql/rule.adoc
+++ b/rules/S4421/plsql/rule.adoc
@@ -16,7 +16,6 @@ The following features are deprecated in Oracle 12:
 |USER_SCHEDULER_CREDENTIALS | DBA_HOST_ACES
 |V$OBJECT_USAGE | USER_OBJECT_USAGE
 |SYS_XMLGEN | SQL/XML-generation functions
-|EXTRACT| XMLQUERY
 |EXISTSNODE | XMLEXISTS
 |DELETEXML| XQuery Update
 |APPENDCHILDXML | XQuery Update


### PR DESCRIPTION
EXTRACT was removed from the rule for now, as it was creating false positives.