### PR TITLE
Modify S5542 [JS/TS]: Only raise for AES-CBC when used with padding (APPSEC-32)

### DIFF
--- a/rules/S5542/javascript/highlighting.adoc
+++ b/rules/S5542/javascript/highlighting.adoc
@@ -1,0 +1,3 @@
+=== Highlighting
+
+Highlight `crypto.createCipheriv(algorithm, key, iv[, options])` or `crypto.createCipher(algorithm, password[, options])` where applicable.

--- a/rules/S5542/javascript/message.adoc
+++ b/rules/S5542/javascript/message.adoc
@@ -1,0 +1,13 @@
+=== Message
+
+==== ECB
+
+Use a secure cipher mode.
+
+==== CBC
+
+Use another cipher mode or disable padding.
+
+==== RSA
+
+Use a secure padding scheme.

--- a/rules/S5542/javascript/rule.adoc
+++ b/rules/S5542/javascript/rule.adoc
@@ -27,7 +27,10 @@ ifdef::env-github,rspecator-view[]
 == Implementation Specification
 (visible only on this page)
 
-include::../message.adoc[]
+include::message.adoc[]
+
+include::highlighting.adoc[]
+
 
 '''
 == Comments And Links


### PR DESCRIPTION
Specification ticket: [APPSEC-32](https://sonarsource.atlassian.net/browse/APPSEC-32)
Implementation ticket: [SonarJS #3592](https://github.com/SonarSource/SonarJS/issues/3592)
[Preview](https://sonarsource.github.io/rspec/#/rspec/S5542)