### PR TITLE
Modify rule S6490: LaYC format

### DIFF
--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -1,23 +1,27 @@
 == Why is this an issue?
 
-With `std::format` and the related formatting functions,
-you can control many aspects of the textual representation of a value.
-Its width and precision can be specified in two ways:
+The `std::format` function and related formatting functions allow you to control how to display a value as text, including its width and precision.
 
-* Statically: the desired values are directly embedded in the format specification. +
-+
-In the following example, the padding character is `_`, the alignment is to the right (`>`), the width specifier is `10`, and the precision specifier is `.2` with a fixed decimal notation (`f`).
-The formatted floating-point value (3.14159) is displayed with two digits after the decimal point and padded with underscores to a minimum width of 10 characters.
-The resulting string is `+"______3.14"+`.
-+
+For example, you can convert the number `3.14159` to a string with a minimum width of `10` and a precision of `2` using:
 [source,cpp]
 ----
 std::format("{:_>10.2f}", 3.14159)
 ----
 
-* Dynamically: `{}` or `{arg-id}` is used to refer to a complementary function argument. +
-+
-The next example results in the same value as in the previous example.
+The format string uses:
+
+* `_` as the padding character
+* `>` to align the value to the right
+* `10` to specify the width
+* `.2` to specify the precision
+* `f` to use the fixed decimal notation
+
+The resulting string is `+"______3.14"+`.
+
+Furthermore, there are two ways to specify the width and the precision:
+
+* Statically, by embedding the desired values in the format specification, as in the previous example.
+* Dynamically, by referring to complementary function arguments using `{}` or `{arg-id}`. The previous example becomes:
 +
 [source,cpp]
 ----
@@ -29,7 +33,11 @@ On the other hand, using dynamic values can result in runtime exceptions and une
 
 Specifically, a `std::format_error` exception is thrown when a dynamic value for the width or the precision specifiers is either negative or not a built-in integer.
 
-This rule focuses on the latter problem: it raises an issue when the specifier used for the width or the precision is not an integer.
+== How to fix it
+
+The rule raises an issue when the width or precision specifier is not an integer.
+
+=== Code examples
 
 [source,cpp]
 ----

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -6,19 +6,18 @@ The value of each of these options can be specified:
 * statically, by placing the desired value in a format specification,
 * or dynamically, by using `{}` or `{arg-id}` to refer to a complementary function argument.
 
-A `std::format_error` exception is thrown when a dynamic value for the width or the precision is either not a built-in integer or negative.
+A `std::format_error` exception is thrown when a dynamic value for the width or the precision specifiers is either not a built-in integer or negative.
 
-This rule focuses on the first problem and raises an issue when the argument used for the width or precision is not an integer.
+This rule focuses on the first problem: it raises an issue when the specifier used for the width or the precision is not an integer.
 
 === Noncompliant code example
 
 [source,cpp]
 ----
-std::format("{0:*^{1}}", s, 5.0); // Noncompliant: width argument is not integer
-std::format("{0:*^10.{1}}", d, "3"); // Noncompliant: precision argument is not integer
-std::format("{0:*^{1}.{2}}", d, "12", 4.0); // Noncompliant: neither  width nor precision arguments are integer
-std::format("{0:*^{1}.{2}}", s, "17", 5.0); // Noncompliant: both width precision arguments are not integer
-std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2); // Noncompliant: the second argument (d) is interpreted as width
+std::format("{0:*^{1}}", s, 5.0); // Noncompliant: the width specifier is not an integer.
+std::format("{0:*^10.{1}}", d, "3"); // Noncompliant: the precision specifier is not an integer.
+std::format("{0:*^{1}.{2}}", d, "12", 4.0); // Noncompliant: neither the width nor the precision specifiers are integers.
+std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2); // Noncompliant: the second argument (d) is interpreted as the width specifier.
 ----
 
 === Compliant solution

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -1,8 +1,7 @@
 == Why is this an issue?
 
-With `std::format`, you can control the length and padding of the textual representation of a value using the width and precision specifiers.
-
-The value of the width and precision specifiers can be specified:
+With `std::format`, you can control many aspects of the textual representation of a value.
+Its width and precision can be specified in two ways:
 
 * Statically: the desired values are directly embedded in the format specification. +
 +

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -55,3 +55,11 @@ void example(std::string_view s, double d, int maxLen) {
   std::format("{0:*^{2}.{3}} {1}", s, d, maxLen, maxLen + 2);
 }
 ----
