### PR TITLE
Modify rule S2970: Improve description of supported test library functions

### DIFF
--- a/rules/S2970/csharp/rule.adoc
+++ b/rules/S2970/csharp/rule.adoc
@@ -1,11 +1,25 @@
-include::../description.adoc[]
+It is very easy to write incomplete assertions when using some test frameworks. This rule enforces complete assertions in the following cases:
+
+* MSTest: https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.assert.that[`Assert.That`] is not followed by an assertion invocation (also https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.stringassert.that[`StringAssert.That`] and https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.collectionassert.that[`CollectionAssert.That`]).
+* Fluent Assertions: https://fluentassertions.com/introduction[`Should()`] is not followed by an assertion invocation.
+* NFluent: https://www.n-fluent.net[`Check.That()`] is not followed by an assertion invocation
+* NSubstitute: https://nsubstitute.github.io/help/received-calls[`Received()`] is not followed by an invocation
+
+In such cases, what is intended to be a test doesn't actually verify anything.
 
 == Noncompliant Code Example
 
 [source,csharp]
 ----
 string actual = "Hello World!";
-actual.Should();  // Noncompliant
+// MSTest
+StringAssert.That;   // Noncompliant
+// Fluent Assertions
+actual.Should();     // Noncompliant
+// NFluent
+Check.That(actual);  // Noncompliant
+// NSubstitute
+command.Received();  // Noncompliant
 ----
 
 == Compliant Solution
@@ -13,7 +27,14 @@ actual.Should();  // Noncompliant
 [source,csharp]
 ----
 string actual = "Hello World!";
+// MSTest
+StringAssert.That.Contains(actual, "Hello");
+// Fluent Assertions
 actual.Should().Contain("Hello");
+// NFluent
+Check.That(actual).Contains("Hello");
+// NSubstitute
+command.Received().Execute();
 ----
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2970/csharp/rule.adoc
+++ b/rules/S2970/csharp/rule.adoc
@@ -1,6 +1,5 @@
 It is very easy to write incomplete assertions when using some test frameworks. This rule enforces complete assertions in the following cases:
 
-* MSTest: https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.assert.that[`Assert.That`] is not followed by an assertion invocation (also https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.stringassert.that[`StringAssert.That`] and https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.collectionassert.that[`CollectionAssert.That`]).
 * Fluent Assertions: https://fluentassertions.com/introduction[`Should()`] is not followed by an assertion invocation.
 * NFluent: https://www.n-fluent.net[`Check.That()`] is not followed by an assertion invocation.
 * NSubstitute: https://nsubstitute.github.io/help/received-calls[`Received()`] is not followed by an invocation.
@@ -12,8 +11,6 @@ In such cases, what is intended to be a test doesn't actually verify anything.
 [source,csharp]
 ----
 string actual = "Hello World!";
-// MSTest
-StringAssert.That;   // Noncompliant
 // Fluent Assertions
 actual.Should();     // Noncompliant
 // NFluent
@@ -27,8 +24,6 @@ command.Received();  // Noncompliant
 [source,csharp]
 ----
 string actual = "Hello World!";
-// MSTest
-StringAssert.That.Contains(actual, "Hello");
 // Fluent Assertions
 actual.Should().Contain("Hello");
 // NFluent

--- a/rules/S2970/csharp/rule.adoc
+++ b/rules/S2970/csharp/rule.adoc
@@ -2,8 +2,8 @@ It is very easy to write incomplete assertions when using some test frameworks. 
 
 * MSTest: https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.assert.that[`Assert.That`] is not followed by an assertion invocation (also https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.stringassert.that[`StringAssert.That`] and https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.collectionassert.that[`CollectionAssert.That`]).
 * Fluent Assertions: https://fluentassertions.com/introduction[`Should()`] is not followed by an assertion invocation.
-* NFluent: https://www.n-fluent.net[`Check.That()`] is not followed by an assertion invocation
-* NSubstitute: https://nsubstitute.github.io/help/received-calls[`Received()`] is not followed by an invocation
+* NFluent: https://www.n-fluent.net[`Check.That()`] is not followed by an assertion invocation.
+* NSubstitute: https://nsubstitute.github.io/help/received-calls[`Received()`] is not followed by an invocation.
 
 In such cases, what is intended to be a test doesn't actually verify anything.
 

--- a/rules/S2970/description.adoc
+++ b/rules/S2970/description.adoc
@@ -1,1 +1,0 @@
-It is very easy to write incomplete assertions when using some test frameworks. This rule raises an issue when an assertion doesn't actually test anything.


### PR DESCRIPTION
Implementation: https://github.com/SonarSource/sonar-dotnet/issues/6662

[S2970](https://sonarsource.github.io/rspec/#/rspec/S2970/)