### PR TITLE
Modify rule S2990: Fix typo

### DIFF
--- a/rules/S2990/javascript/rule.adoc
+++ b/rules/S2990/javascript/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-The value of `this` depends on in which context it appears: 
+The value of `this` depends on which context it appears: 
 
 * Function: The value of `this` will depend on how a function was called. The value of `this` is not always the object that has the function as an __own__ property, but the object that is used to call the function. The methods `Function.prototype.call()`, `Function.prototype.apply()`, or `Reflect.apply()` can be used to explicitly set the value of `this`. Is it also possible to create a new function with a specific value of this that doesn't change regardless of how the function is called with `Function.prototype.bind()`. In non-strict mode, `this` will always be an object and will default to `globalThis` if set to `undefined` or `null`. 
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

