### PR TITLE
Modify rule S6544: remove mention of error handling, which we will not cover anymore

### DIFF
--- a/rules/S6544/javascript/rule.adoc
+++ b/rules/S6544/javascript/rule.adoc
@@ -12,10 +12,6 @@ This rule forbids returning promises where another type is expected such as in:
 * void returns
 * spread operators
 
-[.underline]#*Missing error handling:*#
-
-Promises that aren't resolved will finish running at an unexpected time. When they do not contain error handling and they raise an exception, the associated call stack will be wrong.
-
 === What is the potential impact?
 
 Using a promise instead of its resolved value can have unexpected results leading to bugs.
@@ -49,8 +45,6 @@ If you mistakenly treated a promise as its resolved value, you can ensure it is 
   // work with result
 })();
 ----
-
-If you forgot to handle the promise rejection, you should handle it either with `.catch(error => {/*...*/})` or `.then(result => {}, error => {})`.
 
 //== How to fix it in FRAMEWORK NAME
 
@@ -134,29 +128,6 @@ apiCalls.forEach(async (apiCall) => {
 for (const apiCall of apiCalls) {
   await apiCall.send();
 }
-----
-
-==== Noncompliant code example
-
-[source,javascript,diff-id=4,diff-type=noncompliant]
-----
-fetch('https://api.com/entries')
-  .then(result => {
-    // ...
-  });
-----
-
-==== Compliant solution
-
-[source,javascript,diff-id=4,diff-type=compliant]
-----
-fetch('https://api.com/entries')
-  .then(result => {
-    // ...
-  })
-  .catch(error => {
-    // ...
-  });
 ----
 
 === How does this work?


### PR DESCRIPTION
Fixes [#3891](https://github.com/SonarSource/SonarJS/issues/3891)