### PR TITLE
Modify rule S2589: Remove CERT tag

### DIFF
--- a/rules/S2589/java/metadata.json
+++ b/rules/S2589/java/metadata.json
@@ -1,18 +1,1 @@
-{
-  "tags": [
-    "cwe",
-    "cert",
-    "suspicious",
-    "redundant"
-  ],
-  "securityStandards": {
-    "CERT": [
-      "MSC12-C."
-    ],
-    "CWE": [
-      489,
-      571,
-      570
-    ]
-  }
-}
+{}


### PR DESCRIPTION
Remove CERT tag as no link to the CERT is present in the documentation.