### PR TITLE
Modify rule S2492: Fix the noncompliant example (PLSQL-S2492)

### DIFF
--- a/rules/S2492/plsql/rule.adoc
+++ b/rules/S2492/plsql/rule.adoc
@@ -8,7 +8,7 @@ With the default regular expression ``++[a-zA-Z]([a-zA-Z0-9_]*[a-zA-Z0-9])?++``:
 [source,sql]
 ----
 DECLARE
-  TYPE Collection-type_ IS VARRAY(42) OF PLS_INTEGER; -- Noncompliant
+  TYPE Collection_type_ IS VARRAY(42) OF PLS_INTEGER; -- Noncompliant
 BEGIN
   NULL;
 END;

--- a/rules/S2492/plsql/rule.adoc
+++ b/rules/S2492/plsql/rule.adoc
@@ -25,7 +25,7 @@ DECLARE
 BEGIN
   NULL;
 END;
-/ {code}
+/
 ----
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
This is a fix for [this issue](https://discuss.sonarsource.com/t/parse-error-on-noncompliant-example-of-plsql-namingtypescheck/12627)