### PR TITLE
Modify rule S6459: LaYC format

### DIFF
--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -87,5 +87,5 @@ auto func2(T&& arg)
 
  * CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
  * CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[std::copy_constructible concept]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[std::copyable concept]

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -87,5 +87,5 @@ auto func2(T&& arg)
 
  * CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
  * CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[std::copy_constructible concept]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[std::copyable concept]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -42,7 +42,7 @@ void f() {
 template <std::copy_constructible T> void func(T&& t);  // Overload #1.
 template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
 
-int main() {
+void f() {
     // Call with an rvalue argument:
     // Calls #2 (no surprise): T is 'std::unique_ptr<int>', which doesn't satisfy 'std::copy_constructible'.
     func(std::make_unique<int>(42));

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -2,41 +2,110 @@
 
 _Type-constraints_ provide a terse way to express constraints on the type deduced for a given template parameter or auto placeholder.
 In a situation when a type-constraint is applied to a forwarding reference parameter (`T&&`), the corresponding concept will be checked
-against the _lvalue reference_ (if the argument is an _lvalue_) or the plain type (if the argument is an _rvalue_).
-
-Even if it is possible to write a check that works for both plain types and references, it requires a dedicated effort,
-and a naive attempt may silently fail for one or the other. For instance, a `std::copyable` constraint is never satisfied for references,
-regardless of the referenced type, while a `std::copy_constructible` constraint always is.
-
-This rule detects forwarding reference parameters that are constrained by the standard-provided concepts using _type-constraint_ syntax.
-
-=== Noncompliant code example
+against the _lvalue reference_ (if the argument is an _lvalue_) or the plain type (if the argument is an _rvalue_):
 
 [source,cpp]
 ----
-auto func(std::copy_constructible auto&& arg) // noncompliant
-{ /* … */ }
+template <SomeConcept T> void func(T&& x);
+void f() {
+  func(SomeType{});  // Argument is an rvalue -> T is deduced as 'SomeType'
+  SomeType obj;
+  func(obj);  //  Argument is lvalue -> T is deduced as 'SomeType&'
+}
+----
 
+Even if it is possible to write `SomeConcept` in a way that works for both plain types and references, it requires a dedicated effort and a
+naive attempt may silently fail for one or the other.
+
+Many standard-provided constraints change their behavior when the type is a reference. For instance, a `std::copyable` constraint is never
+satisfied for references, regardless of the referenced type, while a `std::copy_constructible` constraint always is. Consider the following
+examples:
+
+[source,cpp]
+----
+template <std::copyable T> void func(T&& t);  // Overload #1.
+template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
+
+void f() {
+    // Call with an rvalue argument:
+    // Calls #1 (no surprise): T is 'std::string', which satisfies 'std::copyable'.
+    func(std::string{""});
+    // Call with an lvalue argument:
+    std::string s{""};
+    // Calls #2! T is 'std::string&' which doesn't satisfy 'std::copyable'.
+    func(s);
+}
+----
+
+[source,cpp]
+----
+template <std::copy_constructible T> void func(T&& t);  // Overload #1.
+template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
+
+int main() {
+    // Call with an rvalue argument:
+    // Calls #2 (no surprise): T is 'std::unique_ptr<int>', which doesn't satisfy 'std::copy_constructible'.
+    func(std::make_unique<int>(42));
+    // Call with an lvalue argument:
+    auto i = std::make_unique<int>(42);
+    // Calls #1! T is 'std::unique_ptr<int>&', which satisfies 'std::copy_constructible'.
+    func(i);
+}
+----
+
+Most standard-provided constraints are sensitive to references in their type arguments. On the other hand, the reference in the deduced
+type of a forwarding reference is meant to encode information about the value category of the argument in the caller. This rule detects
+forwarding reference parameters that are constrained by the standard-provided concepts using _type-constraint_ syntax.
+
+=== Exceptions
+
+The `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`)
+are designed to handle forwarding references parameters, and will not raise issues for this rule.
+
+== How to fix it
+
+Either wrap the deduced type in `std::remove_cvref_t` and apply the standard-provided constraint on the result in a `requires` clause, or
+design a custom constraint that works equally for reference and non-reference types (in case you have to deal with this problem often for
+a certain constraint).
+
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+auto func(std::copy_constructible auto&& arg)
+{ /* … */ }
+----
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
 template<std::copyable T>
-auto func2(T&& arg)  // noncompliant
+auto func2(T&& arg)
 { /* … */ }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
-auto func(auto&& argc)
+auto func(auto&& arg)
   requires std::copy_constructible<std::remove_cvref_t<decltype(arg)>>
 { /* … */ }
-
+----
+[source,cpp,diff-id=2,diff-type=compliant]
+----
 template<typename T>
   requires std::copyable<std::remove_cvref_t<T>>
 auto func2(T&& arg)
 { /* … */ }
 ----
 
-=== Exceptions
 
-The `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`)
-are designed to handle forwarding references parameters, and will not raise issues for this rule.
+== Resources
+
+=== Documentation
+
+ * CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
+ * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -57,9 +57,7 @@ a certain constraint).
 ----
 auto func(std::copy_constructible auto&& arg)
 { /* … */ }
