### PR TITLE
Update S3871: Fix whitespace

### DIFF
--- a/rules/S3871/csharp/rule.adoc
+++ b/rules/S3871/csharp/rule.adoc
@@ -25,7 +25,5 @@ public class MyException : Exception
 
 
 include::../exceptions.adoc[]
-
 include::../see.adoc[]
-
 include::../rspecator.adoc[]

--- a/rules/S3871/csharp/rule.adoc
+++ b/rules/S3871/csharp/rule.adoc
@@ -25,5 +25,7 @@ public class MyException : Exception
 
 
 include::../exceptions.adoc[]
+
 include::../see.adoc[]
+
 include::../rspecator.adoc[]

--- a/rules/S3871/exceptions.adoc
+++ b/rules/S3871/exceptions.adoc
@@ -1,3 +1,4 @@
+
 == Exceptions
 
 This rule ignores Exception types that are not derived directly from `System.Exception`, `System.SystemException`, or `System.ApplicationException`.

--- a/rules/S3871/see.adoc
+++ b/rules/S3871/see.adoc
@@ -2,5 +2,3 @@
 == See
 
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring
-
-

--- a/rules/S3871/see.adoc
+++ b/rules/S3871/see.adoc
@@ -1,3 +1,4 @@
+
 == See
 
 * https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring[OWASP Top 10 2017 Category A10] - Insufficient Logging & Monitoring

--- a/rules/S3871/vbnet/rule.adoc
+++ b/rules/S3871/vbnet/rule.adoc
@@ -28,5 +28,7 @@ End Class
 ----
 
 include::../exceptions.adoc[]
+
 include::../see.adoc[]
+
 include::../rspecator.adoc[]

--- a/rules/S3871/vbnet/rule.adoc
+++ b/rules/S3871/vbnet/rule.adoc
@@ -28,7 +28,5 @@ End Class
 ----
 
 include::../exceptions.adoc[]
-
 include::../see.adoc[]
-
 include::../rspecator.adoc[]


### PR DESCRIPTION
Rule API has some inconsistent whitespace handling. 
Bug filed here: https://sonarsource.atlassian.net/jira/software/c/projects/RULEAPI/issues/RULEAPI-772

This workaround demonstrates itself like this in VB file: https://github.com/SonarSource/sonar-dotnet/pull/5822/commits/af6634cc3593c861a2bf1f2a26828533839526e5