### PR TITLE
Modify rule S2234: LaYC format

### DIFF
--- a/rules/S2234/csharp/compliantCode.adoc
+++ b/rules/S2234/csharp/compliantCode.adoc
@@ -1,0 +1,16 @@
+[source,csharp,diff-id=1,diff-type=compliant]
+----
+public double Divide(int divisor, int dividend)
+{
+    return divisor / dividend;
+}
+
+public void DoTheThing()
+{
+    int divisor = 15;
+    int dividend = 5;
+
+    double result = Divide(divisor, dividend); // Compliant: arguments' order match their respective parameter names
+    // ...
+}
+----

--- a/rules/S2234/csharp/compliantCode.adoc
+++ b/rules/S2234/csharp/compliantCode.adoc
@@ -10,7 +10,7 @@ public void DoTheThing()
     int divisor = 15;
     int dividend = 5;
 
-    double result = Divide(divisor, dividend); // Compliant: arguments' order match their respective parameter names
+    double result = Divide(divisor, dividend); // Compliant
     // ...
 }
 ----

--- a/rules/S2234/csharp/metadata.json
+++ b/rules/S2234/csharp/metadata.json
@@ -1,3 +1,4 @@
 {
-  
+  "title": "Arguments should be passed in the same order as the method parameters",
+  "quickfix": "targeted"
 }

--- a/rules/S2234/csharp/noncompliantCode.adoc
+++ b/rules/S2234/csharp/noncompliantCode.adoc
@@ -1,0 +1,16 @@
+[source,csharp,diff-id=1,diff-type=noncompliant]
+----
+public double Divide(int divisor, int dividend)
+{
+    return divisor / dividend;
+}
+
+public void DoTheThing()
+{
+    int divisor = 15;
+    int dividend = 5;
+
+    double result = Divide(dividend, divisor);  // Noncompliant: arguments' order doesn't match their respective parameter names
+    // ...
+}
+----

--- a/rules/S2234/csharp/rule.adoc
+++ b/rules/S2234/csharp/rule.adoc
@@ -1,58 +1,7 @@
-== Why is this an issue?
+:operationName: method
+:noncompliantCode: csharp/noncompliantCode.adoc
+:compliantCode: csharp/compliantCode.adoc
 
-include::../description.adoc[]
+include::../why-dotnet.adoc[]
 
-=== Noncompliant code example
-
-[source,csharp]
-----
-public double Divide(int divisor, int dividend) 
-{
-    return divisor/dividend;
-}
-
-public void DoTheThing() 
-{
-    int divisor = 15;
-    int dividend = 5;
-
-    double result = Divide(dividend, divisor);  // Noncompliant; operation succeeds, but result is unexpected
-    //...
-}
-----
-
-=== Compliant solution
-
-[source,csharp]
-----
-public double Divide(int divisor, int dividend) 
-{
-    return divisor/dividend;
-}
-
-public void DoTheThing() 
-{
-    int divisor = 15;
-    int dividend = 5;
-
-    double result = Divide(divisor, dividend);
-    //...
-}
-----
-
-ifdef::env-github,rspecator-view[]
-
-'''
-== Implementation Specification
-(visible only on this page)
-
-include::../message.adoc[]
-
-include::../highlighting.adoc[]
-
-'''
-== Comments And Links
-(visible only on this page)
-
-include::../comments-and-links.adoc[]
-endif::env-github,rspecator-view[]
+include::../rspectator.adoc[]

--- a/rules/S2234/rspectator.adoc
+++ b/rules/S2234/rspectator.adoc
@@ -1,0 +1,16 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+include::message.adoc[]
+
+include::highlighting.adoc[]
+
+'''
+== Comments And Links
+(visible only on this page)
+
+include::comments-and-links.adoc[]
+endif::env-github,rspecator-view[]

--- a/rules/S2234/vbnet/compliantCode.adoc
+++ b/rules/S2234/vbnet/compliantCode.adoc
@@ -8,7 +8,7 @@ Public Sub DoTheThing()
     Dim divisor = 15
     Dim dividend = 5
 
-    Dim result = Divide(divisor, dividend) ' Compliant: arguments' order match their respective parameter names'
+    Dim result = Divide(divisor, dividend) ' Compliant
     '...
 End Sub
 ----

--- a/rules/S2234/vbnet/compliantCode.adoc
+++ b/rules/S2234/vbnet/compliantCode.adoc
@@ -1,0 +1,14 @@
+[source,vbnet,diff-id=1,diff-type=compliant]
+----
+Public Function Divide(divisor As Integer, dividend As Integer) As Double
+    Return divisor / dividend
+End Function
+
+Public Sub DoTheThing()
+    Dim divisor = 15
+    Dim dividend = 5
+
+    Dim result = Divide(divisor, dividend) ' Compliant: arguments' order match their respective parameter names'
+    '...
+End Sub
+----

--- a/rules/S2234/vbnet/metadata.json
+++ b/rules/S2234/vbnet/metadata.json
@@ -1,3 +1,4 @@
 {
-  
+  "title": "Arguments should be passed in the same order as the procedure parameters",
+  "quickfix": "targeted"
 }

--- a/rules/S2234/vbnet/noncompliantCode.adoc
+++ b/rules/S2234/vbnet/noncompliantCode.adoc
@@ -1,0 +1,14 @@
+[source,vbnet,diff-id=1,diff-type=noncompliant]
+----
+Public Function Divide(divisor As Integer, dividend As Integer) As Double
+    Return divisor / dividend
+End Function
+
+Public Sub DoTheThing()
+    Dim divisor = 15
+    Dim dividend = 5
+
+    Dim result = Divide(dividend, divisor)  ' Noncompliant: arguments' order doesn't match their respective parameter names
+    '...
+End Sub
+----

--- a/rules/S2234/vbnet/rule.adoc
+++ b/rules/S2234/vbnet/rule.adoc
@@ -1,54 +1,7 @@
-== Why is this an issue?
+:operationName: procedure
+:noncompliantCode: vbnet/noncompliantCode.adoc
+:compliantCode: vbnet/compliantCode.adoc
 
-When the names of parameters in a procedure call match the names of the procedure arguments, it contributes to a clearer, more readable code. However, when the names match but are passed in a different order than the method arguments, it indicates a mistake in the parameter order which will likely lead to unexpected results.
+include::../why-dotnet.adoc[]
 
-=== Noncompliant code example
-
-[source,vbnet]
-----
-Public Function Divide(ByVal divisor As Integer, ByVal dividend As Integer) As Double
-    Return divisor / dividend
-End Function
-
-Public Sub DoTheThing()
-    Dim divisor = 15
-    Dim dividend = 5
-
-    Dim result = Divide(dividend, divisor)  ' Noncompliant; operation succeeds, but result is unexpected
-    '...
-End Sub
-----
-
-=== Compliant solution
-
-[source,vbnet]
-----
-Public Function Divide(ByVal divisor As Integer, ByVal dividend As Integer) As Double
-    Return divisor / dividend
-End Function
-
-Public Sub DoTheThing()
-    Dim divisor = 15
-    Dim dividend = 5
-
-    Dim result = Divide(divisor, dividend) 
-    '...
-End Sub
-----
-
-ifdef::env-github,rspecator-view[]
-
-'''
-== Implementation Specification
-(visible only on this page)
-
-include::../message.adoc[]
-
-include::../highlighting.adoc[]
-
-'''
-== Comments And Links
-(visible only on this page)
-
-include::../comments-and-links.adoc[]
-endif::env-github,rspecator-view[]
+include::../rspectator.adoc[]

--- a/rules/S2234/why-dotnet.adoc
+++ b/rules/S2234/why-dotnet.adoc
@@ -1,0 +1,9 @@
+== Why is this an issue?
+
+Calling a {operationName} with argument variables whose names match the {operationName} parameter names but in a different order can cause confusion. It could indicate a mistake in the arguments' order, leading to unexpected results.
+
+include::{noncompliantCode}[]
+
+However, matching the {operationName} parameters' order contributes to clearer and more readable code:
+
+include::{compliantCode}[]


### PR DESCRIPTION
Update [S2234](https://sonarsource.github.io/rspec/#/rspec/S2234) to LaYC format

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

