### PR TITLE
Modify rule S2326: Remove CERT tag

### DIFF
--- a/rules/S2326/java/metadata.json
+++ b/rules/S2326/java/metadata.json
@@ -1,11 +1,1 @@
-{
-  "tags": [
-    "cert",
-    "unused"
-  ],
-  "securityStandards": {
-    "CERT": [
-      "MSC12-CPP."
-    ]
-  }
-}
+{}


### PR DESCRIPTION
Remove tag as no link to the CERT documentation can be found in the description