### PR TITLE
Modify rule S3353: Mark quickfix for CSharp as partially covered

### DIFF
--- a/rules/S3353/csharp/metadata.json
+++ b/rules/S3353/csharp/metadata.json
@@ -1,3 +1,4 @@
 {
-  "title": "Unchanged local variables should be \"const\""
+  "title": "Unchanged local variables should be \"const\"",
+  "quickfix": "covered"
 }

--- a/rules/S3353/csharp/metadata.json
+++ b/rules/S3353/csharp/metadata.json
@@ -1,4 +1,4 @@
 {
   "title": "Unchanged local variables should be \"const\"",
-  "quickfix": "covered"
+  "quickfix": "partial"
 }


### PR DESCRIPTION
Marks the quick fix implemented by https://github.com/SonarSource/sonar-dotnet/pull/6043 as partially implemented. Some edge cases with e.g. multiple declarators are not supported. See also https://github.com/SonarSource/rspec/blob/master/docs/metadata.adoc