### PR TITLE
metadata.adoc: add link to the Coding rule guidelines on SonarQube

### DIFF
--- a/docs/metadata.adoc
+++ b/docs/metadata.adoc
@@ -6,6 +6,10 @@ endif::[]
 
 This document describes how `+metadata.json+` should be structured.
 
+== `title`, `type`, `tags`, `remediation`, and `defaultSeverity`
+
+These fields are described in the https://docs.sonarqube.org/latest/extension-guide/adding-coding-rules/#coding-rule-guidelines[official sonar qube documentation].
+
 == `quickfix` field
 
 Every active rule that is not a security hotspot must specify the availability of a quick fix for its issues.

--- a/docs/metadata.adoc
+++ b/docs/metadata.adoc
@@ -8,7 +8,7 @@ This document describes how `+metadata.json+` should be structured.
 
 == `title`, `type`, `tags`, `remediation`, and `defaultSeverity`
 
-These fields are described in the https://docs.sonarqube.org/latest/extension-guide/adding-coding-rules/#coding-rule-guidelines[official sonar qube documentation].
+These fields are described in the https://docs.sonarqube.org/latest/extension-guide/adding-coding-rules/#coding-rule-guidelines[SonarQube documentation].
 
 == `quickfix` field
 


### PR DESCRIPTION
Add a link to the **Coding rule guidelines** article on [docs.sonarqube](https://docs.sonarqube.org/latest/extension-guide/adding-coding-rules/#coding-rule-guidelines).