### PR TITLE
Modify rule S1472: Add tagged template literals

### DIFF
--- a/rules/S1472/javascript/rule.adoc
+++ b/rules/S1472/javascript/rule.adoc
@@ -12,7 +12,7 @@ The first option will be the one chosen by the JavaScript interpreter.
 By extension, and to improve readability, any kind of function call argument should not start on new line.
 
 Similarly, tagged templates allow for advanced forms of string interpolation by evaluating the tag as a function to call, passing the
-template literal elements as arguments. Therefore the rule also verifies that template literals don't start on a separate line.
+template literal elements as arguments. Therefore, the rule also verifies that template literals don't start on a separate line.
 
 == Noncompliant Code Example
 

--- a/rules/S1472/javascript/rule.adoc
+++ b/rules/S1472/javascript/rule.adoc
@@ -1,5 +1,24 @@
 include::../rule.adoc[]
 
+Similarly, tagged templates allow for advanced forms of string interpolation by evaluating the tag as a function to call, passing the
+template literal elements as arguments. Therefore the rule also verifies that template literals don't start on a separate line.
+
+== Noncompliant Code Example
+
+[source,text]
+----
+const foo = function() { /* ... */ }
+`bar` // Noncompliant
+----
+
+== Compliant Solution
+
+[source,text]
+----
+function foo() { /* ... */ }
+const s = foo`bar`;
+----
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S1472/javascript/rule.adoc
+++ b/rules/S1472/javascript/rule.adoc
@@ -1,4 +1,15 @@
-include::../rule.adoc[]
+Because semicolons at the ends of statements are optional, starting function call arguments on a separate line makes the code confusing. It could lead to errors and most likely _will_ lead to questions for maintainers.
+
+
+What was the initial intent of the developer?
+
+. Define a function and then execute some unrelated code inside a closure ?
+. Pass the second function as a parameter to the first one ?
+
+The first option will be the one chosen by the JavaScript interpreter.
+
+
+By extension, and to improve readability, any kind of function call argument should not start on new line.
 
 Similarly, tagged templates allow for advanced forms of string interpolation by evaluating the tag as a function to call, passing the
 template literal elements as arguments. Therefore the rule also verifies that template literals don't start on a separate line.
@@ -7,16 +18,58 @@ template literal elements as arguments. Therefore the rule also verifies that te
 
 [source,text]
 ----
-const foo = function() { /* ... */ }
-`bar` // Noncompliant
+const fn = function () {
+  //...
+}
+
+(function () { // Noncompliant
+  //...
+})();
+
+const foo = function() {
+  return 'foo';
+}
+
+`bar`; // Noncompliant: foo is a string not a function
 ----
 
 == Compliant Solution
 
+Either
+
+
 [source,text]
 ----
-function foo() { /* ... */ }
-const s = foo`bar`;
+// define a function
+const fn = function () {
+  //...
+}; // <-- semicolon added
+
+// then execute some code inside a closure
+(function () {
+  //...
+})();
+
+function foo() {  // <-- Use a function declaration
+  return 'foo';
+}
+
+`bar`;
+----
+
+Or
+
+[source,text]
+----
+var fn = function () {
+  //...
+}(function () { // <-- start function call arguments on same line
+  //...
+})();
+
+const foo = function() {
+  return 'foo';
+}`bar`; // <-- start template literal on same line
 ----
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
The change adds a paragraph about tagged template literals.

Fixes SonarSource/SonarJS#3705