### PR TITLE
Modify rule S2198

### DIFF
--- a/rules/S2198/cfamily/metadata.json
+++ b/rules/S2198/cfamily/metadata.json
@@ -1,3 +1,6 @@
 {
-  
+  "defaultQualityProfiles": [
+    "Sonar way",
+    "MISRA C++ 2008 recommended"
+  ]  
 }

--- a/rules/S2198/metadata.json
+++ b/rules/S2198/metadata.json
@@ -22,8 +22,7 @@
   "sqKey": "S2198",
   "scope": "Main",
   "defaultQualityProfiles": [
-    "Sonar way",
-    "MISRA C++ 2008 recommended"
+    "Sonar way"
   ],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
Make MISRA-related information CFamily-specific