### PR TITLE
S1909: Remove C# since the rule is not applicable 

### DIFF
--- a/rules/S1909/comments-and-links.adoc
+++ b/rules/S1909/comments-and-links.adoc
@@ -6,3 +6,5 @@ I guess the code snippets and See section are missing in this rule specification
 === on 31 Jul 2014, 18:36:45 Ann Campbell wrote:
 They're in the subtask [~freddy.mallet]
 
+=== on 30 May 2023, 14:45:31 Greg Paidis wrote:
+Removed C# since this rule is not applicable, the language prevents you from jumping into blocks.

--- a/rules/S1909/csharp/metadata.json
+++ b/rules/S1909/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "status": "closed"
 }


### PR DESCRIPTION
See [this conversation](https://github.com/SonarSource/sonar-dotnet/issues/6661) for more details.