### PR TITLE
Modify rule S836: Adapt to LaYC

### DIFF
--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -269,7 +269,7 @@ auto [px, py, pz] = [&] {
 
 === External coding guidelines
 
-* MITRE, CWE-457 - https://cwe.mitre.org/data/definitions/457[Use of Uninitialized Variable]
+* MITRE - https://cwe.mitre.org/data/definitions/457[CWE-457 Use of Uninitialized Variable]
 * MISRA C:2004, 9.1 - All automatic variables shall have been assigned a value before being used.
 * MISRA {cpp}:2008, 8-5-1 - All variables shall have a defined value before they are used.
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -63,7 +63,7 @@ void usingNew() {
 === What is the potential impact?
 
 Using garbage values will cause the program to behave
-non-deterministically at runtime.
+nondeterministically at runtime.
 The program may produce a different output or crash depending
 on the run.
 
@@ -88,7 +88,7 @@ object of the given type is created. Such a constructor is called even
 if a variable is declared without any initializer.
 However, if the constructor code omits the initialization
 of a member that itself does not have the default constructor,
-the member will remain uninitialized. And reading
+the member will remain uninitialized  (See also S2107). And reading
 from it will produce a garbage value:
 
 [source,cpp]
@@ -101,20 +101,21 @@ struct Partial {
   float y;
 };
 
-void initialized() {
+int initialized() {
   Partial p; // constructor is called
   // or even Partial p{};
-  return p.x; // Non-complaint: reading an uninitialized variable
+  return p.x; // Non-compliant: reading an uninitialized variable
 }
 ----
 
 
-=== Exceptions: global, static, and thread-local variables.
+=== Exceptions
 
-All the variables with static storage duration, meaning: global, static,
-or thread-local variables, are zero-initialized before the initializer
-is evaluated. As a consequence, any such variable or member of such
-object has a defined value even if no initializer is specified.
+This rule does not flag the variables with static storage duration, meaning:
+global, static, and thread-local variables.
+
+All the variables with static storage duration are zero-initialized before the initializer is evaluated.
+As a consequence, any variable or member of such an object has a defined value even if no initializer is specified.
 
 [source,cpp]
 ----
@@ -123,7 +124,7 @@ int globTab[10];
 Aggregate globAggr;
 Partial globPart; // x member is zero-initialized
 
-void uses() {
+int uses() {
   static int staticInt;
   return globInt     // Compliant: all zero-initialized
        + globTab[2]
@@ -137,7 +138,7 @@ void uses() {
 
 Commonly, the use of an uninitialized object is an indication of a defect in the
 code, where either variable initialization was skipped on some code paths, or
-the object is used by mistake. Generally, such problems can be addressed by:
+the object is used by mistake. Generally, you can address such problems by:
 
 * Initializing variables on the declaration with a valid value
 * Assigning to the variable on the code path(s) that was missing initialization
@@ -163,7 +164,7 @@ int function(int flag, int b) {
 
 ==== Compliant solution
 
-Initializing variable in all code paths:
+Initializing variable on all code paths:
 
 [source,c,diff-id=1,diff-type=compliant]
 ----
@@ -189,7 +190,7 @@ int function(int flag, int b) {
   } else {
     return 10;
   }
-  return a; // Complaint
+  return a; // Compliant
 }
 ----
 
@@ -202,7 +203,7 @@ int function(int flag, int b) {
   if (flag) {
     a = b;
   }
-  return a; // Complaint
+  return a; // Compliant
 }
 ----
 
@@ -212,7 +213,7 @@ Initializing value in the definition:
 ----
 int function(int flag, int b) {
   int const a = flag ? b : 10;
-  return a; // Complaint
+  return a; // Compliant
 }
 ----
 
@@ -220,17 +221,17 @@ int function(int flag, int b) {
 
 Initializing the variable to zero at the declaration is not always the right
 solution to fix the issue, as it may lead to logic errors if such a value
-is not handled correctly. For example, setting an `age` field of the `Employee`
-the structure may break assumptions of retirement handling code. Or more commonly,
-setting a pointer to `NULL`, will turn dereference of an uninitialized value
-into a null pointer dereference.
+is not handled correctly. For example, setting an `age` field of an `Employee`
+structure may break assumptions of retirement handling code. Or more commonly,
+setting a pointer to `NULL` will turn dereference of an uninitialized value
+into a null-pointer dereference.
 
 
 === Going the extra mile
 
 With the addition of lambdas in {cpp}11, it is possible to initialize
 variables on declaration without creating a separate function
-to the compute value:
+to compute the value:
 
 [source,cpp]
 ----
@@ -265,7 +266,7 @@ auto [px, py, pz] = [&] {
 
 === Documentation
 
-- C++ reference - https://en.cppreference.com/w/cpp/language/storage_duration[Storage class specifiers]
+* C++ reference - https://en.cppreference.com/w/cpp/language/storage_duration[Storage class specifiers]
 
 === External coding guidelines
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -3,10 +3,10 @@ behavior due to garbage values.
 
 == Why is this an issue?
 
-A local variable of any built-in type (like `int`, `float`, and also pointers),
-declared without an initial value, is not initialized to any particular value.
-Consequently, code that uses such a variable without being previously assigned to
-does not have defined behavior. For example:
+A local variable of any built-in type (such as `int`, `float`, and pointers),
+declared without an initial value is not initialized to any particular value.
+Consequently, if no value is assigned to such a variable first, the code that
+uses it has no defined behavior.
 
 [source,cpp]
 ----
@@ -15,14 +15,14 @@ int addition() {
   return x + 10; // Noncompliant: x has grabage value
 }
 
-int derefence() {
+int dereference() {
   int* p; // p is not initialized
   return *p; // Noncompliant: p has garbage value
 }
 ----
 
 Similarly, structures that simply aggregate variables of built-in types, such as arrays or `struct`/`class`
-types without a constructor, will not initialize their members, when declared without
+types without a constructor, will not initialize their members when declared without
 an initializer:
 
 [source,cpp]
@@ -35,11 +35,11 @@ struct Aggregate {
 void aggregates() {
   int* intArray[5]; // each element of array is not initializer
   Aggregate aggr; // members aggr.i, agrr.f are not initialized
-  Aggregate aggrArray[2]; // members of each element are not initialied
+  Aggregate aggrArray[2]; // members of each element are not initialized
 }
 ----
 
-Finally, allocating objects of such builtin or aggregates types on the heap,
+Finally, allocating objects of builtin or such aggregates types on the heap,
 also does not initialize their values:
 
 [source,c]
@@ -62,29 +62,29 @@ void usingNew() {
 
 === What is the potential impact?
 
-In the best-case scenario, using garbage values will cause the
-program to behave non-deterministically at runtime.
+Using garbage values will cause the program to behave
+non-deterministically at runtime.
 The program may produce a different output or crash depending
 on the run.
 
 In some situations, loading a variable may expose a sensitive
 data, such as a password that was previously stored in the same
-location, leading to vulnerability, where such a defect
-is used as a gadget for extracting information from the instance
+location, leading to a vulnerability that uses such a defect
+as a gadget for extracting information from the instance
 of the program.
 
-Finally, in {cpp}, outside a few exceptions related to the uses
-of `unsingned char` or `std::byte`, loading data from an uninitialized
+Finally, in {cpp}, outside of a few exceptions related to the uses
+of `unsigned char` or `std::byte`, loading data from an uninitialized
 variable causes undefined behavior. This means that the compiler
 is not bound by the language standard anymore, and the program
 has no meaning assigned to it. As a consequence, the impact
-of such a defect is not limited to uses of random values.
+of such a defect is not limited to the use of garbage values.
 
 
-=== Why is there issue for a class with a default constructor?
+=== Why is there an issue for a class with a default constructor?
 
 In {cpp}, a class can define a default constructor invoked when an
-object of given type is created. Such a constructor is called even
+object of the given type is created. Such a constructor is called even
 if a variable is declared without any initializer.
 However, if the constructor code omits the initialization
 of a member that itself does not have the default constructor,
@@ -104,12 +104,12 @@ struct Partial {
 void initialized() {
   Partial p; // constructor is called
   // or even Partial p{};
-  return p.x; // Non-complaint: reading uninitialized variable
+  return p.x; // Non-complaint: reading an uninitialized variable
 }
 ----
 
 
-=== Exceptions: global, static and thread local variables.
+=== Exceptions: global, static, and thread-local variables.
 
 All the variables with static storage duration, meaning: global, static,
 or thread-local variables, are zero-initialized before the initializer
@@ -125,7 +125,7 @@ Partial globPart; // x member is zero-initialized
 
 void uses() {
   static int staticInt;
-  return globInt     // Compliant: all zero initialized
+  return globInt     // Compliant: all zero-initialized
        + globTab[2]
        + globAggr.f
        + globPart.x
@@ -139,11 +139,12 @@ Commonly, the use of an uninitialized object is an indication of a defect in the
 code, where either variable initialization was skipped on some code paths, or
 the object is used by mistake. Generally, such problems can be addressed by:
 
-* Initializing variables on the declaration with valid value
+* Initializing variables on the declaration with a valid value
 * Assigning to the variable on the code path(s) that was missing initialization
 
 Whenever possible, it is preferable to initialize a variable with its final
-value on the declaration, as this eliminates the possiblity of this defect occuring.
+value on the declaration, as this eliminates the possibility of this defect
+occurring.
 
 === Code examples
 
@@ -205,9 +206,9 @@ int function(int flag, int b) {
 }
 ----
 
-Initializing value in the defintion:
+Initializing value in the definition:
 
-[source,cpp]
+[source,c]
 ----
 int function(int flag, int b) {
   int const a = flag ? b : 10;
@@ -226,12 +227,12 @@ to the compute value:
 int x = [&] { // capture all context by reference
   if (someCondition())
     return computeVar1();
-  /* peform more computations */
+  /* perform more computations */
   return other;
 }(); // invoke the lambda immediately (right after creation)
 ----
 
-Such pattern is referred as an _Immediately invoked function expression_
+Such pattern is referred to as an _Immediately invoked function expression_
 (IIFE) or _Imediately invoked lambda_.
 Furthermore, with the addition of structured binding in {cpp}17, it is
 possible to declare multiple variables whose values are coupled:

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -228,7 +228,7 @@ int x = [&] { // capture all context by reference
     return computeVar1();
   /* peform more computations */
   return other;
-}(); // invoke lambda just (immediately)  after creation
+}(); // invoke the lambda immediately (right after creation)
 ----
 
 Such pattern is referred as an _Immediately invoked function expression_
@@ -238,14 +238,14 @@ possible to declare multiple variables whose values are coupled:
 
 [source,cpp]
 ----
-auto [px, py. pz] = [&] {
+auto [px, py, pz] = [&] {
   if (x_dir) {
-    return std::make_tuple(1.0, 0, 0);
+    return std::make_tuple(1, 0, 0);
   } else if (y_dir) {
-    return std::make_tuple(0, 1.0, 0);
+    return std::make_tuple(0, 1, 0);
   } else {
     assert(z_dir);
-    return std::make_tuple(0, 0, 1.0);
+    return std::make_tuple(0, 0, 1);
   }
 }();
 ----
@@ -264,7 +264,7 @@ auto [px, py. pz] = [&] {
 
 === Related rules
 
-* S2107 detect fields being left uninitialized after invocation of constructor
+* S2107 detects fields being left uninitialized after the invocation of a constructor
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -1,41 +1,271 @@
+Variables should be initialized before their use to avoid unexpected
+behaviors due to garbage values.
+
 == Why is this an issue?
 
-Variables should be initialized before their use to avoid unexpected behaviors due to garbage values.
-
-
-=== Noncompliant code example
+A local variable of the built-in type (like `int`, `float`, and also pointers),
+declared without, is not an initializer to any particular value.
+Consequently, code that uses such a variable without previously assigned to
+them does not have defined behavior. For example:
 
 [source,cpp]
+----
+int addition() {
+  int x;  // x is not initialized
+  return x + 10; // Noncompliant: x have grabage value
+}
+
+int derefence() {
+  int* p; // p is not initialized
+  return *p; // Noncompliant: p have garbage value
+}
+----
+
+Similarly, structures that aggregate such variables, such as arrays or `struct`/`class`
+types without a constructor, will not initialize thier members, when declared without
+an initializer:
+
+[source,cpp]
+----
+struct Aggregate {
+  int i;
+  float f;
+};
+
+void aggregates() {
+  int* intArray[5]; // each element of array is not initializer
+  Aggregate aggr; // members aggr.i, agrr.f are not initialized
+  Aggregate aggrArray[2]; // members of each element are not initialied
+}
+----
+
+Finally, allocatingn objects of such builtin or aggregates types on heap, also does not
+initialize their values:
+
+[source,c]
+----
+void usingMalloc() {
+  int* intArr = (int*)malloc(sizeof(int) * 10); // each of 10 allocated integers is not initialized
+}
+----
+
+This also applies when `new` is used in `C++`:
+
+[source,cpp]
+----
+void usingNew() {
+  Aggregate* aggrPtr = new Aggregate; // members of allocated Aggregate are not initialized
+  Aggregate* aggrArr = new Aggregate[5]; // members of each of 5 Aggregate objects are not initialized
+}
+----
+
+
+=== What is the potential impact?
+
+In the best-case scenario, using garbage value will cause the
+program to behave non-deterministically at runtime.
+The program may produce a different output or crash depending
+on the run.
+
+In some situations, loading a variable may expose a sensitive
+data, like a password, that was previously stored in the same
+location. Leading to vulnerability, where such defect
+is used as a gadget for extracting information from the instance
+of the program.
+
+Finally, in {cpp}, outside a few exceptions related to the uses
+of `unsinged char` or `std::byte`, loading data from an uninitialized
+variable causes undefined behavior. This means that the compiler
+is not bound by the language standard anymore, and the program
+has no meaning assigned to it. As a consequence, the impact
+of such a defect is not limited to uses of random value.
+
+
+=== Why is the issue for class with default constructor?
+
+In {cpp}, a class can define a default constructor invoked when an
+object of given type is created. Such a constructor is called even
+if the variable is declared without any initializer.
+However, if the constructor code omits the initialization
+of the member, which does not have the default constructor
+itself, such a member will remain uninitialized. And reading
+from it will produce garbage value:
+
+[source,cpp]
+----
+struct Partial {
+  // x is not initialized
+  Partial() : y(10.0) {}
+
+  int x;
+  float y;
+};
+
+void initialized() {
+  Partial p; // constructor is called
+  // or even Partial p{};
+  return p.x; // Non-complaint: reading uninitialized variable
+}
+----
+
+
+=== Exceptions: global, static and thread local variables.
+
+All the variables with static storage duration, meaning global, static,
+or thread-local variables, are zero-initialized before the initializer
+is evaluated. As consequence any such variable or member of such
+object has a defined value, even if no initializer is specified.
+
+[source,cpp]
+----
+int globInt;
+int globTab[10];
+Aggregate globAggr;
+Partial globPart; // x member is zero-initialized
+
+void uses() {
+  static int staticInt;
+  return globInt     // Compliant: all zero initialized
+       + globTab[0] 
+       + globAggr.f
+       + globPart.x 
+       + staticInt;        
+}
+----
+
+== How to fix it
+
+Commonly, the use of an uninitialized object is an indication of a defect in code,
+where either variable initialization was skipped on some code paths, or
+the object is used by mistake. Generally, such problems can be addressed by:
+
+* Initializing variable on the declaration with valid value
+* Assigning to the variable on the code path(s) that was missing initialization
+
+Whenever possible, it is preferable to initialize a variable with its final
+value on the declaration and to avoid modifying its value.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 int function(int flag, int b) {
   int a;
   if (flag) {
     a = b;
   }
-  return a; // Noncompliant - "a" has not been initialized in all paths
+  return a; // Noncompliant: "a" has not been initialized in all paths
 }
 ----
 
+==== Compliant solution
 
-=== Compliant solution
+Initializing variable in all code paths:
+
+[source,c,diff-id=1,diff-type=compliant]
+----
+int function(int flag, int b) {
+  int a;
+  if (flag) {
+    a = b;
+  } else {
+    a = 10;
+  }
+  return a; // Complaint
+}
+----
+
+Skipping path that leads to read of uninitialized value:
+
+[source,c,diff-id=1,diff-type=compliant]
+----
+int function(int flag, int b) {
+  int a;
+  if (flag) {
+    a = b;
+  } else {
+    return 10;
+  }
+  return a; // Complaint
+}
+----
+
+Providing valid initial value:
 
 [source,cpp]
 ----
 int function(int flag, int b) {
-  int a = 0;
+  int a = 10;
   if (flag) {
     a = b;
   }
-  return a;
+  return a; // Complaint
 }
 ----
 
+Initializing value in the defintion:
+
+[source,cpp]
+----
+int function(int flag, int b) {
+  int const a = flag ? b : 10;
+  return a; // Complaint
+}
+----
+
+=== Going the extra mile
+
+With the addition of lambda in {cpp}11, it is possible to initialize 
+variable on declaration without creating a separate function
+to compute value:
+
+[source,cpp]
+----
+int x = [&] { // capture all context by reference
+  if (someCondition())
+    return computeVar1();
+  /* peform more computations */
+  return other;
+}(); // invoke lambda just (immediately)  after creation
+----
+
+Such pattern is referred as _Immediately invoked function expression_
+(IIFE) or _Imediately invoked lambda_. 
+Furthermore, with the addition of structured binding in {cpp}17, it is 
+possible to declare multiple variables whose values are coupled:
+
+[source,cpp]
+----
+auto [px, py. pz] = [&] { 
+  if (x_dir) {
+    return std::make_tuple(1.0, 0, 0);
+  } else if (y_dir) {
+    return std::make_tuple(0, 1.0, 0);
+  } else {
+    assert(z_dir);
+    return std::make_tuple(0, 0, 1.0);
+  }
+}();
+----
 
 == Resources
+
+=== Documentation
+
+- C++ reference - https://en.cppreference.com/w/cpp/language/storage_duration[Storage class specifiers]
+
+=== External coding guidelines
 
 * https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
 * MISRA C:2004, 9.1 - All automatic variables shall have been assigned a value before being used.
 * MISRA {cpp}:2008, 8-5-1 - All variables shall have a defined value before they are used.
+
+=== Related rules
+
+* S2107 detect fields being left uninitialized after invocation of constructor
+
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -1,5 +1,5 @@
 Variables should be initialized before their use to avoid unexpected
-behaviors due to garbage values.
+behavior due to garbage values.
 
 == Why is this an issue?
 
@@ -21,7 +21,7 @@ int derefence() {
 }
 ----
 
-Similarly, structures that aggregate such variables, such as arrays or `struct`/`class`
+Similarly, structures that simply aggregate variables of built-in types, such as arrays or `struct`/`class`
 types without a constructor, will not initialize their members, when declared without
 an initializer:
 
@@ -49,7 +49,7 @@ void usingMalloc() {
 }
 ----
 
-This also applies when `new` is used in `C++`:
+This also applies when `new` is used in {cpp}:
 
 [source,cpp]
 ----
@@ -68,7 +68,7 @@ The program may produce a different output or crash depending
 on the run.
 
 In some situations, loading a variable may expose a sensitive
-data, like a password, that was previously stored in the same
+data, such as a password that was previously stored in the same
 location, leading to vulnerability, where such a defect
 is used as a gadget for extracting information from the instance
 of the program.
@@ -81,15 +81,15 @@ has no meaning assigned to it. As a consequence, the impact
 of such a defect is not limited to uses of random values.
 
 
-=== Why is the issue for class with default constructor?
+=== Why is there issue for a class with a default constructor?
 
 In {cpp}, a class can define a default constructor invoked when an
 object of given type is created. Such a constructor is called even
-if the variable is declared without any initializer.
+if a variable is declared without any initializer.
 However, if the constructor code omits the initialization
-of the member, which itself does not have the default constructor
-, such a member will remain uninitialized. And reading
-from it will produce garbage value:
+of a member that itself does not have the default constructor,
+the member will remain uninitialized. And reading
+from it will produce a garbage value:
 
 [source,cpp]
 ----
@@ -111,10 +111,10 @@ void initialized() {
 
 === Exceptions: global, static and thread local variables.
 
-All the variables with static storage duration, meaning global, static,
+All the variables with static storage duration, meaning: global, static,
 or thread-local variables, are zero-initialized before the initializer
-is evaluated. As consequence any such variable or member of such
-object has a defined value, even if no initializer is specified.
+is evaluated. As a consequence, any such variable or member of such
+object has a defined value even if no initializer is specified.
 
 [source,cpp]
 ----
@@ -173,13 +173,13 @@ int function(int flag, int b) {
   } else {
     a = 10;
   }
-  return a; // Complaint
+  return a; // Compliant
 }
 ----
 
-Skipping path that leads to read of uninitialized value:
+Skipping path that leads to the read of an uninitialized value:
 
-[source,c,diff-id=1,diff-type=compliant]
+[source,c]
 ----
 int function(int flag, int b) {
   int a;
@@ -192,7 +192,7 @@ int function(int flag, int b) {
 }
 ----
 
-Providing valid initial value:
+Providing a valid initial value:
 
 [source,cpp]
 ----

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -269,7 +269,7 @@ auto [px, py, pz] = [&] {
 
 === External coding guidelines
 
-* https://cwe.mitre.org/data/definitions/457[MITRE, CWE-457] - Use of Uninitialized Variable
+* MITRE, CWE-457 - https://cwe.mitre.org/data/definitions/457[Use of Uninitialized Variable]
 * MISRA C:2004, 9.1 - All automatic variables shall have been assigned a value before being used.
 * MISRA {cpp}:2008, 8-5-1 - All variables shall have a defined value before they are used.
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -3,26 +3,26 @@ behaviors due to garbage values.
 
 == Why is this an issue?
 
-A local variable of the built-in type (like `int`, `float`, and also pointers),
-declared without initial value, is not initialized to any particular value.
-Consequently, code that uses such a variable without previously assigned to
-them does not have defined behavior. For example:
+A local variable of any built-in type (like `int`, `float`, and also pointers),
+declared without an initial value, is not initialized to any particular value.
+Consequently, code that uses such a variable without being previously assigned to
+does not have defined behavior. For example:
 
 [source,cpp]
 ----
 int addition() {
   int x;  // x is not initialized
-  return x + 10; // Noncompliant: x have grabage value
+  return x + 10; // Noncompliant: x has grabage value
 }
 
 int derefence() {
   int* p; // p is not initialized
-  return *p; // Noncompliant: p have garbage value
+  return *p; // Noncompliant: p has garbage value
 }
 ----
 
 Similarly, structures that aggregate such variables, such as arrays or `struct`/`class`
-types without a constructor, will not initialize thier members, when declared without
+types without a constructor, will not initialize their members, when declared without
 an initializer:
 
 [source,cpp]
@@ -39,8 +39,8 @@ void aggregates() {
 }
 ----
 
-Finally, allocatign objects of such builtin or aggregates types on heap, also does not
-initialize their values:
+Finally, allocating objects of such builtin or aggregates types on the heap,
+also does not initialize their values:
 
 [source,c]
 ----
@@ -62,23 +62,23 @@ void usingNew() {
 
 === What is the potential impact?
 
-In the best-case scenario, using garbage value will cause the
+In the best-case scenario, using garbage values will cause the
 program to behave non-deterministically at runtime.
 The program may produce a different output or crash depending
 on the run.
 
 In some situations, loading a variable may expose a sensitive
 data, like a password, that was previously stored in the same
-location. Leading to vulnerability, where such defect
+location, leading to vulnerability, where such a defect
 is used as a gadget for extracting information from the instance
 of the program.
 
 Finally, in {cpp}, outside a few exceptions related to the uses
-of `unsinged char` or `std::byte`, loading data from an uninitialized
+of `unsingned char` or `std::byte`, loading data from an uninitialized
 variable causes undefined behavior. This means that the compiler
 is not bound by the language standard anymore, and the program
 has no meaning assigned to it. As a consequence, the impact
-of such a defect is not limited to uses of random value.
+of such a defect is not limited to uses of random values.
 
 
 === Why is the issue for class with default constructor?
@@ -135,15 +135,15 @@ void uses() {
 
 == How to fix it
 
-Commonly, the use of an uninitialized object is an indication of a defect in code,
-where either variable initialization was skipped on some code paths, or
+Commonly, the use of an uninitialized object is an indication of a defect in the
+code, where either variable initialization was skipped on some code paths, or
 the object is used by mistake. Generally, such problems can be addressed by:
 
-* Initializing variable on the declaration with valid value
+* Initializing variables on the declaration with valid value
 * Assigning to the variable on the code path(s) that was missing initialization
 
 Whenever possible, it is preferable to initialize a variable with its final
-value on the declaration, as this eliminates possiblity of this defect occuring.
+value on the declaration, as this eliminates the possiblity of this defect occuring.
 
 === Code examples
 
@@ -217,9 +217,9 @@ int function(int flag, int b) {
 
 === Going the extra mile
 
-With the addition of lambda in {cpp}11, it is possible to initialize
-variable on declaration without creating a separate function
-to compute value:
+With the addition of lambdas in {cpp}11, it is possible to initialize
+variables on declaration without creating a separate function
+to the compute value:
 
 [source,cpp]
 ----
@@ -231,7 +231,7 @@ int x = [&] { // capture all context by reference
 }(); // invoke lambda just (immediately)  after creation
 ----
 
-Such pattern is referred as _Immediately invoked function expression_
+Such pattern is referred as an _Immediately invoked function expression_
 (IIFE) or _Imediately invoked lambda_.
 Furthermore, with the addition of structured binding in {cpp}17, it is
 possible to declare multiple variables whose values are coupled:

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -4,7 +4,7 @@ behaviors due to garbage values.
 == Why is this an issue?
 
 A local variable of the built-in type (like `int`, `float`, and also pointers),
-declared without, is not an initializer to any particular value.
+declared without initial value, is not initialized to any particular value.
 Consequently, code that uses such a variable without previously assigned to
 them does not have defined behavior. For example:
 
@@ -39,7 +39,7 @@ void aggregates() {
 }
 ----
 
-Finally, allocatingn objects of such builtin or aggregates types on heap, also does not
+Finally, allocatign objects of such builtin or aggregates types on heap, also does not
 initialize their values:
 
 [source,c]
@@ -87,8 +87,8 @@ In {cpp}, a class can define a default constructor invoked when an
 object of given type is created. Such a constructor is called even
 if the variable is declared without any initializer.
 However, if the constructor code omits the initialization
-of the member, which does not have the default constructor
-itself, such a member will remain uninitialized. And reading
+of the member, which itself does not have the default constructor
+, such a member will remain uninitialized. And reading
 from it will produce garbage value:
 
 [source,cpp]
@@ -126,10 +126,10 @@ Partial globPart; // x member is zero-initialized
 void uses() {
   static int staticInt;
   return globInt     // Compliant: all zero initialized
-       + globTab[0] 
+       + globTab[2]
        + globAggr.f
-       + globPart.x 
-       + staticInt;        
+       + globPart.x
+       + staticInt;
 }
 ----
 
@@ -143,7 +143,7 @@ the object is used by mistake. Generally, such problems can be addressed by:
 * Assigning to the variable on the code path(s) that was missing initialization
 
 Whenever possible, it is preferable to initialize a variable with its final
-value on the declaration and to avoid modifying its value.
+value on the declaration, as this eliminates possiblity of this defect occuring.
 
 === Code examples
 
@@ -217,7 +217,7 @@ int function(int flag, int b) {
 
 === Going the extra mile
 
-With the addition of lambda in {cpp}11, it is possible to initialize 
+With the addition of lambda in {cpp}11, it is possible to initialize
 variable on declaration without creating a separate function
 to compute value:
 
@@ -232,13 +232,13 @@ int x = [&] { // capture all context by reference
 ----
 
 Such pattern is referred as _Immediately invoked function expression_
-(IIFE) or _Imediately invoked lambda_. 
-Furthermore, with the addition of structured binding in {cpp}17, it is 
+(IIFE) or _Imediately invoked lambda_.
+Furthermore, with the addition of structured binding in {cpp}17, it is
 possible to declare multiple variables whose values are coupled:
 
 [source,cpp]
 ----
-auto [px, py. pz] = [&] { 
+auto [px, py. pz] = [&] {
   if (x_dir) {
     return std::make_tuple(1.0, 0, 0);
   } else if (y_dir) {

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -216,6 +216,16 @@ int function(int flag, int b) {
 }
 ----
 
+=== Pitfalls
+
+Initializing the variable to zero at the declaration is not always the right
+solution to fix the issue, as it may lead to logic errors if such a value
+is not handled correctly. For example, setting an `age` field of the `Employee`
+the structure may break assumptions of retirement handling code. Or more commonly,
+setting a pointer to `NULL`, will turn dereference of an uninitialized value
+into a null pointer dereference.
+
+
 === Going the extra mile
 
 With the addition of lambdas in {cpp}11, it is possible to initialize

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -269,7 +269,7 @@ auto [px, py, pz] = [&] {
 
 === External coding guidelines
 
-* MITRE - https://cwe.mitre.org/data/definitions/457[CWE-457 Use of Uninitialized Variable]
+* CWE - https://cwe.mitre.org/data/definitions/457[457 Use of Uninitialized Variable]
 * MISRA C:2004, 9.1 - All automatic variables shall have been assigned a value before being used.
 * MISRA {cpp}:2008, 8-5-1 - All variables shall have a defined value before they are used.
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

