### PR TITLE
Modify rule S3464: fix grammar, links, resources, rspecator

### DIFF
--- a/rules/S3464/csharp/rule.adoc
+++ b/rules/S3464/csharp/rule.adoc
@@ -1,8 +1,8 @@
 == Why is this an issue?
 
-Recursion is a technique used in computer science to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
+https://en.wikipedia.org/wiki/Recursion[Recursion] is a technique used in computer science to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
 
-For example, the implementation of the generator for the n-th value of the Fibonacci sequence comes naturally from its mathematical definition, when recursion is used:
+For example, the implementation of the generator for the n-th value of the https://en.wikipedia.org/wiki/Fibonacci_sequence[Fibonacci sequence] comes naturally from its mathematical definition, when recursion is used:
 
 [source,csharp]
 ----
@@ -49,7 +49,7 @@ int NthFibonacciNumber(int n)
 }
 ----
 
-It is also acceptable and makes sense in some type definitions:
+It is also acceptable and makes sense in some types definitions:
 
 [source,csharp]
 ----
@@ -75,7 +75,7 @@ class C2<T> : C2<C2<T>> // Error CS0146: Circular base type dependency
 }
 ----
 
-In more complex scenarios, however, the code will compile but execution will result into a https://learn.microsoft.com/en-us/dotnet/api/system.typeloadexception[TypeLoadException] if you try to instantiate the class.
+In more complex scenarios, however, the code will compile but execution will result in a https://learn.microsoft.com/en-us/dotnet/api/system.typeloadexception[TypeLoadException] if you try to instantiate the class.
 
 [source,csharp]
 ----
@@ -91,20 +91,4 @@ var c2 = new C2<int>();     // This would result into a TypeLoadException
 ----
 
 include::../resources.adoc[]
-
-ifdef::env-github,rspecator-view[]
-
-'''
-== Implementation Specification
-(visible only on this page)
-
-include::../message.adoc[]
-
-include::../highlighting.adoc[]
-
-'''
-== Comments And Links
-(visible only on this page)
-
-include::../comments-and-links.adoc[]
-endif::env-github,rspecator-view[]
+include::../rspecator.adoc[]

--- a/rules/S3464/csharp/rule.adoc
+++ b/rules/S3464/csharp/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-https://en.wikipedia.org/wiki/Recursion[Recursion] is a technique used in computer science to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
+https://en.wikipedia.org/wiki/Recursion[Recursion] is a technique used to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
 
 For example, the implementation of the generator for the n-th value of the https://en.wikipedia.org/wiki/Fibonacci_sequence[Fibonacci sequence] comes naturally from its mathematical definition, when recursion is used:
 
@@ -49,7 +49,7 @@ int NthFibonacciNumber(int n)
 }
 ----
 
-It is also acceptable and makes sense in some types definitions:
+It is also acceptable and makes sense in some type definitions:
 
 [source,csharp]
 ----

--- a/rules/S3464/rspecator.adoc
+++ b/rules/S3464/rspecator.adoc
@@ -1,0 +1,16 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+include::message.adoc[]
+
+include::highlighting.adoc[]
+
+'''
+== Comments And Links
+(visible only on this page)
+
+include::comments-and-links.adoc[]
+endif::env-github,rspecator-view[]

--- a/rules/S3464/vbnet/rule.adoc
+++ b/rules/S3464/vbnet/rule.adoc
@@ -43,7 +43,7 @@ Function NthFibonacciNumber(ByVal n As Integer) As Integer
 }
 ----
 
-It is also acceptable and makes sense in some type definitions:
+It is also acceptable and makes sense in some types definitions:
 
 [source,vbnet]
 ----
@@ -69,7 +69,7 @@ Class C2(Of T)
 End Class
 ----
 
-In more complex scenarios, however, the code will compile but execution will result into a https://learn.microsoft.com/en-us/dotnet/api/system.typeloadexception[TypeLoadException] if you try to instantiate the class.
+In more complex scenarios, however, the code will compile but execution will result in a https://learn.microsoft.com/en-us/dotnet/api/system.typeloadexception[TypeLoadException] if you try to instantiate the class.
 
 [source,vbnet]
 ----
@@ -83,27 +83,5 @@ End Class
 Dim c2 = New C2(Of Integer) ' This would result into a TypeLoadException
 ----
 
-== Resources
-
-=== Documentation
-
-* https://en.wikipedia.org/wiki/Recursion_(computer_science)[Recursion]
-* https://learn.microsoft.com/en-us/dotnet/api/system.typeloadexception?view=net-7.0[TypeLoadException]
-
-
-ifdef::env-github,rspecator-view[]
-
-'''
-== Implementation Specification
-(visible only on this page)
-
-include::../message.adoc[]
-
-include::../highlighting.adoc[]
-
-'''
-== Comments And Links
-(visible only on this page)
-
-include::../comments-and-links.adoc[]
-endif::env-github,rspecator-view[]
+include::../resources.adoc[]
+include::../rspecator.adoc[]

--- a/rules/S3464/vbnet/rule.adoc
+++ b/rules/S3464/vbnet/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-https://en.wikipedia.org/wiki/Recursion[Recursion] is a technique used in computer science to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
+https://en.wikipedia.org/wiki/Recursion[Recursion] is a technique used to define a problem in terms of the problem itself, usually in terms of a simpler version of the problem itself.
 
 For example, the implementation of the generator for the n-th value of the https://en.wikipedia.org/wiki/Fibonacci_sequence[Fibonacci sequence] comes naturally from its mathematical definition, when recursion is used:
 
@@ -43,7 +43,7 @@ Function NthFibonacciNumber(ByVal n As Integer) As Integer
 }
 ----
 
-It is also acceptable and makes sense in some types definitions:
+It is also acceptable and makes sense in some type definitions:
 
 [source,vbnet]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

