### PR TITLE
Modify rule S2430: add to default profile, change quickfix to infeasible

### DIFF
--- a/rules/S2430/javascript/metadata.json
+++ b/rules/S2430/javascript/metadata.json
@@ -22,7 +22,7 @@
   "sqKey": "S2430",
   "scope": "Main",
   "defaultQualityProfiles": [
-
+    "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }


### PR DESCRIPTION
 The rule was not part of the default quality profile (Sonar way), so we want to fix that