### PR TITLE
Modify Rule S4457(C#): Remove from Sonar way Profile

### DIFF
--- a/rules/S4457/comments-and-links.adoc
+++ b/rules/S4457/comments-and-links.adoc
@@ -1,3 +1,3 @@
 === on 24 Jan 2023, 12:13:54 Grigorios Paidis wrote:
 
-To see more technical details, check https://stackoverflow.com/questions/56909648/split-async-method-into-two-for-code-analysis/56909963#56909963
+The rule is controversial and was thoroughly and correctly analyzed on https://stackoverflow.com/a/56909963[StackOverflow]. As a consequence, we removed it from SonarWay.

--- a/rules/S4457/comments-and-links.adoc
+++ b/rules/S4457/comments-and-links.adoc
@@ -1,0 +1,3 @@
+=== on 24 Jan 2023, 12:13:54 Grigorios Paidis wrote:
+
+To see more technical details, check https://stackoverflow.com/questions/56909648/split-async-method-into-two-for-code-analysis/56909963#56909963

--- a/rules/S4457/csharp/metadata.json
+++ b/rules/S4457/csharp/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+    "defaultQualityProfiles": [
+
+    ]
 }

--- a/rules/S4457/csharp/metadata.json
+++ b/rules/S4457/csharp/metadata.json
@@ -1,5 +1,3 @@
 {
-    "defaultQualityProfiles": [
-
-    ]
+  
 }

--- a/rules/S4457/csharp/rule.adoc
+++ b/rules/S4457/csharp/rule.adoc
@@ -9,4 +9,9 @@ include::../message.adoc[]
 
 include::../highlighting.adoc[]
 
+'''
+== Comments And Links
+(visible only on this page)
+
+include::../comments-and-links.adoc[]
 endif::env-github,rspecator-view[]

--- a/rules/S4457/metadata.json
+++ b/rules/S4457/metadata.json
@@ -22,7 +22,7 @@
   "sqKey": "S4457",
   "scope": "All",
   "defaultQualityProfiles": [
-    "Sonar way"
+
   ],
   "quickfix": "unknown"
 }

--- a/rules/S4457/vbnet/rule.adoc
+++ b/rules/S4457/vbnet/rule.adoc
@@ -9,4 +9,9 @@ include::../message.adoc[]
 
 include::../highlighting.adoc[]
 
+'''
+== Comments And Links
+(visible only on this page)
+
+include::../comments-and-links.adoc[]
 endif::env-github,rspecator-view[]


### PR DESCRIPTION
After [this discussion](https://github.com/SonarSource/sonar-dotnet/issues/6132) and internal talk with the .NET Bubble, we decided to disable this rule by default.

https://sonarsource.github.io/rspec/#/rspec/S4457/csharp