### PR TITLE
Modify rule S3445: LaYC format

### DIFF
--- a/rules/S3445/csharp/rule.adoc
+++ b/rules/S3445/csharp/rule.adoc
@@ -1,15 +1,13 @@
 == Why is this an issue?
 
-In C#, the `throw` statement can be used in two different ways:
+In C#, the https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/statements#13106-the-throw-statement[throw] statement can be used in two different ways:
 
 * by specifying an expression
 * without specifying an expression
 
 === By specifying an expression
 
-In the software development context, an expression is a value or anything that executes and ends up being a value. The expression shall be implicitly convertible to `System.Exception`, and the result of evaluating the expression is converted to `System.Exception` before being thrown. If the result of the conversion is `null`, a `System.NullReferenceException` is thrown instead.
-
-In this case, the stack trace will be cleared, losing the list of method calls between the original method that threw the exception and the current method.
+In the software development context, an expression is a value or anything that executes and ends up being a value. The expression shall be implicitly convertible to `System.Exception`, and the result of evaluating the expression is converted to `System.Exception` before being thrown.
 
 [source,csharp]
 ----
@@ -18,9 +16,12 @@ try
 }
 catch(Exception exception)
 {
+  // code that uses the exception
   throw exception; // The exception stack trace is cleared up to this point.
 }
 ----
+
+In this case, the https://en.wikipedia.org/wiki/Stack_trace[stack trace], will be cleared, losing the list of method calls between the original method that threw the exception and the current method.
 
 === Without specifying an expression
 
@@ -33,6 +34,7 @@ try
 }
 catch(Exception exception)
 {
+  // code that uses the exception
   throw; // The stack trace of the initial exception is preserved.
 }
 ----

--- a/rules/S3445/csharp/rule.adoc
+++ b/rules/S3445/csharp/rule.adoc
@@ -1,71 +1,94 @@
 == Why is this an issue?
 
-When rethrowing an exception, you should do it by simply calling ``++throw;++`` and not ``++throw exc;++``, because the stack trace is reset with the second syntax, making debugging a lot harder.
+In C#, the `throw` statement can be used in two different ways:
 
+* by specifying an expression
+* without specifying an expression
 
-=== Noncompliant code example
+=== By specifying an expression
 
-[source,csharp]
-----
-try
-{}
-catch(ExceptionType1 exc)
-{
-  Console.WriteLine(exc);
-  throw exc; // Noncompliant; stacktrace is reset
-}
-catch (ExceptionType2 exc) 
-{
-  throw new Exception("My custom message", exc);  // Compliant; stack trace preserved
-}
-----
+In the software development context, an expression is a value or anything that executes and ends up being a value. The expression shall be implicitly convertible to `System.Exception`, and the result of evaluating the expression is converted to `System.Exception` before being thrown. If the result of the conversion is `null`, a `System.NullReferenceException` is thrown instead.
 
-
-=== Compliant solution
+In this case, the stack trace will be cleared, losing the list of method calls between the original method that threw the exception and the current method.
 
 [source,csharp]
 ----
 try
-{}
-catch(ExceptionType1 exc)
 {
-  Console.WriteLine(exc);
+}
+catch(Exception exception)
+{
+  throw exception; // The exception stack trace is cleared up to this point.
+}
+----
+
+=== Without specifying an expression
+
+This syntax is supported only in a `catch` block, in which case, that statement re-throws the exception currently being handled by that `catch` block.
+
+[source,csharp]
+----
+try
+{
+}
+catch(Exception exception)
+{
+  throw; // The stack trace of the initial exception is preserved.
+}
+----
+
+=== Exceptions
+
+It is allowed using the thrown `exception` as an argument and wrapping it in another `exception`.
+
+[source,csharp]
+----
+try
+{
+}
+catch(Exception exception)
+{
+  throw new Exception("Additional information", exception);
+}
+----
+
+== How to fix it
+
+The recommended way to re-throw an exception is to use the throw statement without including an expression. This ensures that all call stack information is preserved when the exception is propagated to the caller, making debugging easier.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
+----
+try
+{
+}
+catch(Exception exception)
+{
+  throw exception;
+}
+----
+
+==== Compliant solution
+
+[source,csharp,diff-id=1,diff-type=compliant]
+----
+try
+{
+}
+catch(Exception)
+{
   throw;
 }
