### PR TITLE
Modify rule S1313: Add exceptions for IPv6 ranges used for documentation purposes

### DIFF
--- a/rules/S1313/swift/rule.adoc
+++ b/rules/S1313/swift/rule.adoc
@@ -25,6 +25,7 @@ No issue is reported for the following cases because they are not considered sen
 * Broadcast address 255.255.255.255
 * Non-routable address 0.0.0.0
 * Addresses in the ranges 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc5737[RFC 5737]
+* Addresses in the range 2001:db8::/32, reserved for documentation purposes by https://datatracker.ietf.org/doc/html/rfc3849[RFC 3849]
 
 include::../see.adoc[]
 


### PR DESCRIPTION
Fixes https://sonarsource.atlassian.net/browse/SONARSWIFT-527