### PR TITLE
Modify rule S5659: Remove CERT tag

### DIFF
--- a/rules/S5659/java/metadata.json
+++ b/rules/S5659/java/metadata.json
@@ -1,7 +1,1 @@
-{
-  "tags": [
-    "cwe",
-    "privacy",
-    "cert"
-  ]
-}
+{}


### PR DESCRIPTION
Remove CERT tag as no link to the CERT is present in the documentation.