### PR TITLE
Modify rule S3451: fix wrong link

### DIFF
--- a/rules/S3451/csharp/rule.adoc
+++ b/rules/S3451/csharp/rule.adoc
@@ -2,7 +2,7 @@
 
 https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.defaultvalueattribute[DefaultValue] does not make the compiler set the default value, as its name may suggest. What you probably wanted to use is https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.defaultparametervalueattribute[DefaultParameterValue]. 
 
-The https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.defaultparametervalueattribute[DefaultValue] attribute from the `System.ComponentModel` namespace, is sometimes used to declare a member's default value. This can be used, for instance, by the reset feature of a visual designer or by a code generator.
+The https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.defaultvalueattribute[DefaultValue] attribute from the `System.ComponentModel` namespace, is sometimes used to declare a member's default value. This can be used, for instance, by the reset feature of a visual designer or by a code generator.
 
 [source,csharp]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