-catch (ExceptionType2 exc) 
-{
-  throw new Exception("My custom message", exc);
-}
 ----
 
+== Resources
 
-ifdef::env-github,rspecator-view[]
+=== Documentation
 
-'''
-== Implementation Specification
-(visible only on this page)
+* https://learn.microsoft.com/en-us/dotnet/api/system.exception?view=net-7.0#re-throwing-an-exception[Re-throwing an exception]
+* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/statements#13106-the-throw-statement[The throw statement]
 
-=== Message
-
-Use "throw;" instead of "throw xxx;" to preserve the stack trace.
-
-
-=== Highlighting
-
-The whole "throw exc;" statement
-
-
-'''
-== Comments And Links
-(visible only on this page)
-
-=== on 8 Dec 2015, 09:14:18 Tamas Vajk wrote:
-\[~ann.campbell.2] LGTM
-
-=== on 26 Jul 2016, 17:50:15 Tamas Vajk wrote:
-\[~ann.campbell.2] I don't think this is a bug.
-
-=== on 27 Jul 2016, 13:30:00 Freddy Mallet wrote:
-Agreed [~tamas.vajk] and this is the limit of the usage of this "Bug" issue type because this is really a "Reliability" issue that might prevent someone in production to understand an unexpected behavior as the root cause of the issue is lost. That's why we're classifying this issue as a bug. cc [~ann.campbell.2]
-
-endif::env-github,rspecator-view[]
+include::../rspecator.adoc[]

--- a/rules/S3445/csharp/rule.adoc
+++ b/rules/S3445/csharp/rule.adoc
@@ -24,7 +24,7 @@ catch(Exception exception)
 
 === Without specifying an expression
 
-This syntax is supported only in a `catch` block, in which case, that statement re-throws the exception currently being handled by that `catch` block.
+This syntax is supported only in a `catch` block, in which case, that statement re-throws the exception currently being handled by that `catch` block, preserving the stack trace.
 
 [source,csharp]
 ----

--- a/rules/S3445/csharp/rule.adoc
+++ b/rules/S3445/csharp/rule.adoc
@@ -90,7 +90,8 @@ catch(Exception)
 
 === Documentation
 
-* https://learn.microsoft.com/en-us/dotnet/api/system.exception?view=net-7.0#re-throwing-an-exception[Re-throwing an exception]
+* https://learn.microsoft.com/en-us/dotnet/api/system.exception#re-throwing-an-exception[Re-throwing an exception]
 * https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/statements#13106-the-throw-statement[The throw statement]
+* https://en.wikipedia.org/wiki/Stack_trace[stack trace]
 
 include::../rspecator.adoc[]

--- a/rules/S3445/rspecator.adoc
+++ b/rules/S3445/rspecator.adoc
@@ -1,0 +1,30 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+Use "throw;" instead of "throw xxx;" to preserve the stack trace.
+
+
+=== Highlighting
+
+The whole "throw exc;" statement
+
+
+'''
+== Comments And Links
+(visible only on this page)
+
+=== on 8 Dec 2015, 09:14:18 Tamas Vajk wrote:
+\[~ann.campbell.2] LGTM
+
+=== on 26 Jul 2016, 17:50:15 Tamas Vajk wrote:
+\[~ann.campbell.2] I don't think this is a bug.
+
+=== on 27 Jul 2016, 13:30:00 Freddy Mallet wrote:
+Agreed [~tamas.vajk] and this is the limit of the usage of this "Bug" issue type because this is really a "Reliability" issue that might prevent someone in production to understand an unexpected behavior as the root cause of the issue is lost. That's why we're classifying this issue as a bug. cc [~ann.campbell.2]
+
+endif::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

