### PR TITLE
Modify rule S5707: LaYC format

### DIFF
--- a/rules/S5707/python/rule.adoc
+++ b/rules/S5707/python/rule.adoc
@@ -2,12 +2,33 @@ This rule raise an issue if something other than `None` or a valid exception is 
 
 == Why is this an issue?
 
-Exception chaining enables users to see if an exception was triggered by another exception (see https://peps.python.org/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
+Exception chaining enables users to see if an exception is the direct consequence of another exception (see https://peps.python.org/pep-3134/[PEP-3134]). This is useful to propagate the original context of the error.
 
-* `raise NewException() from chained_exception`
-* ``++new_exception.__cause__ = chained_exception++``
+Exceptions are chained using either of the following syntax:
 
-It is also possible to erase a chaining by setting ``++new_exception.__cause__ = None++`` or using `raise ... from None` (see https://peps.python.org/pep-0409/[PEP-409]).
+* With the `from` keyword
+
+[source,python]
+----
+try:
+    ...
+except OSError as e:
+    raise RuntimeError("Something went wrong") from e
+----
+
+* With the ``++__cause__++`` property
+
+[source,python]
+----
+try:
+    ...
+except OSError as e:
+    new_exception = RuntimeError("Something went wrong")
+    new_exception.__cause__ = e
+    raise new_exception
+----
+
+It is also possible to erase a chaining by setting ``++new_exception.__cause__ = None++`` or using `raise new_exception from None` (see https://peps.python.org/pep-0409/[PEP-409]).
 
 
 Chaining will fail and raise a `TypeError` if something other than `None` or a valid exception, i.e. an instance or a subclass of `BaseException`, is provided.

--- a/rules/S5707/python/rule.adoc
+++ b/rules/S5707/python/rule.adoc
@@ -1,17 +1,24 @@
+This rule raise an issue if something other than `None` or a valid exception is provided as the cause of an exception chain.
+
 == Why is this an issue?
 
-Exception chaining enables users to see if an exception was triggered by another exception (see https://www.python.org/dev/peps/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
+Exception chaining enables users to see if an exception was triggered by another exception (see https://www.python.org/devpeps/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
 
-* ``++raise NewException() from chained_exception++``
-* ``++new_exception.__cause__ = chained_exception++``
+* `raise NewException() from chained_exception`
+* `new_exception.__cause__ = chained_exception`
 
-It is also possible to erase a chaining by setting ``++new_exception.__cause__ = None++`` or using ``++except ... from None++`` (see https://www.python.org/dev/peps/pep-0409/[PEP-409]).
-
-
-Chaining will fail and raise a ``++TypeError++`` if something else than ``++None++`` or a valid exception, i.e. an instance of ``++BaseException++`` or of a subclass, is provided.
+It is also possible to erase a chaining by setting `new_exception.__cause__ = None` or using `except ... from None` (see https://www.python.org/dev/peps/pep-0409/[PEP-409]).
 
 
-=== Noncompliant code example
+Chaining will fail and raise a `TypeError` if something other than `None` or a valid exception, i.e. an instance or a subclass of `BaseException`, is provided.
+
+== How to fix it
+
+Make sure the cause of a chain of exceptions is either `None` or a valid exception.
+
+=== Code examples
+
+==== Noncompliant code example
 
 [source,python]
 ----
@@ -22,17 +29,17 @@ try:
     raise ValueError("orig")
 except ValueError as e:
     new_exc = TypeError("new")
-    new_exc.__cause__ = A()  # Noncompliant
+    new_exc.__cause__ = A()  # Noncompliant: A is not a subclass of BaseException.
     raise new_exc
 
 try:
     raise ValueError("orig")
 except ValueError as e:
-    raise TypeError("new") from "test"  # Noncompliant
+    raise TypeError("new") from "test"  # Noncompliant: "test" is not a valid exception.
 ----
 
 
-=== Compliant solution
+==== Compliant solution
 
 [source,python]
 ----
@@ -64,10 +71,15 @@ except ValueError as e:
 
 == Resources
 
-* PEP 3134 – https://www.python.org/dev/peps/pep-3134/[Exception Chaining and Embedded Tracebacks]
-* PEP 409 – https://www.python.org/dev/peps/pep-0409/[Suppressing exception context]
-* PEP 352 - https://www.python.org/dev/peps/pep-0352/#exception-hierarchy-changes[Required Superclass for Exceptions]
-* Python documentation - https://docs.python.org/3/library/exceptions.html[Built-in Exceptions]
+=== Documentation
+
+* https://docs.python.org/3/library/exceptions.html[Built-in Exceptions] - Python documentation
+
+=== Standards
+
+* https://www.python.org/dev/peps/pep-3134/[Exception Chaining and Embedded Tracebacks] - PEP 3134 
+* https://www.python.org/dev/peps/pep-0409/[Suppressing exception context] - PEP 409 
+* https://www.python.org/dev/peps/pep-0352/#exception-hierarchy-changes[Required Superclass for Exceptions] - PEP 352 
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5707/python/rule.adoc
+++ b/rules/S5707/python/rule.adoc
@@ -5,9 +5,9 @@ This rule raise an issue if something other than `None` or a valid exception is 
 Exception chaining enables users to see if an exception was triggered by another exception (see https://peps.python.org/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
 
 * `raise NewException() from chained_exception`
-* `new_exception.__cause__ = chained_exception`
+* ``++new_exception.__cause__ = chained_exception++``
 
-It is also possible to erase a chaining by setting `new_exception.__cause__ = None` or using `except ... from None` (see https://peps.python.org/pep-0409/[PEP-409]).
+It is also possible to erase a chaining by setting ``++new_exception.__cause__ = None++`` or using `raise ... from None` (see https://peps.python.org/pep-0409/[PEP-409]).
 
 
 Chaining will fail and raise a `TypeError` if something other than `None` or a valid exception, i.e. an instance or a subclass of `BaseException`, is provided.
@@ -73,7 +73,7 @@ except ValueError as e:
 
 === Documentation
 
-* https://docs.python.org/3/library/exceptions.html[Built-in Exceptions] - Python documentation
+* https://docs.python.org/3/library/exceptions.html[Built-in Exceptions]
 
 === Standards
 

--- a/rules/S5707/python/rule.adoc
+++ b/rules/S5707/python/rule.adoc
@@ -2,12 +2,12 @@ This rule raise an issue if something other than `None` or a valid exception is 
 
 == Why is this an issue?
 
-Exception chaining enables users to see if an exception was triggered by another exception (see https://www.python.org/devpeps/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
+Exception chaining enables users to see if an exception was triggered by another exception (see https://peps.python.org/pep-3134/[PEP-3134]). Exceptions are chained using either of the following syntax:
 
 * `raise NewException() from chained_exception`
 * `new_exception.__cause__ = chained_exception`
 
-It is also possible to erase a chaining by setting `new_exception.__cause__ = None` or using `except ... from None` (see https://www.python.org/dev/peps/pep-0409/[PEP-409]).
+It is also possible to erase a chaining by setting `new_exception.__cause__ = None` or using `except ... from None` (see https://peps.python.org/pep-0409/[PEP-409]).
 
 
 Chaining will fail and raise a `TypeError` if something other than `None` or a valid exception, i.e. an instance or a subclass of `BaseException`, is provided.
@@ -77,9 +77,9 @@ except ValueError as e:
 
 === Standards
 
-* https://www.python.org/dev/peps/pep-3134/[Exception Chaining and Embedded Tracebacks] - PEP 3134 
-* https://www.python.org/dev/peps/pep-0409/[Suppressing exception context] - PEP 409 
-* https://www.python.org/dev/peps/pep-0352/#exception-hierarchy-changes[Required Superclass for Exceptions] - PEP 352 
+* https://peps.python.org/pep-3134/[Exception Chaining and Embedded Tracebacks] - PEP 3134 
+* https://peps.python.org/pep-0409/[Suppressing exception context] - PEP 409 
+* https://peps.python.org/pep-0352/#exception-hierarchy-changes[Required Superclass for Exceptions] - PEP 352 
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

