### PR TITLE
Modify rule S4159: LaYC format

### DIFF
--- a/rules/S4159/csharp/metadata.json
+++ b/rules/S4159/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "quickfix": "targeted"
 }

--- a/rules/S4159/csharp/rule.adoc
+++ b/rules/S4159/csharp/rule.adoc
@@ -1,27 +1,33 @@
 == Why is this an issue?
 
-include::../description.adoc[]
+include::../why.adoc[]
 
-=== Noncompliant code example
+== How to fix it
 
-[source,csharp]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 [Export(typeof(ISomeType))]
-public class SomeType // Noncompliant; doesn't implement 'ISomeType'.
+public class SomeType // Noncompliant: doesn't implement 'ISomeType'.
 {
 }
 ----
 
 
-=== Compliant solution
+==== Compliant solution
 
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 [Export(typeof(ISomeType))]
 public class SomeType : ISomeType
 {
 }
 ----
+
+include::../resources.adoc[]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4159/description.adoc
+++ b/rules/S4159/description.adoc
@@ -1,7 +1,0 @@
-In the Attributed Programming Model, the ``++ExportAttribute++`` declares that a part "exports", or provides to the composition container, an object that fulfills a particular contract. During composition, parts with imports that have matching contracts will have those dependencies filled by the exported object.
-
-
-If the type doesn't implement the interface it is exporting there will be an issue at runtime (either a cast exception or just a container not filled with the exported type) leading to unexpected behaviors/crashes.
-
-
-The rule raises an issue when a class doesn't implement or inherit the type declared in the ``++ExportAttribute++``. 

--- a/rules/S4159/metadata.json
+++ b/rules/S4159/metadata.json
@@ -24,6 +24,5 @@
   "scope": "All",
   "defaultQualityProfiles": [
     "Sonar way"
-  ],
-  "quickfix": "unknown"
+  ]
 }

--- a/rules/S4159/resources.adoc
+++ b/rules/S4159/resources.adoc
@@ -1,0 +1,8 @@
+== Resources
+
+=== Documentation
+
+* https://en.wikipedia.org/wiki/Attribute-oriented_programming[Attribute-oriented programming (@OP)]
+* https://learn.microsoft.com/en-us/dotnet/framework/mef/attributed-programming-model-overview-mef[Attributed Programming Model]
+* https://learn.microsoft.com/en-us/dotnet/framework/mef/[Managed Extensibility Framework (MEF)]
+* https://learn.microsoft.com/en-us/dotnet/api/system.composition.exportattribute[ExportAttribute Class]

--- a/rules/S4159/vbnet/metadata.json
+++ b/rules/S4159/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "quickfix": "targeted"
 }

--- a/rules/S4159/vbnet/rule.adoc
+++ b/rules/S4159/vbnet/rule.adoc
@@ -1,25 +1,32 @@
 == Why is this an issue?
 
-include::../description.adoc[]
+include::../why.adoc[]
 
-=== Noncompliant code example
+== How to fix it
 
-[source,vbnet]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 <Export(GetType(ISomeType))>
-Public Class SomeType  // Noncompliant; doesn't implement 'ISomeType'.
+Public Class SomeType  // Noncompliant: doesn't implement 'ISomeType'.
 End Class
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,vbnet]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 <Export(GetType(ISomeType))>
 Public Class SomeType
     Inherits ISomeType
 End Class
 ----
+
+include::../resources.adoc[]
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S4159/vbnet/rule.adoc
+++ b/rules/S4159/vbnet/rule.adoc
@@ -11,7 +11,7 @@ include::../why.adoc[]
 [source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 <Export(GetType(ISomeType))>
-Public Class SomeType  // Noncompliant: doesn't implement 'ISomeType'.
+Public Class SomeType  ' Noncompliant: doesn't implement 'ISomeType'.
 End Class
 ----
 

--- a/rules/S4159/why.adoc
+++ b/rules/S4159/why.adoc
@@ -1,0 +1,16 @@
+The https://learn.microsoft.com/en-us/dotnet/framework/mef/attributed-programming-model-overview-mef[Attributed Programming Model], also known as https://en.wikipedia.org/wiki/Attribute-oriented_programming[Attribute-oriented programming (@OP)], is a programming model used to embed attributes within codes. 
+
+In this model objects are required to conform a specific structure, so that they can be used by the https://learn.microsoft.com/en-us/dotnet/framework/mef/[Managed Extensibility Framework (MEF)].
+
+MEF provides a way to discover available components implicitly, via *composition*. A MEF component, called a *part*, declaratively specifies: 
+
+* both its dependencies, known as *imports*
+* and what capabilities it makes available, known as *exports*
+
+The https://learn.microsoft.com/en-us/dotnet/api/system.composition.exportattribute[ExportAttribute] declares that a part "exports", or provides to the composition container, an object that fulfills a particular contract. 
+
+During composition, parts with imports that have matching contracts will have those dependencies filled by the exported object.
+
+If the type doesn't implement the interface it is exporting there will be an issue at runtime (either a cast exception or just a container not filled with the exported type) leading to unexpected behaviors/crashes.
+
+The rule raises an issue when a class doesn't implement or inherit the type declared in the `ExportAttribute`. 


### PR DESCRIPTION
Adapts the rule to LaYC format level 2, for dotnet languages (csharp, vbnet).