### PR TITLE
BUILD-2950 Adapt rspec replace set-output (deprecated)

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -38,9 +38,9 @@ jobs:
         pipenv run rspec-tools update-coverage --rulesdir ../rules
         mv ./covered_rules.json ../frontend/public/covered_rules.json
         if git diff --exit-code ../frontend/public/covered_rules.json; then
-          echo "::set-output name=new_coverage::false"
+          echo "new_coverage=false" >> "$GITHUB_OUTPUT"
         else
-          echo "::set-output name=new_coverage::true"
+          echo "new_coverage=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: 'Cancel if coverage did not change'


### PR DESCRIPTION
# BUILD-2950 Adapt rspec replace set-output (deprecated)

## Changes
* Replace usage of set-output 
   That way it will still work[ after 31st of May](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)