### PR TITLE
Modify Rule S6580: Move text from Description to Why

### DIFF
--- a/rules/S6580/description-dotnet.adoc
+++ b/rules/S6580/description-dotnet.adoc
@@ -1,17 +1,1 @@
-When converting a string representation of a date and time to a `DateTime` object with one of the available system parsing methods, you should always provide an `IFormatProvider` parameter.
-If not provided, the method will use the machine's `CultureInfo`; if the given string does not follow it, you'll have an object that does not match the string representation or an unexpected runtime error.
-
-This rule raises an issue for the following date and time string representation parsing methods:
-
-* `Parse`
-* `ParseExact`
-* `TryParse`
-* `TryParseExact`
-
-Of the following types:
-
-* `System.DateOnly`
-* `System.DateTime`
-* `System.DateTimeOffset`
-* `System.TimeOnly`
-* `System.TimeSpan`
+When converting a string representation of a date and time to a `DateTime` object or any other temporal type with one of the available system parsing methods, you should always provide an `IFormatProvider` parameter.

--- a/rules/S6580/why-dotnet.adoc
+++ b/rules/S6580/why-dotnet.adoc
@@ -1,3 +1,18 @@
 == Why is this an issue?
 
-If you try to parse a string representation of date and time that does not have the expected format based on the machine's culture you'll get `DateTime` or `DateTimeOffset` object that does not match the input or a runtime error.
+If you try to parse a string representation of a date or time without a format provider, the method will use the machine's `CultureInfo`; if the given string does not follow it, you'll have an object that does not match the string representation or an unexpected runtime error.
+
+This rule raises an issue for the following date and time string representation parsing methods:
+
+* `Parse`
+* `ParseExact`
+* `TryParse`
+* `TryParseExact`
+
+Of the following types:
+
+* `System.DateOnly`
+* `System.DateTime`
+* `System.DateTimeOffset`
+* `System.TimeOnly`
+* `System.TimeSpan`


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

