### PR TITLE
Modify Rule S5334(Csharp): Fix sample typo

### DIFF
--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -13,7 +13,7 @@ public class ExampleController : Controller
 {
     public void Run(string message)
     {
-        string code = @"
+        const string code = @"
             using System;
             public class MyClass
             {


### PR DESCRIPTION
Gets rid of [unnecessary diffing colors in SQ](https://next.sonarqube.com/sonarqube/coding_rules?q=S5334&open=roslyn.sonaranalyzer.security.cs%3AS5334).