### PR TITLE
Modify rule S5384: fix broken URL

### DIFF
--- a/rules/S5384/apex/rule.adoc
+++ b/rules/S5384/apex/rule.adoc
@@ -26,7 +26,7 @@ trigger MyTrigger on Account(after insert, after update) { // Noncompliant. The 
 == Resources
 
 * https://github.com/ChrisAldridge/Lightweight-Trigger-Framework[Lightweight Apex Trigger Framework]
-* https://meltedwires.com/2013/06/05/trigger-pattern-for-tidy-streamlined-bulkified-triggers-revisited/[Trigger Pattern for Tidy, Streamlined, Bulkified Triggers Revisited]
+* https://web.archive.org/web/20230130071426/https://meltedwires.com/2013/06/05/trigger-pattern-for-tidy-streamlined-bulkified-triggers-revisited/[Trigger Pattern for Tidy, Streamlined, Bulkified Triggers Revisited]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
This PR fixes a broken URL in S5384 by replacing it with an Internet Archive link to the same page.

[Preview](https://sonarsource.github.io/rspec/#/rspec/S5384/apex)