### PR TITLE
Modify rule S3265: LaYC format

### DIFF
--- a/rules/S3265/csharp/rule.adoc
+++ b/rules/S3265/csharp/rule.adoc
@@ -4,6 +4,27 @@ https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types
 
 However, they can also serve as https://en.wikipedia.org/wiki/Bit_field[bit flags], enabling bitwise operations to combine multiple elements within a single value.
 
+[source,csharp]
+----
+enum Days
+{
+  None      = 0b00000000,                   // 0
+  Monday    = 0b00000001,                   // 1
+  Tuesday   = 0b00000010,                   // 2
+  Wednesday = 0b00000100,                   // 4
+  Thursday  = 0b00001000,                   // 8
+  Friday    = 0b00010000,                   // 16
+  Saturday  = 0b00100000,                   // 32
+  Sunday    = 0b01000000,                   // 64
+}
+
+// ...
+
+var weekend = Days.Saturday | Days.Sunday;  // Combined elements are equal to 96 or 0b01100000
+----
+
+When enumerations are used as bit flags, it is considered https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags[good practice] to annotate  the enum type with the https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute[FlagsAttribute]:
+
 [source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 enum Permissions
@@ -13,12 +34,13 @@ enum Permissions
   Write = 2,
   Execute = 4
 }
+
 // ...
 
 var x = Permissions.Read | Permissions.Write;  // Noncompliant: enum is not annotated with [Flags]
 ----
 
-When enumerations are used as bit flags, it is considered https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags[good practice] to annotate  the enum type with the https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute[FlagsAttribute]:
+The `FlagsAttribute` explicitly marks an enumeration as bit flags, making it clear that it uses bit fields and is intended to be used as flags.
 
 [source,csharp,diff-id=1,diff-type=compliant]
 ----
@@ -30,12 +52,11 @@ enum Permissions
   Write = 2,
   Execute = 4
 }
+
 // ...
 
 var x = Permissions.Read | Permissions.Write;  // Compliant: enum is annotated with [Flags]
 ----
-
-The `FlagsAttribute` explicitly marks an enumeration as bit flags, making it clear that it uses bit fields and is intended to be used as flags.
 
 Additionally, adding the `FlagsAttribute` to the enumeration enable a https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute#examples[better string representation] when using the https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring[Enum.ToString] method.
 

--- a/rules/S3265/csharp/rule.adoc
+++ b/rules/S3265/csharp/rule.adoc
@@ -6,21 +6,8 @@ However, they can also serve as https://en.wikipedia.org/wiki/Bit_field[bit flag
 
 [source,csharp]
 ----
-enum Days
-{
-  None      = 0b00000000,                   // 0
-  Monday    = 0b00000001,                   // 1
-  Tuesday   = 0b00000010,                   // 2
-  Wednesday = 0b00000100,                   // 4
-  Thursday  = 0b00001000,                   // 8
-  Friday    = 0b00010000,                   // 16
-  Saturday  = 0b00100000,                   // 32
-  Sunday    = 0b01000000,                   // 64
-}
-
-// ...
-
-var weekend = Days.Saturday | Days.Sunday;  // Combined elements are equal to 96 or 0b01100000
+// Saturday = 0b00100000, Sunday = 0b01000000, weekend = 0b01100000
+var weekend = Days.Saturday | Days.Sunday;  // Combining elements
 ----
 
 When enumerations are used as bit flags, it is considered https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags[good practice] to annotate  the enum type with the https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute[FlagsAttribute]:

--- a/rules/S3265/csharp/rule.adoc
+++ b/rules/S3265/csharp/rule.adoc
@@ -1,122 +1,52 @@
 == Why is this an issue?
 
-``++enum++``s are usually used to identify distinct elements in a set of values. However ``++enum++``s can be treated as bit fields and bitwise operations can be used on them to combine the values. This is a good way of specifying multiple elements of set with a single value. When ``++enum++``s are used this way, it is a best practice to mark the ``++enum++`` with the ``++FlagsAttribute++``.
+https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum[Enumerations] are commonly used to identify distinct elements from a set of values.
 
+However, they can also serve as https://en.wikipedia.org/wiki/Bit_field[bit flags], enabling bitwise operations to combine multiple elements within a single value.
 