+
+== Resources
+
+=== Documentation
+
+* {cpp} reference -
+  https://en.cppreference.com/w/cpp/utility/format/format[`std::format`] and
+  https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification[standard format specification]

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -1,6 +1,7 @@
 == Why is this an issue?
 
-With `std::format`, you can control many aspects of the textual representation of a value.
+With `std::format` and the related formatting functions,
+you can control many aspects of the textual representation of a value.
 Its width and precision can be specified in two ways:
 
 * Statically: the desired values are directly embedded in the format specification. +

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -1,14 +1,35 @@
 == Why is this an issue?
 
-`std::format` and the related formatting functions provide the possibility to specify the desired length and padding of the textual representation of the argument through the width and precision options.
-The value of each of these options can be specified:
+With `std::format`, you can control the length and padding of the textual representation of a value using the width and precision specifiers.
 
-* statically, by placing the desired value in a format specification,
-* or dynamically, by using `{}` or `{arg-id}` to refer to a complementary function argument.
+The value of the width and precision specifiers can be specified:
 
-A `std::format_error` exception is thrown when a dynamic value for the width or the precision specifiers is either not a built-in integer or negative.
+* Statically: the desired values are directly embedded in the format specification. +
++
+In the following example, the padding character is `_`, the alignment is to the right (`>`), the width specifier is `10`, and the precision specifier is `.2` with a fixed decimal notation (`f`).
+The formatted floating-point value (3.14159) is displayed with two digits after the decimal point and padded with underscores to a minimum width of 10 characters.
+The resulting string is `+"______3.14"+`.
++
+[source,cpp]
+----
+std::format("{:_>10.2f}", 3.14159)
+----
 
-This rule focuses on the first problem: it raises an issue when the specifier used for the width or the precision is not an integer.
+* Dynamically: `{}` or `{arg-id}` is used to refer to a complementary function argument. +
++
+The next example results in the same value as in the previous example.
++
+[source,cpp]
+----
+std::format("{0:_>{1}.{2}f}", 3.14159, 10, 2)
+----
+
+On the one hand, using static values is safe and predictable but not very flexible.
+On the other hand, using dynamic values can result in runtime exceptions and unexpected program termination.
+
+Specifically, a `std::format_error` exception is thrown when a dynamic value for the width or the precision specifiers is either negative or not a built-in integer.
+
+This rule focuses on the latter problem: it raises an issue when the specifier used for the width or the precision is not an integer.
 
 [source,cpp]
 ----

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -1,34 +1,33 @@
 == Why is this an issue?
 
-`std::format` and the related formatting functions provide the possibility to specify the desired length
-and padding of the textual representation of the argument through the width and precision options.
+`std::format` and the related formatting functions provide the possibility to specify the desired length and padding of the textual representation of the argument through the width and precision options.
 The value of each of these options can be specified:
 
 * statically, by placing the desired value in a format specification
 * or dynamically, by using `{}` or `{arg-id}` to refer to a complementary function argument.
 
-When dynamic values are used either for the width or precision, an `std::format_error` exception is thrown if the corresponding argument is not a built-in integer.
+When dynamic values are used for the width or precision, a `std::format_error` exception is thrown if the corresponding argument is not a built-in integer.
 This rule raises an issue when the argument used for the width or precision is not an integer.
 
 === Noncompliant code example
 
 [source,cpp]
 ----
- std::cout << std::format("{0:*^{1}}", s, 5.0) << std::endl; // Noncompliant, width argument is not integer
- std::cout << std::format("{0:*^10.{1}}", d, "3") << std::endl; // Noncompliant, precision argument is not integer
- std::cout << std::format("{0:*^{1}.{2}}", d, "12", 4.0) << std::endl; // Noncompliant, neither  width nor precision arguments are integer
- std::cout << std::format("{0:*^{1}.{2}}", s, "17", 5.0) << std::endl; // Noncompliant, both width precision arguments are not integer
- std::cout << std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2) << std::endl; // Noncompliant, second argument (d) is interpreted as width
+std::format("{0:*^{1}}", s, 5.0); // Noncompliant: width argument is not integer
+std::format("{0:*^10.{1}}", d, "3"); // Noncompliant: precision argument is not integer
+std::format("{0:*^{1}.{2}}", d, "12", 4.0); // Noncompliant: neither  width nor precision arguments are integer
+std::format("{0:*^{1}.{2}}", s, "17", 5.0); // Noncompliant: both width precision arguments are not integer
+std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2); // Noncompliant: the second argument (d) is interpreted as width
 ----
 
 === Compliant solution
 
 [source,cpp]
 ----
