### PR TITLE
Modify rule S961: LaYC format

### DIFF
--- a/rules/S961/cfamily/rule.adoc
+++ b/rules/S961/cfamily/rule.adoc
@@ -1,12 +1,13 @@
 == Why is this an issue?
 
-This is a constraint error, but preprocessors have been known to ignore this problem. Each argument in a function-like macro must consist of at least one preprocessing token otherwise the behaviour is undefined.
-
+Before compilation, preprocessors replace macros with the code they expand to. If a function-like macro is invoked without all of its arguments, the resulting code may not be valid, and this can cause the program to fail to compile or to behave unexpectedly at runtime.
 
 == Resources
 
+* CPP reference - https://en.cppreference.com/w/cpp/preprocessor/replace[Replacing text macros]
+* CPP reference - https://en.cppreference.com/w/cpp/language/translation_phases#Phase_3[Phases of translation: Phase 3]
 * MISRA C:2004, 19.8 - A function-like macro shall not be invoked without all of its arguments.
-* https://cwe.mitre.org/data/definitions/628[MITRE, CWE-628] - Function Call with Incorrectly Specified Arguments
+* https://cwe.mitre.org/data/definitions/628[CWE] - CWE-628: Function Call with Incorrectly Specified Arguments
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S961/cfamily/rule.adoc
+++ b/rules/S961/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Before compilation, preprocessors replace macros with the code they expand to. If a function-like macro is invoked without all of its arguments, the resulting code may not be valid, and this can cause the program to fail to compile or to behave unexpectedly at runtime.
+Before compilation, the preprocessor replaces macros with the code they expand to. The resulting code may be invalid when a function-like macro is invoked without all its arguments, which can cause the program to fail to compile or to behave unexpectedly at runtime.
 
 == Resources
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

