### PR TITLE
Update link_formatting.adoc

### DIFF
--- a/docs/link_formatting.adoc
+++ b/docs/link_formatting.adoc
@@ -21,7 +21,7 @@ Here is how the above links should look like:
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.object.tostring[`Object.ToString` Method]
 * Google Security Blog - https://security.googleblog.com/2016/09/moving-towards-more-secure-web.html[Moving towards a more secure web]
 * Stack Overflow - Answer by Stephen Cleary for https://stackoverflow.com/a/27551261[Best way to handle null task inside async method?]
-* S2755 - https://rules.sonarsource.com/java/RSPEC-2755[XML parsers should not be vulnerable to XXE attacks]
+* https://rules.sonarsource.com/java/RSPEC-2755[S2755 - XML parsers should not be vulnerable to XXE attacks]
 
 
 === Additional things to consider when adding a link to a rule:


### PR DESCRIPTION
Fixed rule link example so that rule number was also part of the underlined link.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

