### PR TITLE
Modify rule S5945: Add constexpr exception and fix typos (CPP-3873)

### DIFF
--- a/rules/S5945/cfamily/rule.adoc
+++ b/rules/S5945/cfamily/rule.adoc
@@ -46,7 +46,6 @@ This rule will not report these uses of C-style arrays:
 
  * in `extern "C"` code, since those arrays are often required here for compatibility with external code;
  * in `constexpr` contexts, since using `std::string` is not straightforward at all because the string cannot escape the `constexpr` scope;
- * in the arguments of `main`, since their types are mandated by the standard;
  * when using a constant array of characters with no explicit size, such as `const char str[] = "a string literal";`, since the alternative would require an unnecessary heap allocation.
 
 

--- a/rules/S5945/cfamily/rule.adoc
+++ b/rules/S5945/cfamily/rule.adoc
@@ -33,9 +33,9 @@ void f() {
 void f() {
   std::array<int, 10> a1; // If the size really is a constant
   // Or
-  std::vector<int>a2; // For variable size
+  std::vector<int> a2; // For variable size
 
-  auto s = "Hello!"; // Compliant by exception
+  auto s = "Hello!"; // Compliant: the type of "s" is not an array.
 }
 ----
 
@@ -46,7 +46,8 @@ This rule will not report these uses of C-style arrays:
 
  * in `extern "C"` code, since those arrays are often required here for compatibility with external code;
  * in `constexpr` contexts, since using `std::string` is not straightforward at all because the string cannot escape the `constexpr` scope;
- * in the arguments of `main`, since their types are mandated by the standard.
+ * in the arguments of `main`, since their types are mandated by the standard;
+ * when using a constant array of characters with no explicit size, such as `const char str[] = "a string literal";`, since the alternative would require an unnecessary heap allocation.
 
 
 == Resources

--- a/rules/S5945/cfamily/rule.adoc
+++ b/rules/S5945/cfamily/rule.adoc
@@ -6,14 +6,14 @@ C-style arrays (such as ``++int i[10]++``) are not very convenient to use:
 * If the number of elements in the array can vary, it will lead to manual memory allocation (or people will use fixed-size arrays that "should be large enough", which is both a waste of memory and a limitation of the program)
 * It is very easy to lose the size of the array since an array passed to a function decays into a pointer
 
-The {cpp} standard library proposes two types that are better than C-style arrays and together cover all the use cases of C-style arrays:
+The {cpp} standard library proposes a few types that are better than C-style arrays and together cover all the use cases of C-style arrays:
 
-* For fixed-size arrays, where the memory is on the stack, use ``++std::array++``. It is like a C-style array, except that it has a normal argument passing semantic, and the size is always a part of the type. If ``++std::array++`` is not available to you (before {cpp}11), you can roll your own version.
+* For fixed-size arrays, where the memory is on the stack, use ``++std::array++``. It is like a C-style array, except that it has normal argument passing semantics, and the size is always a part of the type. If ``++std::array++`` is not available to you (before {cpp}11), you can roll your own version.
 * For variable-size arrays, use ``++std::vector++``. It can be resized and handles memory allocation transparently.
 * For character strings, you should use ``++std::string++`` instead of arrays of characters.
-* For arrays of characters that are not strings (e.g., alphabet, exit codes, keyboard control list) perfer ``++std::array++`` or ``++std::vector++`` as per the first two bullets.
+* For arrays of characters that are not strings (e.g., alphabet, exit codes, keyboard control list), prefer ``++std::array++`` or ``++std::vector++`` as per the first two bullets.
 
-The rule S945 is related to this rule but focuses on passing arguments of an array type. S5025 will flag the use of dynamic memory allocation that could be replaced by ``++std::vector++``.
+The rule S945 is related to this rule but focuses on passing arguments of an array type. S5025 flags the use of dynamic memory allocation that could be replaced by ``++std::vector++``.
 
 
 === Noncompliant code example
@@ -42,7 +42,11 @@ void f() {
 
 === Exceptions
 
-This rule will not report the use of C-style arrays in ``++extern "C"++`` code (since those arrays are often required here for compatibility with external code) and in the arguments of ``++main++``.
+This rule will not report these uses of C-style arrays:
+
+ * in `extern "C"` code, since those arrays are often required here for compatibility with external code;
+ * in `constexpr` contexts, since using `std::string` is not straightforward at all because the string cannot escape the `constexpr` scope;
+ * in the arguments of `main`, since their types are mandated by the standard.
 
 
 == Resources


### PR DESCRIPTION
Related to CPP-3873 & SonarSource/sonar-cpp#2263.

I started fixing typos and went on to add the exception for `constexpr`. @alejandro-alvarez-sonarsource, This should be merged once your PR is merged.