### PR TITLE
Modify rule S6258: Add new Terraform code sample

### DIFF
--- a/rules/S6258/terraform/rule.adoc
+++ b/rules/S6258/terraform/rule.adoc
@@ -118,7 +118,7 @@ resource "google_container_cluster" "example" {
 For Amazon https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket[S3 access requests]:
 [source,terraform]
 ----
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "example-logs" {
   bucket = "example_logstorage"
   acl    = "log-delivery-write"
 }
@@ -126,10 +126,17 @@ resource "aws_s3_bucket" "example" {
 resource "aws_s3_bucket" "example" {
   bucket = "example"
 
-  logging {
-      target_bucket = "example_logstorage"
+  logging { # AWS provider <= 3
+      target_bucket = aws_s3_bucket.example-logs.id
       target_prefix = "log/example"
   }
+}
+
+resource "aws_s3_bucket_logging" "example" { # AWS provider >= 4
+  bucket = aws_s3_bucket.example.id
+
+  target_bucket = aws_s3_bucket.example-logs.id
+  target_prefix = "log/example"
 }
 ----
 


### PR DESCRIPTION
Implementation ticket: https://sonarsource.atlassian.net/browse/SONARIAC-418

The new implementation does not raise an issue for AWS provider >= 4, so the issues reported for this rule will slowly dry out. Since there are already a lot of code samples for this rule, I decided to combine the compliant solution for both versions.