### PR TITLE
Modify rule S2692: align C# and VB.NET examples

### DIFF
--- a/rules/S2692/vbnet/rule.adoc
+++ b/rules/S2692/vbnet/rule.adoc
@@ -16,14 +16,20 @@ Any checks which look for values `> 0` ignore the first element, which is likely
 strings.Contains(someString) ' Boolean result
 ----
 
-This rule raises an issue when an `IndexOf` value retrieved from a `String`, `List` or array is tested against `> 0`.
+This rule raises an issue when the output value of any of the following methods is tested against `> 0`:
+
+* https://learn.microsoft.com/en-us/dotnet/api/system.collections.ilist.indexof[IndexOf], applied to `String`, list or array
+* https://learn.microsoft.com/en-us/dotnet/api/system.string.indexofany[IndexOfAny], applied to a `String`
+* https://learn.microsoft.com/en-us/dotnet/api/system.string.lastindexof[LastIndexOf], applied to a `String`, list or array
+* https://learn.microsoft.com/en-us/dotnet/api/system.string.lastindexofany[LastIndexOfAny], applied to a `String`
 
 [source,vbnet]
 ----
-strings.IndexOf(someString) > 0  ' Noncompliant: index 0 missing
+someArray.IndexOf(someItem) > 0        ' Noncompliant: index 0 missing
+someString.IndexOfAny(charsArray) > 0  ' Noncompliant: index 0 missing
+someList.LastIndexOf(someItem) > 0     ' Noncompliant: index 0 missing
+someString.LastIndexOf(charsArray) > 0 ' Noncompliant: index 0 missing
 ----
-
-This rule also raises an issue when https://learn.microsoft.com/en-us/dotnet/api/system.string.indexofany[IndexOfAny], https://learn.microsoft.com/en-us/dotnet/api/system.string.lastindexof[LastIndexOf] or https://learn.microsoft.com/en-us/dotnet/api/system.string.lastindexofany[LastIndexOfAny] from a `String` is tested against `> 0`.
 
 == How to fix it
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

