### PR TITLE
Modify rule S6385: Change resource type, fix formatting

### DIFF
--- a/rules/S6385/azureresourcemanager/rule.adoc
+++ b/rules/S6385/azureresourcemanager/rule.adoc
@@ -63,6 +63,7 @@ include::../description.adoc[]
 === Going the extra mile
 
 Here is a list of recommendations that can be followed regarding good usages of roles:
+
 * Apply the least privilege principle by creating a custom role with as few permissions as possible. 
 * As custom role can be updated, gradually add atomic permissions when required.
 * Limit the assignable scopes of the custom role to a set of Resources or Ressource Groups.

--- a/rules/S6385/highlighting.adoc
+++ b/rules/S6385/highlighting.adoc
@@ -1,7 +1,7 @@
 === Highlighting
 
 * Primary location
-** Highlight the ``++azurerm_role_definition++`` resource.
+** Highlight the resource of type ``++Microsoft.Authorization/roleDefinitions++``.
 * Secondary location
 ** The ``++*++`` item in the ``++actions++`` list
 ** Subscription or Management Group scopes in `assignable_scopes` 


### PR DESCRIPTION
While working on SONARIAC-772 I've found a couple of issues with the RSPEC for S6385 for ARM. This PR fixes them:
* Change resource type name from the one copied from Terraform to the one applicable in ARM
* Fix formatting in bullet point list

Implementation ticket: SONARIAC-772, PR using this fix https://github.com/SonarSource/sonar-iac/pull/767

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

