### PR TITLE
modify-rule-layc-S3923

### DIFF
--- a/rules/S3923/exceptions.adoc
+++ b/rules/S3923/exceptions.adoc
@@ -1,6 +1,6 @@
 === Exceptions
 
-This rule does not apply to `if` chains without `else`, nor to `witch` without a `default` clause.
+This rule does not apply to `if` chains without `else`, nor to `switch` without a `default` clause.
 
 
 ----


### PR DESCRIPTION
Small typo fix

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

