### PR TITLE
Modify rule S1215: LaYC format

### DIFF
--- a/rules/S1215/csharp/metadata.json
+++ b/rules/S1215/csharp/metadata.json
@@ -4,5 +4,6 @@
     "performance",
     "unpredictable",
     "bad-practice"
-  ]
+  ],
+  "quickfix": "targeted"
 }

--- a/rules/S1215/csharp/rspecator.adoc
+++ b/rules/S1215/csharp/rspecator.adoc
@@ -1,0 +1,16 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+Refactor the code to remove this use of 'XXX'.
+
+'''
+== Comments And Links
+(visible only on this page)
+
+include::../comments-and-links.adoc[]
+endif::env-github,rspecator-view[]

--- a/rules/S1215/csharp/rule.adoc
+++ b/rules/S1215/csharp/rule.adoc
@@ -1,35 +1,38 @@
 == Why is this an issue?
 
-Calling ``++GC.Collect++`` is rarely necessary, and can significantly affect application performance. That's because it triggers a blocking operation that examines _every object in memory_ for cleanup. Further, you don't have control over when this blocking cleanup will actually run.
+https://learn.microsoft.com/en-us/dotnet/api/system.gc.collect[GC.Collect] is a method that forces or suggests to the https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/[garbage collector] to run a collection of objects in the managed heap that are no longer being used and free their memory.
 
+Calling `GC.Collect` is rarely necessary and can significantly affect application performance. That's because it is a https://en.wikipedia.org/wiki/Tracing_garbage_collection[tracing garbage collector] and needs to examine _every object in memory_ for cleanup and analyze all reachable objects from every application's root: 
 
-As a general rule, the consequences of calling this method far outweigh the benefits unless perhaps you've just triggered some event that is unique in the run of your program that caused a lot of long-lived objects to die.
+* static fields
+* local variables on thread stacks
+* CPU registers
+* GC handles
+* finalize queue
 
+To perform tracing and memory releasing correctly, the garbage collection https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/latency[may] need to block all threads currently in execution. That is why, as a general rule, the https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/performance#troubleshoot-performance-issues[performance implications] of calling `GC.Collect` far outweigh the benefits.
 
-This rule raises an issue when ``++GC.Collect++`` is invoked.
-
-=== Noncompliant code example
+This rule raises an issue when any overload of `Collect` is invoked.
 
 [source,csharp]
 ----
 static void Main(string[] args)
 {
   // ...
+  GC.Collect();                              // Noncompliant
   GC.Collect(2, GCCollectionMode.Optimized); // Noncompliant
 }
 ----
 
-ifdef::env-github,rspecator-view[]
+There may be exceptions to this rule: for example, you've just triggered some event that is unique in the run of your program that caused a lot of long-lived objects to die, and you want to release their memory.
 
-'''
-== Implementation Specification
-(visible only on this page)
+== Resources
 
-include::../message.adoc[]
+=== Documentation
 
-'''
-== Comments And Links
-(visible only on this page)
+* https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/[Garbage collection]
+* https://learn.microsoft.com/en-us/dotnet/api/system.gc.collect[GC.Collect]
+* https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/latency[Garbage collection latency modes]
+* https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/performance#troubleshoot-performance-issues[Garbage collection troubleshoot performance issues]
 
-include::../comments-and-links.adoc[]
-endif::env-github,rspecator-view[]
+include::rspecator.adoc[]

--- a/rules/S1215/csharp/rule.adoc
+++ b/rules/S1215/csharp/rule.adoc
@@ -2,13 +2,7 @@
 
 https://learn.microsoft.com/en-us/dotnet/api/system.gc.collect[GC.Collect] is a method that forces or suggests to the https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/[garbage collector] to run a collection of objects in the managed heap that are no longer being used and free their memory.
 
-Calling `GC.Collect` is rarely necessary and can significantly affect application performance. That's because it is a https://en.wikipedia.org/wiki/Tracing_garbage_collection[tracing garbage collector] and needs to examine _every object in memory_ for cleanup and analyze all reachable objects from every application's root: 
-
-* static fields
-* local variables on thread stacks
-* CPU registers
-* GC handles
-* finalize queue
+Calling `GC.Collect` is rarely necessary and can significantly affect application performance. That's because it is a https://en.wikipedia.org/wiki/Tracing_garbage_collection[tracing garbage collector] and needs to examine _every object in memory_ for cleanup and analyze all reachable objects from every application's root (static fields, local variables on thread stacks, etc.).
 
 To perform tracing and memory releasing correctly, the garbage collection https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/latency[may] need to block all threads currently in execution. That is why, as a general rule, the https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/performance#troubleshoot-performance-issues[performance implications] of calling `GC.Collect` far outweigh the benefits.
 


### PR DESCRIPTION
Adapts the rule to LaYC format level 2, for csharp.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone

