### PR TITLE
Modify rule S4275: LaYC format

### DIFF
--- a/rules/S4275/csharp/rule.adoc
+++ b/rules/S4275/csharp/rule.adoc
@@ -1,6 +1,16 @@
 == Why is this an issue?
 
-Properties provide a way to enforce encapsulation by providing accessors that give controlled access to `private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
+Properties provide a way to enforce https://en.wikipedia.org/wiki/Encapsulation_(computer_programming)[encapsulation] by providing accessors that give controlled access to `private` fields. However, in classes with multiple fields, it is not unusual that https://en.wikipedia.org/wiki/Copy-and-paste_programming[copy-and-paste] is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
+
+[source,csharp]
+----
+class C
+{
+    private int x;
+    private int y;
+    public int Y => x; // Noncompliant: The returned field should be 'y'
+}
+----
 
 This rule raises an issue in any of these cases:
 

--- a/rules/S4275/csharp/rule.adoc
+++ b/rules/S4275/csharp/rule.adoc
@@ -4,8 +4,8 @@ Properties provide a way to enforce encapsulation by providing accessors that gi
 
 This rule raises an issue in any of these cases:
 
-* A setter does not update the field with the corresponding name.
 * A getter does not access the field with the corresponding name.
+* A setter does not update the field with the corresponding name.
 
 For simple properties, it is better to use https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties[auto-implemented properties] (C# 3.0 or later).
 
@@ -13,7 +13,9 @@ Field and property names are compared as case-insensitive. All underscore charac
 
 == How to fix it
 
-=== Noncompliant code example
+=== Code examples
+
+==== Noncompliant code example
 
 [source,csharp,diff-id=1,diff-type=noncompliant]
 ----
@@ -36,7 +38,7 @@ class A
 }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
 [source,csharp,diff-id=1,diff-type=compliant]
 ----
@@ -60,8 +62,6 @@ class A
 ----
 
 == Resources
-
-=== Documentation
 
 * Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties[Properties (C# Programming Guide)]
 

--- a/rules/S4275/csharp/rule.adoc
+++ b/rules/S4275/csharp/rule.adoc
@@ -1,21 +1,21 @@
 == Why is this an issue?
 
-Properties provide a way to enforce encapsulation by providing ``++public++``, ``++protected++`` or ``++internal++`` methods that give controlled access to ``++private++`` fields. However in classes with multiple fields it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
-
+Properties provide a way to enforce encapsulation by providing accessors that give controlled access to `private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
 
 This rule raises an issue in any of these cases:
 
 * A setter does not update the field with the corresponding name.
 * A getter does not access the field with the corresponding name.
 
-For simple properties it is better to use https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties[auto-implemented properties] (C# 3.0 or later).
-
+For simple properties, it is better to use https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties[auto-implemented properties] (C# 3.0 or later).
 
 Field and property names are compared as case-insensitive. All underscore characters are ignored.
 
+== How to fix it
+
 === Noncompliant code example
 
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 class A
 {
@@ -38,7 +38,7 @@ class A
 
 === Compliant solution
 
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 class A
 {
@@ -58,6 +58,13 @@ class A
     }
 }
 ----
+
+== Resources
+
+=== Documentation
+
+* Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties[Properties (C# Programming Guide)]
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S4275/metadata.json
+++ b/rules/S4275/metadata.json
@@ -24,5 +24,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "targeted"
 }

--- a/rules/S4275/vbnet/metadata.json
+++ b/rules/S4275/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "title": "Get and set procedures should access the expected fields"
 }

--- a/rules/S4275/vbnet/metadata.json
+++ b/rules/S4275/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-    "title": "Get and set procedures should access the expected fields"
+    "title": "Property procedures should access the expected fields"
 }

--- a/rules/S4275/vbnet/rule.adoc
+++ b/rules/S4275/vbnet/rule.adoc
@@ -1,21 +1,23 @@
 == Why is this an issue?
 
-Properties provide a way to enforce encapsulation by providing ``++public++``, ``++protected++`` or ``++internal++`` methods that give controlled access to ``++private++`` fields. However in classes with multiple fields it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a getter or setter.
-
+Properties provide a way to enforce encapsulation by providing procedures that give controlled access to `Private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a get procedure or a set procedure.
 
 This rule raises an issue in any of these cases:
 
-* A setter does not update the field with the corresponding name.
-* A getter does not access the field with the corresponding name.
+* A get procedure does not access the field with the corresponding name.
+* A set procedure does not update the field with the corresponding name.
 
-For simple properties it is better to use https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties[auto-implemented properties] (VB.NET 10.0 or later).
-
+For simple properties, it is better to use https://learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/procedures/auto-implemented-properties[auto-implemented properties] (VB.NET 10.0 or later).
 
 Field and property names are compared as case-insensitive. All underscore characters are ignored.
 
-=== Noncompliant code example
+== How to fix it
 
-[source,vbnet]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 Public Class Sample
 
@@ -34,9 +36,9 @@ Public Class Sample
 End Class
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,vbnet]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 Public Class Sample
 
@@ -54,6 +56,11 @@ Public Class Sample
 
 End Class
 ----
+
+== Resources
+
+* Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/procedures/property-procedures[Property Procedures (Visual Basic)]
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S4275/vbnet/rule.adoc
+++ b/rules/S4275/vbnet/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Properties provide a way to enforce encapsulation by providing procedures that give controlled access to `Private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by a get procedure or a set procedure.
+Properties provide a way to enforce encapsulation by providing property procedures that give controlled access to `Private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by the property procedures.
 
 This rule raises an issue in any of these cases:
 

--- a/rules/S4275/vbnet/rule.adoc
+++ b/rules/S4275/vbnet/rule.adoc
@@ -1,6 +1,20 @@
 == Why is this an issue?
 
-Properties provide a way to enforce encapsulation by providing property procedures that give controlled access to `Private` fields. However, in classes with multiple fields, it is not unusual that cut and paste is used to quickly create the needed properties, which can result in the wrong field being accessed by the property procedures.
+Properties provide a way to enforce https://en.wikipedia.org/wiki/Encapsulation_(computer_programming)[encapsulation] by providing property procedures that give controlled access to `Private` fields. However, in classes with multiple fields, it is not unusual that https://en.wikipedia.org/wiki/Copy-and-paste_programming[copy-and-paste] is used to quickly create the needed properties, which can result in the wrong field being accessed by the property procedures.
+
+[source,vbnet]
+----
+Class C
+    Private _x As Integer
+    Private _Y As Integer
+
+    Public ReadOnly Property Y As Integer
+        Get
+            Return _x ' Noncompliant: The returned field should be '_y'
+        End Get
+    End Property
+End Class
+----
 
 This rule raises an issue in any of these cases:
 


### PR DESCRIPTION
Update rule content and descriptions to LaYC format.
[S4275: Getters and setters should access the expected fields](https://sonarsource.github.io/rspec/#/rspec/S4275)

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