-std::cout << std::format("{0:*^{1}}", s, 5) << std::endl; // Compliant 
-std::cout << std::format("{0:*^10.3}", d) << std::endl; // Compliant
-std::cout << std::format("{0:*^{1}.{2}}", d, 12, 4) << std::endl; // Compliant
-std::cout << std::format("{0:*^17.5}", s, "17", 5.0) << std::endl; // Compliant
-std::cout << std::format("{0:*^{2}.{3}} {1}", s, d, maxLen, maxLen + 2) << std::endl; // Compliant
+std::format("{0:*^{1}}", s, 5);
+std::format("{0:*^10.3}", d);
+std::format("{0:*^{1}.{2}}", d, 12, 4);
+std::format("{0:*^17.5}", s, "17", 5.0);
+std::format("{0:*^{2}.{3}} {1}", s, d, maxLen, maxLen + 2);
 ----
 

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -3,11 +3,12 @@
 `std::format` and the related formatting functions provide the possibility to specify the desired length and padding of the textual representation of the argument through the width and precision options.
 The value of each of these options can be specified:
 
-* statically, by placing the desired value in a format specification
+* statically, by placing the desired value in a format specification,
 * or dynamically, by using `{}` or `{arg-id}` to refer to a complementary function argument.
 
-When dynamic values are used for the width or precision, a `std::format_error` exception is thrown if the corresponding argument is not a built-in integer.
-This rule raises an issue when the argument used for the width or precision is not an integer.
+A `std::format_error` exception is thrown when a dynamic value for the width or the precision is either not a built-in integer or negative.
+
+This rule focuses on the first problem and raises an issue when the argument used for the width or precision is not an integer.
 
 === Noncompliant code example
 

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -61,5 +61,5 @@ void example(std::string_view s, double d, int maxLen) {
 === Documentation
 
 * {cpp} reference -
-  https://en.cppreference.com/w/cpp/utility/format/format[`std::format`] and
-  https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification[standard format specification]
+  https://en.cppreference.com/w/cpp/utility/format/format[`std::format`]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification[standard format specification]

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -10,24 +10,27 @@ A `std::format_error` exception is thrown when a dynamic value for the width or 
 
 This rule focuses on the first problem: it raises an issue when the specifier used for the width or the precision is not an integer.
 
-=== Noncompliant code example
-
 [source,cpp]
 ----
-std::format("{0:*^{1}}", s, 5.0); // Noncompliant: the width specifier is not an integer.
-std::format("{0:*^10.{1}}", d, "3"); // Noncompliant: the precision specifier is not an integer.
-std::format("{0:*^{1}.{2}}", d, "12", 4.0); // Noncompliant: neither the width nor the precision specifiers are integers.
-std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2); // Noncompliant: the second argument (d) is interpreted as the width specifier.
-----
+void example(std::string_view s, double d, int maxLen) {
+  // Noncompliant: the width specifier is a floating point value.
+  std::format("{0:*^{1}}", s, 5.0);
+  // Compliant: the integer 5 is used instead.
+  std::format("{0:*^{1}}", s, 5);
 
-=== Compliant solution
+  // Noncompliant: the precision specifier is a string literal.
+  std::format("{0:*^10.{1}}", d, "3");
+  // Compliant: the value 3 is inlined.
+  std::format("{0:*^10.3}", d);
 
-[source,cpp]
-----
-std::format("{0:*^{1}}", s, 5);
-std::format("{0:*^10.3}", d);
-std::format("{0:*^{1}.{2}}", d, 12, 4);
-std::format("{0:*^17.5}", s, "17", 5.0);
-std::format("{0:*^{2}.{3}} {1}", s, d, maxLen, maxLen + 2);
-----
+  // Noncompliant: the width and precision specifiers are not integers.
+  std::format("{0:*^{1}.{2}}", d, "12", 4.0);
+  // Compliant: appropriate integer values are used.
+  std::format("{0:*^{1}.{2}}", d, 12, 4);
 
+  // Noncompliant: "d" is interpreted as the width specifier.
+  std::format("{:*^{}.{}} {}", s, d, maxLen, maxLen + 2);
+  // Compliant: use explicit argument index.
+  std::format("{0:*^{2}.{3}} {1}", s, d, maxLen, maxLen + 2);
+}
+----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

