### PR TITLE
Modify rule S2137: Change text to include JavaScript standard builtins

### DIFF
--- a/rules/S2137/javascript/rule.adoc
+++ b/rules/S2137/javascript/rule.adoc
@@ -1,10 +1,10 @@
 JavaScript has special identifiers that, while not reserved, still should not be used as identifiers. They form the JavaScript standard built-in objects and are available in all environments. They include identifiers like:
 
-* ``++eval++`` - evaluates a string as JavaScript code
-* ``++arguments++`` - used to access function arguments through indexed properties. It exists only inside function declarations and function expressions
-* ``++undefined++`` - returned for values and properties that have not yet been assigned
+* ``++eval++`` - Evaluates a string as JavaScript code.
+* ``++arguments++`` - Used to access function arguments through indexed properties. It exists only inside function declarations and function expressions.
+* ``++undefined++`` - Returned for values and properties that have not yet been assigned.
 * ``++NaN++`` - Not a Number; returned when math functions fail.
-* ``++Infinity++`` - when a number exceeds the upper limit of the floating point numbers
+* ``++Infinity++`` - When a number exceeds the upper limit of the floating point numbers.
 
 These words should not be bound or assigned, because doing so would overwrite the original definitions of these identifiers. What's more, assigning or binding some of these names will generate an error in JavaScript strict mode code.
 

--- a/rules/S2137/javascript/rule.adoc
+++ b/rules/S2137/javascript/rule.adoc
@@ -1,10 +1,9 @@
-JavaScript has special identifiers that, while not reserved, still should not be used as identifiers. They include:
-
+JavaScript has special identifiers that, while not reserved, still should not be used as identifiers. They form the JavaScript standard built-in objects and are available in all environments. They include identifiers like:
 
 * ``++eval++`` - evaluates a string as JavaScript code
-* ``++arguments++`` - used to access function arguments through indexed properties. 
+* ``++arguments++`` - used to access function arguments through indexed properties. It exists only inside function declarations and function expressions
 * ``++undefined++`` - returned for values and properties that have not yet been assigned
-* ``++NaN++`` - Not a Number; returned when math functions fail. 
+* ``++NaN++`` - Not a Number; returned when math functions fail.
 * ``++Infinity++`` - when a number exceeds the upper limit of the floating point numbers
 
 These words should not be bound or assigned, because doing so would overwrite the original definitions of these identifiers. What's more, assigning or binding some of these names will generate an error in JavaScript strict mode code.
@@ -17,13 +16,12 @@ These words should not be bound or assigned, because doing so would overwrite th
 eval = 17; // Noncompliant
 arguments++; // Noncompliant
 ++eval; // Noncompliant
-var obj = { set p(arguments) { } }; // Noncompliant
-var eval; // Noncompliant
-try { } catch (arguments) { } // Noncompliant
-function x(eval) { } // Noncompliant
-function arguments() { } // Noncompliant
-var y = function eval() { }; // Noncompliant
-var f = new Function("arguments", "return 17;"); // Noncompliant
+const obj = { set p(arguments) { } }; // Noncompliant
+let eval; // Noncompliant
+try { /* ... */ } catch (arguments) { } // Noncompliant
+function x(eval) { /* ... */ } // Noncompliant
+function arguments() { /* ... */ } // Noncompliant
+const y = function eval() { /* ... */ }; // Noncompliant
 
 function fun() {
   if (arguments.length == 0) { // Compliant
@@ -40,13 +38,12 @@ function fun() {
 result = 17;
 args++;
 ++result;
-var obj = { set p(arg) { } };
-var result;
-try { } catch (args) { }
-function x(arg) { }
-function args() { } 
-var y = function fun() { }; 
-var f = new Function("args", "return 17;");
+const obj = { set p(arg) { } };
+let result;
+try { /* ... */ } catch (args) { }
+function x(arg) { /* ... */ }
+function args() { /* ... */ }
+const y = function fun() { /* ... */ };
 
 function fun() {
   if (arguments.length == 0) {


### PR DESCRIPTION
The rule now checks for JavaScript standard built-in identifiers instead of the list previously defined in the rule. The code samples have been updated to use `const`/`let` instead of `var`. The rule actually doesn't check function constructor calls, so the corresponding code examples have been removed: `new Function("arguments", "return 17;")`.

Fixes SonarSource/SonarJS#3708