### PR TITLE
Modify rule S5146: Fix invalid Python sample

### DIFF
--- a/rules/S5146/python/how-to-fix-it/flask.adoc
+++ b/rules/S5146/python/how-to-fix-it/flask.adoc
@@ -12,8 +12,8 @@ from flask import Flask, redirect
 
 app = Flask("example")
 
-@app.route("/redirect")
-def redirect():
+@app.route("/redirecting")
+def redirecting():
     url = request.args["url"]
     return redirect(url) # Noncompliant
 ----
@@ -26,8 +26,8 @@ from flask import Flask, redirect, url_for
 
 app = Flask("example")
 
-@app.route("/redirect")
-def redirect():
+@app.route("/redirecting")
+def redirecting():
     url = request.args["url"]
     return redirect(url_for(url))
 ----

--- a/rules/S5146/python/how-to-fix-it/flask.adoc
+++ b/rules/S5146/python/how-to-fix-it/flask.adoc
@@ -8,9 +8,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 [source,python,diff-id=1,diff-type=noncompliant]
 ----
-from flask import Flask, redirect
-
-app = Flask("example")
+from flask import redirect
 
 @app.route("/redirecting")
 def redirecting():
@@ -22,9 +20,7 @@ def redirecting():
 
 [source,python,diff-id=1,diff-type=compliant]
 ----
-from flask import Flask, redirect, url_for
-
-app = Flask("example")
+from flask import redirect, url_for
 
 @app.route("/redirecting")
 def redirecting():

--- a/rules/S5146/python/how-to-fix-it/flask.adoc
+++ b/rules/S5146/python/how-to-fix-it/flask.adoc
@@ -8,7 +8,9 @@ include::../../common/fix/code-rationale.adoc[]
 
 [source,python,diff-id=1,diff-type=noncompliant]
 ----
-from flask import redirect
+from flask import Flask, redirect
+
+app = Flask("example")
 
 @app.route("/redirecting")
 def redirecting():
@@ -20,7 +22,9 @@ def redirecting():
 
 [source,python,diff-id=1,diff-type=compliant]
 ----
-from flask import redirect, url_for
+from flask import Flask, redirect, url_for
+
+app = Flask("example")
 
 @app.route("/redirecting")
 def redirecting():


### PR DESCRIPTION
I couldn't get Sonarcloud to trigger this issue using the provided noncompliant code example. 

I think the code examples as written end up being circular because the local function 'redirect()' will call itself rather than the imported 'redirect()' function of the same name. The fix is to change the local function name to be redirecting(). I changed the API endpoint name as well so that it matched. Once I had made this change, the noncompliant code example did lead to Sonarcloud spotting the issue.

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

