### PR TITLE
Modify rule S4018: modify message to make it clear the rule is about type inference

### DIFF
--- a/rules/S4018/message.adoc
+++ b/rules/S4018/message.adoc
@@ -1,4 +1,4 @@
 === Message
 
-Refactor this method to have parameters matching all the type parameters.
+Use all type parameters in the parameter list to enable type inference.
 

--- a/rules/S4018/message.adoc
+++ b/rules/S4018/message.adoc
@@ -1,4 +1,4 @@
 === Message
 
-Use all type parameters in the parameter list to enable type inference.
+Refactor this method to use all type parameters in the parameter list to enable type inference.
 

--- a/rules/S4018/metadata.json
+++ b/rules/S4018/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Generic methods should provide type parameters",
+  "title": "All type parameters should be used in the parameter list to enable type inference",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S4018/rule.adoc
+++ b/rules/S4018/rule.adoc
@@ -13,6 +13,7 @@ namespace MyLibrary
   {
     public void MyMethod<T>()  // Noncompliant
     {
+        // this method can only be invoked by providing the type argument e.g. 'MyMethod<int>()'
     }
   }
 }

--- a/rules/S4018/rule.adoc
+++ b/rules/S4018/rule.adoc
@@ -1,4 +1,4 @@
-The best way to determine the type of a generic method is by inference based on the type of argument that is passed to the method. This is not possible when a parameter type is missing from the argument list.
+Type inference enables the call of a generic method without explicitly specifying its type arguments. This is not possible when a parameter type is missing from the argument list.
 
 
 == Noncompliant Code Example

--- a/rules/S4018/rule.adoc
+++ b/rules/S4018/rule.adoc
@@ -32,6 +32,7 @@ namespace MyLibrary
   {
     public void MyMethod<T>(T param)
     {
+        // type inference allows this to be invoked 'MyMethod(arg)'
     }
   }
 }


### PR DESCRIPTION
The rule's message and description were too vague. They didn't make it clear that the type parameters need to be used in the argument list in order to enable type inference when the method is called. Those texts in the rule were updated to reflect that.

Implementation ticket: SonarSource/sonar-dotnet/issues/6636