### PR TITLE
Modify rule S3400: Methods should not return constants

### DIFF
--- a/rules/S3400/java/rule.adoc
+++ b/rules/S3400/java/rule.adoc
@@ -11,7 +11,11 @@ static final int BEST_NUMBER = 12;
 
 == Exceptions
 
-Methods with annotations, such as ``++@Override++`` and Spring's ``++@RequestMapping++``, are ignored.
+The following types of method are ignored:
+
+* methods that override a method.
+* methods that are not final (either by ``++final++``, ``++private++`` or ``++static++`` modifier, or by a final owner class).
+* methods with annotations, such as ``++@Override++`` or Spring's ``++@RequestMapping++``.
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
refined exceptions for the rule