### PR TITLE
Modify rule S1181: Correct the "See" section

### DIFF
--- a/rules/S1181/cfamily/rule.adoc
+++ b/rules/S1181/cfamily/rule.adoc
@@ -36,7 +36,11 @@ There are cases though where you want to catch all exceptions, because no except
 
 Additionally, if the ``++catch++`` handler is throwing an exception (either the same as before, with ``++throw;++`` or a new one that may make more sense to the callers of the function), or is never exiting (because it calls a ``++noreturn++`` function, for instance ``++exit++``), then the accurate type of the exception usually does not matter any longer: this case is excluded too.
 
-include::../see.adoc[]
+== See
+
+* https://cwe.mitre.org/data/definitions/396[MITRE, CWE-396] - Declaration of Catch for Generic Exception
+* https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#Re-exception-types[{cpp} Core Guidelines E.14] - Use purpose-designed user-defined types as exceptions (not built-in types)
+
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1181/see.adoc
+++ b/rules/S1181/see.adoc
@@ -1,4 +1,4 @@
 == See
 
 * https://cwe.mitre.org/data/definitions/396[MITRE, CWE-396] - Declaration of Catch for Generic Exception
-* https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#Re-exception-types[{cpp} Core Guidelines E.14] - Use purpose-designed user-defined types as exceptions (not built-in types)
+* https://wiki.sei.cmu.edu/confluence/display/java/ERR08-J.+Do+not+catch+NullPointerException+or+any+of+its+ancestors[CERT, ERR08-J.] - Do not catch NullPointerException or any of its ancestors


### PR DESCRIPTION
* Split "See" section between C++&Java, therefore removing a C++ specific link that appeared for Java
* Restore the removed link in the Java version