### PR TITLE
Modify rule S6245: Add new Terraform code sample

### DIFF
--- a/rules/S6245/terraform/rule.adoc
+++ b/rules/S6245/terraform/rule.adoc
@@ -8,26 +8,46 @@ include::../recommended.adoc[]
 
 Server-side encryption is not used:
 
+[source,terraform]
 ----
-resource "aws_s3_bucket" "mynoncompliantbucket" {
-  bucket = "mynoncompliantbucket"
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
 }
 ----
 
 == Compliant Solution
 
-Server-side encryption with Amazon S3-Managed Keys is used:
+Server-side encryption with Amazon S3-managed keys is used for AWS provider version 3 or below:
 
 [source,terraform]
 ----
-resource "aws_s3_bucket" "mycompliantbucket" {
-  bucket = "mycompliantbucket"
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
 
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
+        sse_algorithm = "AES256"
       }
+    }
+  }
+}
+----
+
+Server-side encryption with Amazon S3-managed keys is used for AWS provider version 4 or above:
+
+[source,terraform]
+----
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+  bucket = aws_s3_bucket.example.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/rules/S6245/terraform/rule.adoc
+++ b/rules/S6245/terraform/rule.adoc
@@ -10,7 +10,7 @@ Server-side encryption is not used:
 
 [source,terraform]
 ----
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "example" { # Sensitive
   bucket = "example"
 }
 ----


### PR DESCRIPTION
Implementation ticket: https://sonarsource.atlassian.net/browse/SONARIAC-417

The new implementation does not raise an issue for AWS provider >= 4, so the issues reported for this rule will slowly dry out. At some point, we can deprecate and remove this rule unless the detection logic gets improved.