-----
-[source,cpp,diff-id=2,diff-type=noncompliant]
-----
+
 template<std::copyable T>
 auto func2(T&& arg)
 { /* … */ }
@@ -72,9 +70,7 @@ auto func2(T&& arg)
 auto func(auto&& arg)
   requires std::copy_constructible<std::remove_cvref_t<decltype(arg)>>
 { /* … */ }
-----
-[source,cpp,diff-id=2,diff-type=compliant]
-----
+
 template<typename T>
   requires std::copyable<std::remove_cvref_t<T>>
 auto func2(T&& arg)

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -14,12 +14,10 @@ void f() {
 }
 ----
 
-Even if it is possible to write `SomeConcept` in a way that works for both plain types and references, it requires a dedicated effort and a
-naive attempt may silently fail for one or the other.
+Even if it is possible to write `SomeConcept` in a way that works for both plain types and references, it is not straightforward and requires a dedicated effort.
 
 Many standard-provided constraints change their behavior when the type is a reference. For instance, a `std::copyable` constraint is never
-satisfied for references, regardless of the referenced type, while a `std::copy_constructible` constraint always is. Consider the following
-examples:
+satisfied for references, regardless of the referenced type, while a `std::copy_constructible` constraint always is. The following example illustrates this:
 
 [source,cpp]
 ----
@@ -53,14 +51,12 @@ void f() {
 }
 ----
 
-Most standard-provided constraints are sensitive to references in their type arguments. On the other hand, the reference in the deduced
-type of a forwarding reference is meant to encode information about the value category of the argument in the caller. This rule detects
-forwarding reference parameters that are constrained by the standard-provided concepts using _type-constraint_ syntax.
+The rule raises an issue when a forwarding reference parameter is constrained by a standard-provided concept using _type-constraint_ syntax.
 
 === Exceptions
 
 The `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`)
-are designed to handle forwarding references parameters, and will not raise issues for this rule.
+are designed to handle forwarding reference parameters and will not raise issues for this rule.
 
 == How to fix it
 

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -28,28 +28,10 @@ template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
 
 void f() {
     // Call with an rvalue argument:
-    // Calls #1 (no surprise): T is 'std::string', which satisfies 'std::copyable'.
-    func(std::string{""});
+    func(std::string{""});  // Calls #1: T is 'std::string', which satisfies 'std::copyable'.
     // Call with an lvalue argument:
     std::string s{""};
-    // Calls #2! T is 'std::string&' which doesn't satisfy 'std::copyable'.
-    func(s);
-}
-----
-
-[source,cpp]
-----
-template <std::copy_constructible T> void func(T&& t);  // Overload #1.
-template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
-
-void f() {
-    // Call with an rvalue argument:
-    // Calls #2 (no surprise): T is 'std::unique_ptr<int>', which doesn't satisfy 'std::copy_constructible'.
-    func(std::make_unique<int>(42));
-    // Call with an lvalue argument:
-    auto i = std::make_unique<int>(42);
-    // Calls #1! T is 'std::unique_ptr<int>&', which satisfies 'std::copy_constructible'.
-    func(i);
+    func(s);  // Calls #2: T is a reference type ('std::string&') and therefore doesn't satisfy 'std::copyable'.
 }
 ----
 

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -44,9 +44,12 @@ are designed to handle forwarding reference parameters and will not raise issues
 
 == How to fix it
 
