### PR TITLE
Modify rule S3654: Improve on rule description (CPP-3734)

### DIFF
--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without neatly destroying others objects.
+Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without neatly destroying other objects.
 
 Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
 Destructors may still throw an exception if they are explicitly declared as ``noexcept(false)``.

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -4,7 +4,7 @@ Destructors are usually (implicitly) declared as ``noexcept`` by default such th
 Destructors may still propagate an exception if they are explicitly declared as ``noexcept(false)``.
 However, even a destructor that is declared as ``noexcept(false)`` will call `std::terminate` if it throws during stack unwinding.
 
-A commonly used example that highlights the severity of the underlying problem is presented in what follows.
+A commonly used example that highlights the severity of the underlying problem is presented in what follows:
 The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects.
 Suppose a call to an object's destructor throws an exception.
 In that case, there are only two conceptional ways to proceed:

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -7,7 +7,7 @@ However, even a destructor that is declared as ``noexcept(false)`` will call `st
 A commonly used example that highlights the severity of the underlying problem is presented in what follows:
 The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects.
 Suppose a call to an object's destructor throws an exception.
-In that case, there are only two conceptional ways to proceed:
+In that case, there are only two conceptual ways to proceed:
 
 1. Abort destruction. This will result in a partially destroyed object and possibly many more objects whose destructor has not been called. 
 2. Ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions. This is disallowed by C++'s exception-handling mechanism and results in a call to ``std::terminate``.

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,7 +1,7 @@
 Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without neatly destroying other objects.
 
 Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
-Destructors may still throw an exception if they are explicitly declared as ``noexcept(false)``.
+Destructors may still propagate an exception if they are explicitly declared as ``noexcept(false)``.
 However, if a destructor that is declared as ``noexcept(false)`` happens to be called during stack unwinding, ``std::terminate`` is called instead.
 
 A commonly used example that highlights the severity of the underlying problem is presented in what follows.

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without neatly destroying other objects.
+Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without being allowed to perform a clean shutdown.
 
 Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
 Destructors may still propagate an exception if they are explicitly declared as ``noexcept(false)``.

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,6 +1,9 @@
 Throwing an exception from a destructor can lead to undefined behavior, meaning that your program could be terminated abruptly without neatly destroying others objects.
 
-A commonly used example that highlights the severity of the underlying problem is presented in what follows. The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all of the managed objects. If a call to an object's destructor throws an exception, there are only two conceptional ways to proceed: (i) abort destruction which will result in a half-destroyed object and possibly many more objects whose destructor has not been called, or (ii) ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions which is disallowed by C++ exception-handling mechanism and results in a call to ``std::terminate``. Both of these options are undesired.
+A commonly used example that highlights the severity of the underlying problem is presented in what follows. The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects. Suppose a call to an object's destructor throws an exception. In that case, there are only two conceptional ways to proceed:
+1. Abort destruction. This will result in a partially destroyed object and possibly many more objects whose destructor has not been called. 
+2. Ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions. This is disallowed by C++ exception-handling mechanism and results in a call to ``std::terminate``. 
+Both of these options are undesired.
 
 Thus destructors should never ``++throw++`` exceptions. Instead, they should catch and handle those thrown by the functions they call, and be ``++noexcept++``.
 

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,18 +1,19 @@
-Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without being allowed to perform a clean shutdown.
+Throwing an exception from a destructor may result in a call to ``std::terminate`` and can introduce undefined behavior, meaning that your program could be terminated abruptly without being allowed to perform a clean shutdown.
 
 Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
 Destructors may still propagate an exception if they are explicitly declared as ``noexcept(false)``.
-However, even a destructor that is declared as ``noexcept(false)`` will call `std::terminate` if it throws during stack unwinding.
+However, even a destructor that is declared as ``noexcept(false)`` will call ``std::terminate`` if it throws during stack unwinding.
 
 A commonly used example that highlights the severity of the underlying problem is presented in what follows:
-The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects.
+The destructor of a container needs to call the destructors for all managed objects.
 Suppose a call to an object's destructor throws an exception.
-In that case, there are only two conceptual ways to proceed:
+In that case, there are only two _conceptual_ ways to proceed:
 
 1. Abort destruction. This will result in a partially destroyed object and possibly many more objects whose destructor has not been called. 
-2. Ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions. This is disallowed by C++'s exception-handling mechanism and results in a call to ``std::terminate``.
+2. Ignore the exception and proceed with destroying the remaining objects. However, this potentially results in more partially destroyed objects, if further destructors throw an exception.
 
-Both of these options are undesired.
+Both of these options are undesired and hence, whenever an object that is managed using a C++ standard container throws an exception, the behavior is undefined. 
+
 Thus, destructors should never ``++throw++`` exceptions.
 Instead, they should catch and handle those thrown by the functions they call, and be ``++noexcept++``.
 

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,11 +1,20 @@
-Throwing an exception from a destructor can lead to undefined behavior, meaning that your program could be terminated abruptly without neatly destroying others objects.
+Throwing an exception from a destructor may result in a call to ``std::terminate``, meaning that your program could be terminated abruptly without neatly destroying others objects.
 
-A commonly used example that highlights the severity of the underlying problem is presented in what follows. The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects. Suppose a call to an object's destructor throws an exception. In that case, there are only two conceptional ways to proceed:
+Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
+Destructors may still throw an exception if they are explicitly declared as ``noexcept(false)``.
+However, if a destructor that is declared as ``noexcept(false)`` happens to be called during stack unwinding, ``std::terminate`` is called instead.
+
+A commonly used example that highlights the severity of the underlying problem is presented in what follows.
+The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects.
+Suppose a call to an object's destructor throws an exception.
+In that case, there are only two conceptional ways to proceed:
+
 1. Abort destruction. This will result in a partially destroyed object and possibly many more objects whose destructor has not been called. 
-2. Ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions. This is disallowed by C++ exception-handling mechanism and results in a call to ``std::terminate``. 
-Both of these options are undesired.
+2. Ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions. This is disallowed by C++'s exception-handling mechanism and results in a call to ``std::terminate``.
 
-Thus destructors should never ``++throw++`` exceptions. Instead, they should catch and handle those thrown by the functions they call, and be ``++noexcept++``.
+Both of these options are undesired.
+Thus, destructors should never ``++throw++`` exceptions.
+Instead, they should catch and handle those thrown by the functions they call, and be ``++noexcept++``.
 
 
 This rule raises an issue when a destructor is not ``++noexcept++``. By default, destructors are ``++noexcept++``, therefore most of the time, nothing needs to be written in the source code. A destructor is not ``++noexcept++`` if:

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -2,7 +2,7 @@ Throwing an exception from a destructor may result in a call to ``std::terminate
 
 Destructors are usually (implicitly) declared as ``noexcept`` by default such that ``std::terminate`` is called when they throw an exception.
 Destructors may still propagate an exception if they are explicitly declared as ``noexcept(false)``.
-However, if a destructor that is declared as ``noexcept(false)`` happens to be called during stack unwinding, ``std::terminate`` is called instead.
+However, even a destructor that is declared as ``noexcept(false)`` will call `std::terminate` if it throws during stack unwinding.
 
 A commonly used example that highlights the severity of the underlying problem is presented in what follows.
 The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all managed objects.

--- a/rules/S3654/cfamily/rule.adoc
+++ b/rules/S3654/cfamily/rule.adoc
@@ -1,5 +1,6 @@
-Throwing an exception from a destructor results in undefined behavior, meaning that your program could be terminated abruptly without neatly destroying others objects.
+Throwing an exception from a destructor can lead to undefined behavior, meaning that your program could be terminated abruptly without neatly destroying others objects.
 
+A commonly used example that highlights the severity of the underlying problem is presented in what follows. The destructor of a standard container like ``++std::vector++`` automatically calls the destructors for all of the managed objects. If a call to an object's destructor throws an exception, there are only two conceptional ways to proceed: (i) abort destruction which will result in a half-destroyed object and possibly many more objects whose destructor has not been called, or (ii) ignore the exception and proceed with destroying the remaining objects. However, if yet another exception is thrown while destroying the remaining objects, there would be two outstanding exceptions which is disallowed by C++ exception-handling mechanism and results in a call to ``std::terminate``. Both of these options are undesired.
 
 Thus destructors should never ``++throw++`` exceptions. Instead, they should catch and handle those thrown by the functions they call, and be ``++noexcept++``.
 


### PR DESCRIPTION
Adjust rule description: throwing an exception in a destructor is not necessarily undefined behavior. However, it is highly dangerous to throw in a destructor. This PR also adds an example on why that is.