### PR TITLE
Fix comment in S6493 code example

### DIFF
--- a/rules/S6493/cfamily/rule.adoc
+++ b/rules/S6493/cfamily/rule.adoc
@@ -1,13 +1,13 @@
 ``std::make_format_args`` and ``std::make_wformat_args`` return objects containing an array of formatting arguments that can be implicitly converted to ``std::basic_format_args``. The type of the returned object cannot be spelled; it can only be accessed through `auto`.
 
-A formatting argument has reference semantics for user-defined types and does not extend the lifetime of the passed arguments. 
+A formatting argument has reference semantics for non-built-in types and does not extend the lifetime of the passed arguments. 
 It is your responsibility to ensure that the arguments to ``std::make_format_args`` and ``std::make_wformat_args`` outlive their return value:
 
 * When assigning the result of ``std::make_format_args`` to a variable of type ``std::basic_format_args``, it will always dangle.
-* When assigning the result of ``std::make_format_args`` to a variable of type ``auto``, it will dangle only when the formatting arguments contain an rvalue of a non-user-defined type.
+* When assigning the result of ``std::make_format_args`` to a variable of type ``auto``, it will dangle only when the formatting arguments contain an rvalue of a non-built-in type.
 
 While it is possible to assign ``std::make_format_args`` to a variable declared with ``auto`` if all the formatting arguments
-are user-defined types or lvalues, it is suspicious and error-prone. That is why we recommend that the result of
+are built-in types or lvalues, it is suspicious and error-prone. That is why we recommend that the result of
 ``std::make_format_args`` is only used as an argument for formatting functions.
  
 This rule detects when the result of ``std::make_format_args`` or ``std::make_wformat_args`` isn't used as an argument.

--- a/rules/S6493/cfamily/rule.adoc
+++ b/rules/S6493/cfamily/rule.adoc
@@ -36,7 +36,7 @@ std::string getGoodbyesForRemote() {
   return "zero";
 }
 void helloAndGoodByeForRemote() {
-  // nonCompliant, dangles; getHellosForRemote() is an rvalue of non-user-defined type std::string
+  // nonCompliant, dangles; getHellosForRemote() is an rvalue of non-built-in type std::string
   auto numberOfHelloAndGoodBye = std::make_format_args(getHellosForRemote(), getGoodbyesForRemote()); 
   std::cout << vformat("Hello {0} times, and goodbyes {1} times :|\n", numberOfHelloAndGoodBye);
 }


### PR DESCRIPTION
I don't think "non-user-defined type" is what was intended here. If you consider any class or enum type to be "user-defined" then `std::string` *is* user-defined. If the term is being used to mean "not defined by the implementation" then that's not relevant here, because that isn't what determines whether it dangles in this code or not.