### PR TITLE
Deprecate Rule css:S5362 (`function-calc-no-invalid`)

### DIFF
--- a/rules/S5362/css/metadata.json
+++ b/rules/S5362/css/metadata.json
@@ -1,14 +1,12 @@
 {
   "title": "Expressions within \"calc\" should be valid",
   "type": "BUG",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
 
@@ -21,8 +19,6 @@
   "ruleSpecification": "RSPEC-5362",
   "sqKey": "S5362",
   "scope": "All",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
Fixes https://github.com/SonarSource/SonarJS/issues/3470