### PR TITLE
Fix PR rate limiting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           npm run predeploy
         env:
           NODE_OPTIONS: "--max-old-space-size=3048"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: read
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.


### PR DESCRIPTION
Propagate the GITHUB_TOKEN to the `predeploy` action to enable authorized read access to the list of open PRs.
Also specify explicitly that the action requires read access to PRs