### PR TITLE
Modify rule S5972: LaYC format

### DIFF
--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-`std::string` and `std::string_view` provide functions to search for specific characters or groups of characters within a string. If the search is successful, these functions will return the position of the first character in the string that matches the search pattern. If the search fails, the functions will return the particular value `npos`.
+`std::string` and `std::string_view` provide functions to search for specific characters or groups of characters within a string. If the search is successful, these functions will return the position of the first character in the string that matches the search pattern. If the search fails, the functions will return the special value `npos`.
 
 `npos` is equivalent to `true` when used in a boolean context. Therefore, using the returned value in a boolean context to determine if the search was successful does not work.
 

--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -6,7 +6,7 @@
 
 == How to fix it
 
-The rule raises an issue when the returned value of the following functions is used in a boolean context:
+The returned value of the following functions should be compared to `npos` when used in a boolean context:
 
 * `find`
 * `rfind`

--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -15,7 +15,6 @@ The returned value of the following functions should be compared to `npos` when 
 * `find_first_not_of`
 * `find_last_not_of`
 
-The returned value of these functions needs to be compared to `npos`.
 
 === Code examples
 

--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -2,7 +2,7 @@
 
 `std::string` and `std::string_view` provide functions to search for specific characters or groups of characters within a string. If the search is successful, these functions will return the position of the first character in the string that matches the search pattern. If the search fails, the functions will return the special value `npos`.
 
-`npos` is equivalent to `true` when used in a boolean context. Therefore, using the returned value in a boolean context to determine if the search was successful does not work.
+`npos` is converted to `true` when used in a boolean context. Therefore, using the returned value in a boolean context to determine if the search was successful does not work.
 
 == How to fix it
 

--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -1,8 +1,12 @@
 == Why is this an issue?
 
-The functions of `std::string` and `std::string_view` that search inside the string return the character position, and use the special value `npos` if the pattern was not found. When converted to a boolean, `npos` is equivalent to `true`. Therefore, testing if the search succeeded requires to compare the returned value to `npos`, not to use it in a boolean context.
+`std::string` and `std::string_view` provide functions to search for specific characters or groups of characters within a string. If the search is successful, these functions will return the position of the first character in the string that matches the search pattern. If the search fails, the functions will return the particular value `npos`.
 
-This rule raises an issue when the returned value the following functions are used in a boolean context:
+`npos` is equivalent to `true` when used in a boolean context. Therefore, using the returned value in a boolean context to determine if the search was successful does not work.
+
+== How to fix it
+
+The rule raises an issue when the returned value of the following functions is used in a boolean context:
 
 * `find`
 * `rfind`
@@ -11,31 +15,40 @@ This rule raises an issue when the returned value the following functions are us
 * `find_first_not_of`
 * `find_last_not_of`
 
+The returned value of these functions needs to be compared to `npos`.
 
-=== Noncompliant code example
+=== Code examples
 
-[source,cpp]
+==== Noncompliant code example
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 void f() {
   std::string s = "";
-  if (s.find("42")) { // Noncompliant
-    // this branch is taken even if "s" doesn't contain "42"
+  if (s.find("42")) { // Noncompliant: the condition is true even if "s" does not contain "42"
+    // ...
   }
 }
 ----
 
-
-=== Compliant solution
-
-[source,cpp]
+==== Compliant solution
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 void f() {
   std::string s = "";
   if (s.find("42") != std::string::npos) {
-    // this branch is correctly not taken
+    // ...
   }
 }
 ----
+
+== Resources
+
+=== Documentation
+
+* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string[Search functions for std::basic_string]
+* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string_view[Search functions for std::basic_string_view]
+* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string/npos[std::basic_string<CharT,Traits>::npos]
+* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string_view/npos[std::basic_string_view<CharT,Traits>::npos]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

