### PR TITLE
Modify rule S1694 (CS): correct code comment in sample

### DIFF
--- a/rules/S1694/csharp/rule.adoc
+++ b/rules/S1694/csharp/rule.adoc
@@ -16,7 +16,7 @@ public abstract class Animal //Noncompliant; should be an interface
   abstract void Feed();
 }
 
-public abstract class Color //Noncompliant; should be concrete with a private constructor
+public abstract class Color //Noncompliant; should be concrete with a protected constructor
 {
   private int red = 0;
   private int green = 0;


### PR DESCRIPTION
The comment is misleading as a private constructor is too restrictive.