### PR TITLE
Modify rule S6487: LaYC format

### DIFF
--- a/rules/S6487/cfamily/rule.adoc
+++ b/rules/S6487/cfamily/rule.adoc
@@ -26,15 +26,15 @@ This rule raises an issue when:
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-std::cout << std::format("{} {}", 1, 2, sqrt(2)); // Noncompliant
-std::cout << std::format("{0} {0} {2}", 1, 2, 3); // Noncompliant
+std::cout << std::format("{} {}", 1, 2, sqrt(2));
+std::cout << std::format("{0} {0} {2}", 1, 2, 3);
 ----
 
 ==== Compliant solution
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
-std::cout << std::format("{} {} {}", 1, 2, sqrt(2)); // Compliant
-std::cout << std::format("{0} {0} {2} {1}", 1, 2, 3); // Compliant
+std::cout << std::format("{} {} {}", 1, 2, sqrt(2));
+std::cout << std::format("{0} {0} {2} {1}", 1, 2, 3);
 ----
 
 == Resources


### PR DESCRIPTION
Remove extra comments

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

