### PR TITLE
Modify rule S3456: Raise on ReadOnlySpan.ToArray() 

### DIFF
--- a/rules/S3456/csharp/highlighting.adoc
+++ b/rules/S3456/csharp/highlighting.adoc
@@ -1,6 +1,6 @@
 === Highlighting
 
-- ``ToCharArray()``
+- `ToCharArray()`
 
-- ``ToArray()``
+- `ToArray()`
 

--- a/rules/S3456/csharp/highlighting.adoc
+++ b/rules/S3456/csharp/highlighting.adoc
@@ -1,6 +1,6 @@
 === Highlighting
 
-- ``++ToCharArray()++``
+- ``ToCharArray()``
 
-- ``++ToArray()++``
+- ``ToArray()``
 

--- a/rules/S3456/csharp/highlighting.adoc
+++ b/rules/S3456/csharp/highlighting.adoc
@@ -1,4 +1,6 @@
 === Highlighting
 
-``++ToCharArray()++``
+- ``++ToCharArray()++``
+
+- ``++ToArray()++``
 

--- a/rules/S3456/csharp/message.adoc
+++ b/rules/S3456/csharp/message.adoc
@@ -1,4 +1,4 @@
 === Message
 
-Remove this redundant "ToCharArray" call.
+Remove this redundant ["ToCharArray"|"ToArray"] call.
 

--- a/rules/S3456/csharp/metadata.json
+++ b/rules/S3456/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"string.ToCharArray()\" and \"u8-string.ToArray()\" should not be called redundantly",
+  "title": "\"string.ToCharArray()\" and \"ReadOnlySpan<T>.ToArray()\" should not be called redundantly",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/rules/S3456/csharp/metadata.json
+++ b/rules/S3456/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"string.ToCharArray()\" should not be called redundantly",
+  "title": "\"string.ToCharArray()\" and \"u8-string.ToArray()\" should not be called redundantly",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/rules/S3456/csharp/rule.adoc
+++ b/rules/S3456/csharp/rule.adoc
@@ -1,6 +1,8 @@
-``++ToCharArray++`` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit ``++ToCharArray++`` calls should be omitted.
+``ToCharArray`` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit ``ToCharArray`` calls should be omitted.
 
-The same applies for ``++ToArray++`` invocations on u8-string, targeting C# 11 and afterwards.
+The same applies for ``ToArray`` invocations on ``ReadOnlySpan<T>``, targeting C# 11 and afterwards.
+
+UTF-8 string literals are also impacted, as they are of type ``ReadOnlySpan<byte>``.
 
 == Noncompliant Code Example
 
@@ -12,8 +14,8 @@ foreach (var c in str.ToCharArray()) // Noncompliant
   // ...    
 }
 
-ReadOnlySpan<byte> utf8String = "some UTF-8 string"u8;
-foreach (var c in utf8String.ToArray()) // Noncompliant
+ReadOnlySpan<byte> span = "some UTF-8 string literal"u8;
+foreach (var c in span.ToArray()) // Noncompliant
 {
   // ...    
 }
@@ -30,8 +32,8 @@ foreach (var c in str)
   // ...    
 }
 
-ReadOnlySpan<byte> utf8String = "some UTF-8 string"u8;
-foreach (var c in utf8String) // Compliant 
+ReadOnlySpan<byte> span = "some UTF-8 string literal"u8;
+foreach (var b in span) // Compliant 
 {
   // ...    
 }

--- a/rules/S3456/csharp/rule.adoc
+++ b/rules/S3456/csharp/rule.adoc
@@ -1,8 +1,7 @@
 `ToCharArray` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit `ToCharArray` calls should be omitted.
 
-The same applies for `ToArray` invocations on `ReadOnlySpan<T>`, targeting C# 11 and afterwards.
-
-UTF-8 string literals are also impacted, as they are of type `ReadOnlySpan<byte>`.
+C#11 introduced support for UTF-8 string literals, which are stored as `ReadOnlySpan<byte>` objects.
+For that reason, the rule also raises on `ToArray` invocations of `ReadOnlySpan<T>`.
 
 == Noncompliant Code Example
 

--- a/rules/S3456/csharp/rule.adoc
+++ b/rules/S3456/csharp/rule.adoc
@@ -1,8 +1,8 @@
-``ToCharArray`` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit ``ToCharArray`` calls should be omitted.
+`ToCharArray` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit `ToCharArray` calls should be omitted.
 
-The same applies for ``ToArray`` invocations on ``ReadOnlySpan<T>``, targeting C# 11 and afterwards.
+The same applies for `ToArray` invocations on `ReadOnlySpan<T>`, targeting C# 11 and afterwards.
 
-UTF-8 string literals are also impacted, as they are of type ``ReadOnlySpan<byte>``.
+UTF-8 string literals are also impacted, as they are of type `ReadOnlySpan<byte>`.
 
 == Noncompliant Code Example
 

--- a/rules/S3456/csharp/rule.adoc
+++ b/rules/S3456/csharp/rule.adoc
@@ -1,5 +1,6 @@
 ``++ToCharArray++`` can be omitted when the operation on the array could have been done directly on the string, such as when iterating over the characters in a string, and when accessing a character in a string via an array index. In those cases, explicit ``++ToCharArray++`` calls should be omitted.
 
+The same applies for ``++ToArray++`` invocations on u8-string, targeting C# 11 and afterwards.
 
 == Noncompliant Code Example
 
@@ -7,6 +8,12 @@
 ----
 string str = "some string";
 foreach (var c in str.ToCharArray()) // Noncompliant
+{
+  // ...    
+}
+
+ReadOnlySpan<byte> utf8String = "some UTF-8 string"u8;
+foreach (var c in utf8String.ToArray()) // Noncompliant
 {
   // ...    
 }
@@ -19,6 +26,12 @@ foreach (var c in str.ToCharArray()) // Noncompliant
 ----
 string str = "some string";
 foreach (var c in str)
+{
+  // ...    
+}
+
+ReadOnlySpan<byte> utf8String = "some UTF-8 string"u8;
+foreach (var c in utf8String) // Compliant 
 {
   // ...    
 }


### PR DESCRIPTION
Added the necessary changes to support `utf8_string.ToArray()`, as can be seen on [this PR](https://github.com/SonarSource/sonar-dotnet/issues/6392).