### PR TITLE
Modify rule S6493: LaYC format

### DIFF
--- a/rules/S6493/cfamily/rule.adoc
+++ b/rules/S6493/cfamily/rule.adoc
@@ -3,10 +3,10 @@
 ``std::make_format_args`` and ``std::make_wformat_args`` return objects containing an array of formatting arguments that can be implicitly converted to ``std::basic_format_args``. The type of the returned object cannot be spelled; it can only be accessed through `auto`.
 
 A formatting argument has reference semantics for non-built-in types and does not extend the lifetime of the passed arguments. 
-It is your responsibility to ensure that the arguments to ``std::make_format_args`` and ``std::make_wformat_args`` outlive their return value:
+It is your responsibility to ensure that the arguments to ``std::make_format_args`` and ``std::make_wformat_args`` outlive their return value. Specifically, be aware that:
 
-* When assigning the result of ``std::make_format_args`` to a variable of type ``std::basic_format_args``, it will always dangle.
-* When assigning the result of ``std::make_format_args`` to a variable of type ``auto``, it will dangle only when the formatting arguments contain an rvalue of a non-built-in type.
+* Assigning the result of ``std::make_format_args`` to a variable of type ``std::basic_format_args`` will always dangle.
+* Assigning the result of ``std::make_format_args`` to a variable of type ``auto`` will dangle when the formatting arguments contain an rvalue of a non-built-in type.
 
 While it is possible to assign ``std::make_format_args`` to a variable declared with ``auto`` if all the formatting arguments
 are built-in types or lvalues, it is suspicious and error-prone. That is why we recommend that the result of
@@ -14,9 +14,15 @@ are built-in types or lvalues, it is suspicious and error-prone. That is why we 
  
 This rule detects when the result of ``std::make_format_args`` or ``std::make_wformat_args`` isn't used as an argument.
 
-=== Noncompliant code example
+== How to fix it
 
-[source,cpp]
+Pass the result of ``std::make_format_args`` or ``std::make_wformat_args`` directly as an argument.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 void helloAndGoodByeReality() {
   // Noncompliant, dangles
@@ -38,22 +44,16 @@ std::string getGoodbyesForRemote() {
   return "zero";
 }
 void helloAndGoodByeForRemote() {
-  // nonCompliant, dangles; getHellosForRemote() is an rvalue of non-built-in type std::string
+  // Noncompliant, dangles; getHellosForRemote() is an rvalue of non-built-in type std::string
   auto numberOfHelloAndGoodBye = std::make_format_args(getHellosForRemote(), getGoodbyesForRemote()); 
   std::cout << vformat("Hello {0} times, and goodbyes {1} times :|\n", numberOfHelloAndGoodBye);
 }
 
-int main() {
-  helloAndGoodByeReality();
-  helloAndGoodByeExpectation();
-  helloAndGoodByeForRemote();
-}
-
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 void helloAndGoodByeReality() {
   std::cout << vformat("Hello {0} times, and goodbyes {1} times :(\n",
@@ -76,12 +76,6 @@ void helloAndGoodByeForRemote() {
   std::cout <<
     vformat("Hello {0} times, and goodbyes {1} times :|\n",
       std::make_format_args(getHellosForRemote(), getGoodbyesForRemote())); // Compliant
-}
-
-int main() {
-  helloAndGoodByeReality();
-  helloAndGoodByeExpectation();
-  helloAndGoodByeForRemote();
 }
 
 ----


### PR DESCRIPTION
Note: Given what the [introduction](https://xtranet-sonarsource.atlassian.net/wiki/spaces/PM/pages/2715320326/LaYC+Rule+Content+Specification#Introduction.1) should be, I don't think it is a good fit here...