### PR TITLE
Modify rule S1612 (Java): Short lambdas are considered compliant

### DIFF
--- a/rules/S1612/java/rule.adoc
+++ b/rules/S1612/java/rule.adoc
@@ -1,13 +1,10 @@
-Method/constructor references are commonly agreed to be, most of the time, more compact and readable than using lambdas, and are therefore preferred. 
+Method/constructor references are commonly agreed to be more readable than lambdas in most situations, and are therefore preferred.
 
-In some rare cases, when it is not clear from the context what kind of function is being described and reference would not increase the clarity, it might be fine to keep the lambda. 
+However, method references are sometimes less concise than lambdas. In such cases, it might be fine to keep the lambda if it is better for readability. This choice is ultimately up to the programmer. Therefore, this rule only raises issues on lambda functions that could be replaced by shorter method references.
 
-
-Similarly, ``++null++`` checks can be replaced with references to the ``++Objects::isNull++`` and ``++Objects::nonNull++`` methods, ``++casts++`` can be replaced with ``++SomeClass.class::cast++`` and ``++instanceof++`` can be replaced with ``++SomeClass.class::isInstance++``.
-
+``++null++`` checks can be replaced with references to the ``++Objects::isNull++`` and ``++Objects::nonNull++`` methods, ``++casts++`` can be replaced with ``++SomeClass.class::cast++`` and ``++instanceof++`` can be replaced with ``++SomeClass.class::isInstance++``.
 
 *Note* that this rule is automatically disabled when the project's ``++sonar.java.source++`` is lower than ``++8++``.
-
 
 == Noncompliant Code Example
 
@@ -39,7 +36,7 @@ class A {
   void process(List<A> list) {
     list.stream()
       .filter(B.class::isInstance)
-      .map(B.class::cast)
+      .map(B.class::cast)            // Note: keeping the lambda would also be compliant here, since it is shorter
       .map(B::<String>getObject)
       .forEach(System.out::println);
   }


### PR DESCRIPTION
When a lambda function is shorter than its equivalent method reference, the code is considered compliant and no issue is raised.