-=== Noncompliant code example
-
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 enum Permissions
-{ 
+{
   None = 0,
-  Read = 1,   
-  Write = 2, 
-  Execute = 4 
-}
-// ...
-
-var x = Permissions.Read | Permissions.Write;  // Noncompliant; enum is not marked with [Flags]
-----
-
-
-=== Compliant solution
-
-[source,csharp]
-----
-[Flags]
-enum Permissions
-{ 
-  None = 0,
-  Read = 1, 
-  Write = 2, 
+  Read = 1,
+  Write = 2,
   Execute = 4
 }
 // ...
 
-var x = Permissions.Read | Permissions.Write;
+var x = Permissions.Read | Permissions.Write;  // Noncompliant: enum is not annotated with [Flags]
 ----
 
+When enumerations are used as bit flags, it is considered https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags[good practice] to annotate  the enum type with the https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute[FlagsAttribute]:
 
-ifdef::env-github,rspecator-view[]
-
-'''
-== Implementation Specification
-(visible only on this page)
-
-=== Message
-
-* Mark enum "XXX" with "Flags" attribute or remove this bitwise operation.
-* Remove this bitwise operation; the enum "XXX" is not marked with "Flags" attribute.
-
-
-'''
-== Comments And Links
-(visible only on this page)
-
-=== on 9 Jul 2015, 15:46:00 Ann Campbell wrote:
-\[~tamas.vajk] I know that as written this rule doesn't cover _BitwiseOperatorOnEnumWithoutFlags_ but IMO it obviates it. According to http://stackoverflow.com/a/8480/2662707[SO] the ``++[Flags]++`` doesn't actually get you anything w/r/t bitwise usage. What's important is the assigned values.
-
-
-I propose a Minor followup rule to make sure that ``++[Flags]++`` is applied when the enum values are power-of-2. 
-
-
-WDYT?
-
-=== on 10 Jul 2015, 09:41:50 Tamas Vajk wrote:
-\[~ann.campbell.2] I've modified slightly the messages and the sample code. I think now it covers your proposed follow-up rule as well.
-
-=== on 10 Jul 2015, 11:14:07 Ann Campbell wrote:
-Thanks [~tamas.vajk]
-
-=== on 1 Sep 2015, 07:02:18 Dinesh Bolkensteyn wrote:
-IMO it should be another rule (a MINOR one) that suggests to mark power-of-two Enums with ``++Flags++`` - that knowledge cannot just sneak into this rule's issue message [~ann.campbell.2].
-
-=== on 1 Sep 2015, 14:21:41 Ann Campbell wrote:
-That's between you [~tamas.vajk], [~dinesh.bolkensteyn].
-
-=== on 2 Sep 2015, 12:20:36 Tamas Vajk wrote:
-\[~ann.campbell.2] We discussed it with [~dinesh.bolkensteyn] and he convinced me that we should have a minor severity rule that proposes to use the ``++[Flags]++`` whenever an enum only contains power-of-two items. (We can't merge that one into this issue, because of the different severity, but has a value, because it improves the understability of the code)
-
-=== on 2 Sep 2015, 15:22:59 Tamas Vajk wrote:
-\[~ann.campbell.2] We realized during the implementation that this power-of-two enum value restriction can't be enforced, because 
-
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
-enum Permission
-{ 
+[Flags]
+enum Permissions
+{
   None = 0,
-  Read = 1,   
-  Write = 2, 
-  ReadWrite = Read  | Write, //means 3
-  Execute = 4 
+  Read = 1,
+  Write = 2,
+  Execute = 4
 }
+// ...
+
+var x = Permissions.Read | Permissions.Write;  // Compliant: enum is annotated with [Flags]
 ----
-is totally valid. So there is no need for the other RSPEC which we discussed above. I'll change this one.
 
-=== on 2 Sep 2015, 15:24:59 Tamas Vajk wrote:
-\[~dinesh.bolkensteyn] could you please review this rspec? Thanks
+The `FlagsAttribute` explicitly marks an enumeration as bit flags, making it clear that it uses bit fields and is intended to be used as flags.
 
-=== on 19 Oct 2015, 12:55:44 Tamas Vajk wrote:
-This RSPEC is closed, as we realized during the implementation that this power-of-two enum value restriction can't be enforced.
+Additionally, adding the `FlagsAttribute` to the enumeration enable a https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute#examples[better string representation] when using the https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring[Enum.ToString] method.
 
-=== on 3 Dec 2015, 09:32:15 Tamas Vajk wrote:
-\[~ann.campbell.2] I reopened this RSPEC. I'm going through the R# rules, and I think it would still make sense. Note that the rule was closed because we realized that flags enums can't be forced to have only power of two values. So I removed that part, and only left the bitwise operation part in the rule. WDYT?
+== Resources
 
-=== on 4 Dec 2015, 18:40:13 Ann Campbell wrote:
-\[~tamas.vajk] I moved the Noncompliant marker in the Noncompliant Code Example.
+=== Documentation
 
-=== on 7 Dec 2015, 15:59:08 Tamas Vajk wrote:
-\[~ann.campbell.2] I see the point of marking the declaration noncompliant, but from a user perspective it would be better on the call:
+* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum[Enumeration in C#]
+** https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags[Enumeration types as bit flags]
+* https://learn.microsoft.com/en-us/dotnet/api/system.flagsattribute[FlagsAttribute class]
+* https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring[Enum.ToString method]
+* https://en.wikipedia.org/wiki/Bit_field[Bit field - Wikipedia]
 
-Let's say we mark the `enum` noncompliant, and say that it should not be used as flags, if it's not marked with `[Flags]`. But the developer would need some verification that indeed it's used somewhere in a binary or/and. So we would probably include a filename and line number in the issue message. And then the dev could go check it there, and then come back to the declaration and fix it.
-
-
-While in the other case if the usage is marked, the dev would only need to go to the definition, which is just one shortcut away.
-
-
-What do you think?
-
-=== on 7 Dec 2015, 16:17:37 Ann Campbell wrote:
-If we're going to do that [~tamas.vajk], then we need to flip the rule around: "Non-flags enums should not be used in bitwise operations" (note double-negative).
-
-endif::env-github,rspecator-view[]
+include::../rspecator.adoc[]

--- a/rules/S3265/rspecator.adoc
+++ b/rules/S3265/rspecator.adoc
@@ -1,0 +1,82 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+* Mark enum "XXX" with "Flags" attribute or remove this bitwise operation.
+* Remove this bitwise operation; the enum "XXX" is not marked with "Flags" attribute.
+
+
+'''
+== Comments And Links
+(visible only on this page)
+
+=== on 9 Jul 2015, 15:46:00 Ann Campbell wrote:
+\[~tamas.vajk] I know that as written this rule doesn't cover _BitwiseOperatorOnEnumWithoutFlags_ but IMO it obviates it. According to http://stackoverflow.com/a/8480/2662707[SO] the `[Flags]` doesn't actually get you anything w/r/t bitwise usage. What's important is the assigned values.
+
+
+I propose a Minor followup rule to make sure that `[Flags]` is applied when the enum values are power-of-2.
+
+
+WDYT?
+
+=== on 10 Jul 2015, 09:41:50 Tamas Vajk wrote:
+\[~ann.campbell.2] I've modified slightly the messages and the sample code. I think now it covers your proposed follow-up rule as well.
+
+=== on 10 Jul 2015, 11:14:07 Ann Campbell wrote:
+Thanks [~tamas.vajk]
+
+=== on 1 Sep 2015, 07:02:18 Dinesh Bolkensteyn wrote:
+IMO it should be another rule (a MINOR one) that suggests to mark power-of-two Enums with `Flags` - that knowledge cannot just sneak into this rule's issue message [~ann.campbell.2].
+
+=== on 1 Sep 2015, 14:21:41 Ann Campbell wrote:
+That's between you [~tamas.vajk], [~dinesh.bolkensteyn].
+
+=== on 2 Sep 2015, 12:20:36 Tamas Vajk wrote:
+\[~ann.campbell.2] We discussed it with [~dinesh.bolkensteyn] and he convinced me that we should have a minor severity rule that proposes to use the `[Flags]` whenever an enum only contains power-of-two items. (We can't merge that one into this issue, because of the different severity, but has a value, because it improves the understability of the code)
+
+=== on 2 Sep 2015, 15:22:59 Tamas Vajk wrote:
+\[~ann.campbell.2] We realized during the implementation that this power-of-two enum value restriction can't be enforced, because
+
+----
+enum Permission
+{
+  None = 0,
+  Read = 1,
+  Write = 2,
+  ReadWrite = Read  | Write, //means 3
+  Execute = 4
+}
+----
+is totally valid. So there is no need for the other RSPEC which we discussed above. I'll change this one.
+
+=== on 2 Sep 2015, 15:24:59 Tamas Vajk wrote:
+\[~dinesh.bolkensteyn] could you please review this rspec? Thanks
+
+=== on 19 Oct 2015, 12:55:44 Tamas Vajk wrote:
+This RSPEC is closed, as we realized during the implementation that this power-of-two enum value restriction can't be enforced.
+
+=== on 3 Dec 2015, 09:32:15 Tamas Vajk wrote:
+\[~ann.campbell.2] I reopened this RSPEC. I'm going through the R# rules, and I think it would still make sense. Note that the rule was closed because we realized that flags enums can't be forced to have only power of two values. So I removed that part, and only left the bitwise operation part in the rule. WDYT?
+
+=== on 4 Dec 2015, 18:40:13 Ann Campbell wrote:
+\[~tamas.vajk] I moved the Noncompliant marker in the Noncompliant Code Example.
+
+=== on 7 Dec 2015, 15:59:08 Tamas Vajk wrote:
+\[~ann.campbell.2] I see the point of marking the declaration noncompliant, but from a user perspective it would be better on the call:
+
+Let's say we mark the `enum` noncompliant, and say that it should not be used as flags, if it's not marked with `[Flags]`. But the developer would need some verification that indeed it's used somewhere in a binary or/and. So we would probably include a filename and line number in the issue message. And then the dev could go check it there, and then come back to the declaration and fix it.
+
+
+While in the other case if the usage is marked, the dev would only need to go to the definition, which is just one shortcut away.
+
+
+What do you think?
+
+=== on 7 Dec 2015, 16:17:37 Ann Campbell wrote:
+If we're going to do that [~tamas.vajk], then we need to flip the rule around: "Non-flags enums should not be used in bitwise operations" (note double-negative).
+
+endif::env-github,rspecator-view[]


### PR DESCRIPTION
Update rule content and descriptions to LaYC format.
https://sonarsource.github.io/rspec/#/rspec/S3265

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