-Either wrap the deduced type in `std::remove_cvref_t` and apply the standard-provided constraint on the result in a `requires` clause, or
-design a custom constraint that works equally for reference and non-reference types (in case you have to deal with this problem often for
-a certain constraint).
+To apply a constraint to a forwarding reference parameter, consider the following options:
+
+* Either wrap the deduced type in `std::remove_cvref_t` and use the standard-provided constraint on the result in a `requires` clause.
+
+* Or design a custom constraint that works for both reference and non-reference types, which is useful if you frequently encounter this
+  issue with a specific constraint.
 
 
 === Code examples

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-_Type-constraints_ provide a terse way to express constraints on the type deduced for a given template parameter or auto placeholder.
+_Type-constraints_ provide a concise way to express constraints on the type deduced for a given template parameter or auto placeholder.
 In a situation when a type-constraint is applied to a forwarding reference parameter (`T&&`), the corresponding concept will be checked
 against the _lvalue reference_ (if the argument is an _lvalue_) or the plain type (if the argument is an _rvalue_):
 
@@ -14,10 +14,12 @@ void f() {
 }
 ----
 
-Even if it is possible to write `SomeConcept` in a way that works for both plain types and references, it is not straightforward and requires a dedicated effort.
+Even if it is possible to write `SomeConcept` in a way that works for both plain types and references, it is not straightforward and
+requires a dedicated effort.
 
 Many standard-provided constraints change their behavior when the type is a reference. For instance, a `std::copyable` constraint is never
-satisfied for references, regardless of the referenced type, while a `std::copy_constructible` constraint always is. The following example illustrates this:
+satisfied for references, regardless of the referenced type, while a `std::copy_constructible` constraint always is. The following example
+illustrates this:
 
 [source,cpp]
 ----

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -29,9 +29,10 @@ template <typename T> void func(T&& t);  // Overload #2 (unconstrained).
 void f() {
     // Call with an rvalue argument:
     func(std::string{""});  // Calls #1: T is 'std::string', which satisfies 'std::copyable'.
+
     // Call with an lvalue argument:
     std::string s{""};
-    func(s);  // Calls #2: T is a reference type ('std::string&') and therefore doesn't satisfy 'std::copyable'.
+    func(s);  // Calls #2: T is a reference type ('std::string&') and therefore does not satisfy 'std::copyable'.
 }
 ----
 
@@ -39,8 +40,7 @@ The rule raises an issue when a forwarding reference parameter is constrained by
 
 === Exceptions
 
-The `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`)
-are designed to handle forwarding reference parameters and will not raise issues for this rule.
+The rule does not raise an issue for the `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`) which are designed to handle forwarding reference parameters.
 
 == How to fix it
 
@@ -58,11 +58,11 @@ To apply a constraint to a forwarding reference parameter, consider the followin
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-auto func(std::copy_constructible auto&& arg)
+auto func(std::copy_constructible auto&& arg) // Noncompliant
 { /* … */ }
 
 template<std::copyable T>
-auto func2(T&& arg)
+auto func2(T&& arg) //  Noncompliant
 { /* … */ }
 ----
 
@@ -86,5 +86,6 @@ auto func2(T&& arg)
 === Documentation
 
  * CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
+ * CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
  * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
  * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

