### PR TITLE
Modify rule S4277: Fix vbnet diff tag 

### DIFF
--- a/rules/S4277/vbnet/rule.adoc
+++ b/rules/S4277/vbnet/rule.adoc
@@ -6,7 +6,7 @@ include::../why-dotnet.adoc[]
 
 ==== Noncompliant code example
 
-[source,vbnet,diff-id=1,diff-type=noncompliant]]
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 <Export(GetType(IFooBar))>
 <PartCreationPolicy(CreationPolicy.[Shared])>


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

