### PR TITLE
Modify rule S4423: Remove instructions that are not relevant for API Gateway V2 (APPSEC-182)

### DIFF
--- a/rules/S4423/cloudformation/how-to-fix-it/api-gateway.adoc
+++ b/rules/S4423/cloudformation/how-to-fix-it/api-gateway.adoc
@@ -17,16 +17,6 @@ Resources:
       SecurityPolicy: "TLS_1_0"  # Noncompliant
 ----
 
-The ApiGatewayV2 uses a weak TLS version by default:
-
-[source,cloudformation,diff-id=2,diff-type=noncompliant]
-----
-AWSTemplateFormatVersion: '2010-09-09'
-Resources:
-  CustomApi: # Noncompliant
-    Type: AWS::ApiGatewayV2::DomainName
-----
-
 ==== Compliant solution
 
 [source,cloudformation,diff-id=1,diff-type=compliant]
@@ -37,17 +27,6 @@ Resources:
     Type: AWS::ApiGateway::DomainName
     Properties:
       SecurityPolicy: "TLS_1_2"
-----
-
-[source,cloudformation,diff-id=2,diff-type=compliant]
-----
-AWSTemplateFormatVersion: '2010-09-09'
-Resources:
-  CustomApi:
-    Type: AWS::ApiGatewayV2::DomainName
-    Properties:
-      DomainNameConfigurations:
-        - SecurityPolicy: "TLS_1_2"
 ----
 
 === How does this work?

--- a/rules/S4423/cloudformation/rule.adoc
+++ b/rules/S4423/cloudformation/rule.adoc
@@ -44,17 +44,11 @@ For `AWS::ApiGateway::DomainName`:
 
  * If `SecurityPolicy` is specified but has the wrong value
 ** Change this code to disable support of older TLS versions.
- * If `SecurityPolicy` is not specified at all
- ** Set "SecurityPolicy" to disable support of older TLS versions.
 
 For `AWS::ApiGatewayV2::DomainName`:
 
  * If `SecurityPolicy` is specified but has the wrong value
  ** Change this code to disable support of older TLS versions.
- * If `DomainNameConfigurations` exists but `SecurityPolicy` is not specified
-** Set "SecurityPolicy" to disable support of older TLS versions.
- * If `DomainNameConfigurations` does not exist
-** Set "DomainNameConfigurations.SecurityPolicy" to disable support of older TLS versions.
 
 
 === Highlighting
@@ -69,13 +63,10 @@ For `AWS::Elasticsearch::Domain` and `AWS::OpenSearchService::Domain`:
 For `AWS::ApiGateway::DomainName`:
 
  * Highlight `SecurityPolicy` if it is specified but has the wrong value
- * Highlight resource if `SecurityPolicy` is not specified at all
 
 For `AWS::ApiGatewayV2::DomainName`:
 
  * Highlight `SecurityPolicy` if it is specified but has the wrong value
- * Highlight `DomainNameConfigurations` if it exists but `SecurityPolicy` is not specified
- * Highlight resource if `DomainNameConfigurations` does not exist
 
 
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

