### PR TITLE
Deprecate rule S6374: in favor of S2755 (APPSEC-130)

### DIFF
--- a/rules/S6374/metadata.json
+++ b/rules/S6374/metadata.json
@@ -1,21 +1,17 @@
 {
   "title": "XML parsers should not load external schemas",
   "type": "VULNERABILITY",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "15min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
-
+      "RSPEC-2755"
     ],
-    "legacyKeys": [
-
-    ]
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6374",


### PR DESCRIPTION
[This comment on Jira](https://sonarsource.atlassian.net/browse/APPSEC-130?focusedCommentId=509832) goes into detail on why this rule should be deprecated.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

