### PR TITLE
Fix broken links in `feature/education`

### DIFF
--- a/rules/S5764/java/rule.adoc
+++ b/rules/S5764/java/rule.adoc
@@ -51,8 +51,7 @@ public class Compliant {
 
 == See
 
-* Java Performance Tuning Guide - http://java-performance.info/java-io-bufferedinputstream-and-java-util-zip-gzipinputstream/[java.io.BufferedInputStream and java.util.zip.GZIPInputStream]
-
+* Stackoverflow question about usage of GZIPInputStream and the BufferedInputStream - https://stackoverflow.com/questions/4438085/seeking-out-the-optimum-size-for-bufferedinputstream-in-java/4438217#4438217[GZIPInputStream and the BufferedInputStream]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5768/abap/rule.adoc
+++ b/rules/S5768/abap/rule.adoc
@@ -39,7 +39,6 @@ ENDIF.
 
 == See
 
-* https://archive.sap.com/documents/docs/DOC-46714[Best Practice Guide - Considerations for Custom ABAP Code During a Migration to SAP HANA]
 * https://help.sap.com/doc/saphelp_nw70/7.0.31/en-US/aa/4734940f1c11d295380000e8353423/content.htm?no_cache=true[SAP documentation - Keep the Result Set Small]
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
I cherry-picked some commits from master to fix the "Validate links" check for education PRs.