### PR TITLE
Modify rule S131(PLSQL): Change title to fit implementation

### DIFF
--- a/rules/S131/plsql/metadata.json
+++ b/rules/S131/plsql/metadata.json
@@ -1,3 +1,3 @@
 {
-  "title": "\"CASE\" expressions should end with \"ELSE\" clauses"
+  "title": "\"CASE\" statements should end with \"ELSE\" clauses"
 }

--- a/rules/S131/plsql/rule.adoc
+++ b/rules/S131/plsql/rule.adoc
@@ -1,4 +1,4 @@
-The requirement for a final ``++ELSE++`` clause is defensive programming. The ``++CASE++`` expression should always provide a value.
+The requirement for a final ``++ELSE++`` clause is defensive programming. The ``++CASE++`` statement should always provide a value.
 
 == Noncompliant Code Example
 

--- a/rules/S5663/java/rule.adoc
+++ b/rules/S5663/java/rule.adoc
@@ -21,7 +21,7 @@ String question = "What's the point, really?";
 == See
 
 * https://openjdk.java.net/jeps/378[JEP 378: Text Blocks]
-* https://cr.openjdk.java.net/~jlaskey/Strings/TextBlocksGuide_v9.html[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
+* https://openjdk.org/projects/amber/guides/text-blocks-guide[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5664/java/rule.adoc
+++ b/rules/S5664/java/rule.adoc
@@ -6,10 +6,10 @@ Either use only spaces or only tabs for the indentation of a text block. Mixing 
 [source,java]
 ----
 String textBlock = """
-        this is 
+        this is
 <tab>text block!
         !!!!
-      """;  
+      """;
 ----
 
 
@@ -18,7 +18,7 @@ String textBlock = """
 [source,java]
 ----
 String textBlock = """
-        this is 
+        this is
         text block!
         !!!!
       """;
@@ -28,7 +28,7 @@ String textBlock = """
 == See
 
 * https://openjdk.java.net/jeps/378[JEP 378: Text Blocks]
-* https://cr.openjdk.java.net/~jlaskey/Strings/TextBlocksGuide_v9.html[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
+* https://openjdk.org/projects/amber/guides/text-blocks-guide[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5665/java/rule.adoc
+++ b/rules/S5665/java/rule.adoc
@@ -20,7 +20,7 @@ String textBlock = """
 [source,java]
 ----
 String textBlock = """
-        \""" this 
+        \""" this
         is
         text  block!
         !!!!
@@ -31,7 +31,7 @@ String textBlock = """
 == See
 
 * https://openjdk.java.net/jeps/378[JEP 378: Text Blocks]
-* https://cr.openjdk.java.net/~jlaskey/Strings/TextBlocksGuide_v9.html[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
+* https://openjdk.org/projects/amber/guides/text-blocks-guide[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6126/java/rule.adoc
+++ b/rules/S6126/java/rule.adoc
@@ -5,7 +5,7 @@ In Java 15 Text Blocks are now official and can be used. The most common pattern
 
 [source,java]
 ----
-String textBlock = 
+String textBlock =
                "<html>\n" +
                "    <body>\n" +
                "        <tag>\n" +
@@ -32,7 +32,7 @@ String textBlock = """
 == See
 
 * https://openjdk.java.net/jeps/378[JEP 378: Text Blocks]
-* https://cr.openjdk.java.net/~jlaskey/Strings/TextBlocksGuide_v9.html[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
+* https://openjdk.org/projects/amber/guides/text-blocks-guide[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6203/java/rule.adoc
+++ b/rules/S6203/java/rule.adoc
@@ -53,7 +53,7 @@ listOfString.stream()
 == See
 
 * https://openjdk.java.net/jeps/378[JEP 378: Text Blocks]
-* https://cr.openjdk.java.net/~jlaskey/Strings/TextBlocksGuide_v9.html[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
+* https://openjdk.org/projects/amber/guides/text-blocks-guide[Programmer's Guide To Text Blocks], by Jim Laskey and Stuart Marks
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
Someone opened [this thread](https://community.sonarsource.com/t/case-expressions-should-end-with-else-clauses-plsql-s131/83156) in community asking to replace the word `expression` with the word `statements`.

Based on [SONARPLSQL-757](https://sonarsource.atlassian.net/browse/SONARPLSQL-757) it's indeed the case.

[SONARPLSQL-757]: https://sonarsource.atlassian.net/browse/SONARPLSQL-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