### PR TITLE
Modify rule S1168: Raise on default and ternaries

### DIFF
--- a/rules/S1168/csharp/description.adoc
+++ b/rules/S1168/csharp/description.adoc
@@ -1,0 +1,3 @@
+Returning ``++null++`` or ``++default++`` instead of an actual array, collection or map forces callers of the method to explicitly test for nullity, making them more complex and less readable.
+
+Moreover, in many cases, ``++null++`` or ``++default++`` is used as a synonym for empty.

--- a/rules/S1168/csharp/description.adoc
+++ b/rules/S1168/csharp/description.adoc
@@ -1,3 +1,3 @@
-Returning ``++null++`` or ``++default++`` instead of an actual array, collection or map forces callers of the method to explicitly test for nullity, making them more complex and less readable.
+Returning ``++null++`` or ``++default++`` instead of an actual collection forces the method callers to explicitly test for null, making the code more complex and less readable.
 
 Moreover, in many cases, ``++null++`` or ``++default++`` is used as a synonym for empty.

--- a/rules/S1168/csharp/rule.adoc
+++ b/rules/S1168/csharp/rule.adoc
@@ -9,11 +9,9 @@ public Result[] GetResults()
     return null; // Noncompliant
 }
 
-public IEnumerable<Result> GetResults()
+public IEnumerable<Result> GetResults(bool condition)
 {
     var results = GenerateResults();
-    var condition = RollDice();
-
     return condition 
         ? results 
         : null; // Noncompliant
@@ -41,11 +39,9 @@ public Result[] GetResults()
     return new Result[0];
 }
 
-public IEnumerable<Result> GetResults()
+public IEnumerable<Result> GetResults(bool condition)
 {
     var results = GenerateResults();
-    var condition = RollDice();
-
     return condition 
         ? results 
         : Enumerable.Empty<Result>(); 

--- a/rules/S1168/csharp/rule.adoc
+++ b/rules/S1168/csharp/rule.adoc
@@ -1,4 +1,4 @@
-include::../description.adoc[]
+include::description.adoc[]
 
 == Noncompliant Code Example
 
@@ -11,7 +11,12 @@ public Result[] GetResults()
 
 public IEnumerable<Result> GetResults()
 {
-    return null; // Noncompliant
+    var results = GenerateResults();
+    var condition = RollDice();
+
+    return condition 
+        ? results 
+        : null; // Noncompliant
 }
 
 public IEnumerable<Result> GetResults() => null; // Noncompliant
@@ -20,11 +25,11 @@ public IEnumerable<Result> Results
 {
     get
     {
-        return null; // Noncompliant
+        return default(IEnumerable<Result>); // Noncompliant
     }
 }
 
-public IEnumerable<Result> Results => null; // Noncompliant
+public IEnumerable<Result> Results => default; // Noncompliant
 ----
 
 == Compliant Solution
@@ -38,7 +43,12 @@ public Result[] GetResults()
 
 public IEnumerable<Result> GetResults()
 {
-    return Enumerable.Empty<Result>();
+    var results = GenerateResults();
+    var condition = RollDice();
+
+    return condition 
+        ? results 
+        : Enumerable.Empty<Result>(); 
 }
 
 public IEnumerable<Result> GetResults() => Enumerable.Empty<Result>();


### PR DESCRIPTION
Added the necessary changes to support the following cases:

```csharp
return default;
return default(T);
return condition ? null : someResult;
```

More can be found on [this PR](https://github.com/SonarSource/sonar-dotnet/pull/6457).
