### PR TITLE
Modify s6426 layc

### DIFF
--- a/rules/S6426/javascript/rule.adoc
+++ b/rules/S6426/javascript/rule.adoc
@@ -1,6 +1,7 @@
 == Why is this an issue?
 
-Testing frameworks like Mocha and Jest provide a way to run a single test case for a file by appending `.only()` to the test function. This is useful when debugging a specific use case. However, it should not be used in production or development, as it is likely a leftover from debugging and serves no purpose in those contexts. 
+
+When using testing frameworks like Mocha and Jest, appending `.only()` to the test function allows running a single test case for a file. This is useful when debugging a specific use case. However, it should not be used in production or development, as it is likely a leftover from debugging and serves no purpose in those contexts. 
 
 It is strongly recommended not to include `.only()` usages in version control.
 

--- a/rules/S6426/javascript/rule.adoc
+++ b/rules/S6426/javascript/rule.adoc
@@ -1,7 +1,8 @@
 == Why is this an issue?
 
-Testing frameworks like Mocha and Jest provide a way to run a single test case for a file by appending `.only()` to the test function. This is convenient when debugging a specific use case. It makes, however, no sense to have it in production or development, and it was likely left by mistake after such a debugging session.
-Therefore, it is strongly recommended not to commit usages of `.only()` to version control.
+Testing frameworks like Mocha and Jest provide a way to run a single test case for a file by appending `.only()` to the test function. This is useful when debugging a specific use case. However, it should not be used in production or development, as it is likely a leftover from debugging and serves no purpose in those contexts. 
+
+It is strongly recommended not to include `.only()` usages in version control.
 
 === Noncompliant code example
 


### PR DESCRIPTION
Reworded the text slightly. I left the noncompliant/compliant titles in because I didn't think it was worthwhile to move them to the second tab. 

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone

