### PR TITLE
Readme: Clarify rule deprecation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,9 @@ In the `metadata.json` of the rule you want to deprecate:
 * Remove all tags
 * Remove all quality profiles
 * Change the status to `deprecated`
-* Fill in the `replacementRules` field with the rules that deprecate this one, if any
+* Fill in the `replacementRules` array with strings in the form `"RSPEC-xxxx"` with the rules that deprecate this one, if any
+
+See link:rules/S1212/metadata.json[S1212] for an example.
 
 ==== To delete a rule
 If the rule has never been implemented and is still defined in an open pull request, just close the pull request. +


### PR DESCRIPTION
The replacementRule part isn't specifying the rule id format:
```json
  "extra": {
    "replacementRules": [
      "RSPEC-4200" // or "S4200" or "RSPEC-S4200"? 😕 
    ],
    "legacyKeys": [

    ]
  },
```

Also, a link to an existing example helps with cross-checking.