### PR TITLE
Handle variables *inside* an include

### DIFF
--- a/ci/replace_variables_in_path.sh
+++ b/ci/replace_variables_in_path.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -uo pipefail
+
+BEFORE=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\1/")
+VAR=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\2/")
+AFTER=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\3/")
+
+grep "${VAR}" "$1" | cut -f2 | xargs -I@ echo "${BEFORE}@${AFTER}"

--- a/ci/replace_variables_in_path.sh
+++ b/ci/replace_variables_in_path.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
+set -uoe pipefail
 
-set -uo pipefail
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 VARS_FILE INCLUDE_TEXT"
+    echo "  This script should be called by validate_asciidoc.sh."
+    echo "  When provided with an include that contains one variable part, will"
+    echo "       output all possible values for this include."
+    echo ""
+    echo "  VARS_FILE:    a text file listing all variables as \"name\tvalue\""
+    echo ""
+    echo "  INCLUDE_TEXT: the whole include declaration"
+    exit 1
+fi
+
+if echo "$2" | grep -Eq "\{.*\{" ; then
+    echo "Multiple variables detected in \"$2\" this is not supported"
+    exit 2
+fi
 
 BEFORE=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\1/")
-VAR=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\2/")
-AFTER=$(echo "$2" | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\3/")
+VAR=$(echo "$2"    | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\2/")
+AFTER=$(echo "$2"  | sed -r "s/include::(.*)\{(.*)\}(.*)\[\]/\3/")
 
 grep "${VAR}" "$1" | cut -f2 | xargs -I@ echo "${BEFORE}@${AFTER}"

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -24,6 +24,8 @@ exit_code=0
 
 ./ci/generate_html.sh
 
+PATH_WITH_VARIABLE="$(realpath ./ci/replace_variables_in_path.sh)"
+
 cd rspec-tools
 if pipenv run rspec-tools check-description --d ../out; then
     echo "rule.adoc is fine"
@@ -84,14 +86,14 @@ do
 
     # Check that all adoc are included
 
-    # Files can be included through variables. We create a list of variables containing a path to an adoc
+    # Files can be included through variables. We create a list of variables
     # These paths are relative to the file where they are _included_, not where they are _declared_
     # Which is why we need to create this list and cannot do anything with the paths it contains until we find the corresponding include
-    find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh ":\w+:\s+[A-Za-z0-9\/-]+\.adoc" "$1" | grep -v "rule.adoc" | sed -r "s/:(\w+):\s+([A-Za-z0-9\/-]+\.adoc)/\1\t\2/"' shell {} \; > vars
+    find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh ":\w+:\s+[A-Za-z0-9\/-]+" "$1" | sed -r "s/:(\w+):\s+([A-Za-z0-9\/-]+)/\1\t\2/"' shell {} \; > vars
     # Directly included
     find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh "include::" "$1" | grep -Ev "{\w+}" | grep -v "rule.adoc" | sed -r "s/include::(.*)\[\]/\1/" | xargs -r -I@ realpath "$PWD/@"' shell {} \; > included
     # Included through variable
-    VARS_FULL_PATH=$(realpath vars) find "$dir" -name "*.adoc" -execdir sh -c 'grep -h "include::{" "$1" | sed -r "s/include::\{(.*)\}\[\]/\1/" | grep -f - ${VARS_FULL_PATH} | cut -f2 | xargs -r -I@ realpath "$PWD/@"' shell {} \; >> included
+    VARS_FULL_PATH=$(realpath vars) PATH_WITH_VARIABLE=${PATH_WITH_VARIABLE} find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh "include::.*\{" "$1" | xargs -r -I@ $PATH_WITH_VARIABLE $VARS_FULL_PATH "@" | xargs -r -I@ realpath "$PWD/@"' shell {} \; >> included
     find "$dir" -name "*.adoc" ! -name 'rule.adoc' ! -name 'tmp*.adoc' -exec sh -c 'realpath $1' shell {} \; > created
     orphans=$(comm -1 -3 <(sort -u included) <(sort -u created))
     if [[ -n "$orphans" ]]; then

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -89,7 +89,7 @@ do
     # Files can be included through variables. We create a list of variables
     # These paths are relative to the file where they are _included_, not where they are _declared_
     # Which is why we need to create this list and cannot do anything with the paths it contains until we find the corresponding include
-    find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh ":\w+:\s+[A-Za-z0-9\/-]+" "$1" | sed -r "s/:(\w+):\s+([A-Za-z0-9\/-]+)/\1\t\2/"' shell {} \; > vars
+    find "$dir" -name "*.adoc" -execdir sed -r -n -e 's/^:(\w+):\s+([A-Za-z0-9\/._-]+)$/\1\t\2/p' {} \; > vars
     # Directly included
     find "$dir" -name "*.adoc" -execdir sh -c 'grep -Eh "include::" "$1" | grep -Ev "{\w+}" | grep -v "rule.adoc" | sed -r "s/include::(.*)\[\]/\1/" | xargs -r -I@ realpath "$PWD/@"' shell {} \; > included
     # Included through variable


### PR DESCRIPTION
The point of this branch is the second commit that changes validate_asciidoc.sh. The first one is taken from another PR and should not be reviewed.

The previous version of the validation could handle the following case:
```asciidoc
:path: path/to/file.adoc
include::{path}[]
```

This new validation also adds support for the case of a variable inside a path:
```asciidoc
:language: csharp
include::rules/S1000/{language}/file.adoc[]
```