### PR TITLE
Modify rule S1232: Expand and comply with LaYC format

### DIFF
--- a/rules/S1232/cfamily/metadata.json
+++ b/rules/S1232/cfamily/metadata.json
@@ -4,7 +4,7 @@
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10min"
+    "constantCost": "2min"
   },
   "tags": [
     "symbolic-execution",

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -27,32 +27,49 @@ Practically, you can observe the following effects:
   delete and deallocate only the first element of the array.
 - Freeing with `free()` the underlying memory for an object constructed with `new`
   will skip the destructor call, most likely leading to a memory leak.
-  Additionally, a destructor might still be called on freed memory causing further undefined behavior.
+  Additionally, a destructor might still be called on deallocated memory causing further undefined behavior.
 
 === Why is the issue raised for a type with a trivial destructor?
 
-TODO:
+Automatic constructor and destructor invocation is not the only difference between
+the C-style `malloc`/`free` memory allocator, and the {cpp}-style `new`/`delete`.
 
+These two memory allocators use different metadata and different algorithms.
+For example, `new` has an array form `+new[]+` that stores an "array cookie".
+
+
+The following example causes undefined behavior,
+even though the destructor has now effect,
+because `free()` expects different metadata for the pointer it is passed
+than what is arranged by the `new` operator:
+
+[source,cpp]
 ----
 struct TrivialClass {};
 
 
 TrivialClass* p = new TrivialClass();
-free(p); // no destructor is called.
+free(p); // Noncompliant: no-op destructor is skipped; still undefined behavior
 ----
 
+In the code below, `+delete[]+` expects to find an array cookie and fails:
 
+[source,cpp]
 ----
 int* p = malloc(10 * sizeof(int));
-delete[] p; // expect array coookie
+delete[] p; // Noncompliant: expect array cookie
 ----
 
 
-TODO `::operator new(std::size_t count)`
+If you need allocate memory in a custom `T::operator new(std::size_t)`,
+you should use `void* ::operator new(std::size_t)` and not `free()`.
 
+Note that `::operator new` is still not compatible with `free()`:
+
+[source,cpp]
 ----
-::operator new(10 * sizeof(int));
-free()
+auto p = ::operator new(10 * sizeof(int));
+free(p); // Noncompliant
 ----
 
 == How to fix it
@@ -91,7 +108,7 @@ free(_pChar); // Compliant: free the memory C-style
 === Going the extra mile
 
 Manually allocating and deallocating memory is a code smell
-because of the issue covered by this rule, and because it is easy to leak memory.
+because of the above, and because it is easy to leak memory.
 
 Whenever possible, prefer the RAII (Resource Acquisition Is Initialization) {cpp} idiom.
 

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -24,7 +24,7 @@ Practically, you can observe the following effects:
   will skip the destructor call, most likely leading to a memory leak.
   An automatic mechanism, such as RAII,
   might still invoke later the destructor on the freed memory causing a segmentation fault.
-- Deleting with `delete` an "object" allocated with `new`
+- Deleting with `delete` an memory block allocated with `operator new`
   will lead to a destructor invocation on an "object" that was never constructed
   so the destructor might hit an unsatisfied assumption.
 

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -42,8 +42,8 @@ string* _pString1 = new string;
 string* _pString2 = new string[100];
 char* _pChar = (char *) malloc(100);
 
-delete [] _pString1; // Noncompliant: an object was declared but array deletion is attempted
-delete _pString2;  // Noncompliant: an array was declared but an object (the first in the array) is deleted
+delete [] _pString1; // Noncompliant: an object was declared, but array deletion is attempted
+delete _pString2;  // Noncompliant: an array was declared, but an object (the first in the array) is deleted
 delete _pChar; // Noncompliant
 ----
 
@@ -64,11 +64,11 @@ free(_pChar); // Compliant: free the memory C-style
 === Going the extra mile
 
 Manually allocating and deallocating memory is a code smell
-because of the issue covered by this rule, and it is easy to leak memory.
+because of the issue covered by this rule, and because it is easy to leak memory.
 
 Whenever possible, prefer the RAII (resource acquisition is allocation) {cpp} idiom.
 
-If in the example above you use the appropriate standard objects,
+If, in the example above, you use the appropriate standard objects,
 you do not need to remember how and when to deallocate them:
 
 [source,cpp]
@@ -90,7 +90,7 @@ std::string _pChar{100, '\0'};
 
 === Related rules
 
-* S5025 recommends to avoid manual memory management
+* S5025 recommends avoiding manual memory management
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -14,12 +14,6 @@ Specifically, deallocation should correspond to allocation as per the table belo
 |`p = malloc(sizeof(int)*5);` | `free(p);`
 |============================================
 
-Specifically, arrays should be deleted with `+delete []+` and objects should be deleted with `delete`.
-
-This is also true for the memory allocated with `+malloc+` or one of its variants.
-It must be released using `free()` and not `delete`.
-Similarly, the memory allocated with `new` cannot be released using `free()` instead of `delete`.
-
 === What is the potential impact?
 
 Using a mismatching deallocation construct leads to undefined behavior.

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -1,41 +1,96 @@
+Use the same form to deallocate objects as used to allocate them to avoid segmentation faults and memory leaks.
+
 == Why is this an issue?
 
-The same form that was used to create an object should always be used to delete it. Specifically, arrays should be deleted with ``++delete []++`` and objects should be deleted with ``++delete++``. To do otherwise will cause segfaults (in the case of deleting an object with ``++delete []++``) and memory leaks (in the case of deleting an array with ``++delete++``).
+The same form that was used to create an object should always be used to delete it.
+Specifically, arrays should be deleted with `+delete []+` and objects should be deleted with `delete`.
 
-This is also true when memory was allocated with ``++malloc++``, or one of its variants, then it must be released using ``++free()++`` not ``++delete++``. Similarly memory allocated by ``++new++`` can not be released using ``++free++`` instead of ``++delete++``.
+This is also true for the memory allocated with `+malloc+` or one of its variants.
+It must be released using `free()` and not `delete`.
+Similarly, the memory allocated with `new` cannot be released using `free()` instead of `delete`.
 
+=== What is the potential impact?
 
-=== Noncompliant code example
+Using a mismatching deallocation construct leads to undefined behavior.
+This means the compiler is not bound by the language standard anymore and your program has no meaning assigned to it.
 
-[source,cpp]
+Practically, you can observe the following effects:
+
+- Deleting a single object with `+delete[]+` leads to a segmentation fault
+  trying to access memory-manager metadata that is not there.
+- Deleting an array with `delete` leads to a memory leak because it will
+  delete and deallocate only the first element of the array.
+- Freeing with `free()` the underlying memory for an object constructed with `new`
+  will skip the destructor call, most likely leading to a memory leak.
+  An automatic mechanism, such as RAII,
+  might still invoke later the destructor on the freed memory causing a segmentation fault.
+- Deleting with `delete` an "object" allocated with `new`
+  will lead to a destructor invocation on an "object" that was never constructed
+  so the destructor might hit an unsatisfied assumption.
+
+== How to fix it
+
+Use the deallocation mechanism that matches the allocation.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 string* _pString1 = new string;
 string* _pString2 = new string[100];
 char* _pChar = (char *) malloc(100);
 
-delete [] _pString1; // Noncompliant; an object was declared but array deletion is attempted
-delete _pString2;  // Noncompliant; an array was declared but an object (the first in the array) is deleted
+delete [] _pString1; // Noncompliant: an object was declared but array deletion is attempted
+delete _pString2;  // Noncompliant: an array was declared but an object (the first in the array) is deleted
 delete _pChar; // Noncompliant
 ----
 
 
-=== Compliant solution
+==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 string* _pString1 = new string;
 string* _pString2 = new string[100];
 char* _pChar = (char *) malloc(100);
 
-delete _pString1;
-delete [] _pString2; 
-free(_pChar);
+delete _pString1; // Compliant: delete the object
+delete [] _pString2; // Compliant: delete the entire array
+free(_pChar); // Compliant: free the memory C-style
 ----
 
+=== Going the extra mile
+
+Manually allocating and deallocating memory is a code smell
+because of the issue covered by this rule, and it is easy to leak memory.
+
+Whenever possible, prefer the RAII (resource acquisition is allocation) {cpp} idiom.
+
+If in the example above you use the appropriate standard objects,
+you do not need to remember how and when to deallocate them:
+
+[source,cpp]
+----
+auto _pString1 = std::make_unique<std::string>();
+auto _pString2 = std::make_unique<std::string[]>(100);
+std::string _pChar{100, '\0'};
+
+// No need to call "delete" or "free".
+// Memory allocated for the three objects above will be freed automatically
+// when they go out of scope.
+----
 
 == Resources
 
-* https://wiki.sei.cmu.edu/confluence/x/Gns-BQ[CERT, MEM51-CPP.] - Properly deallocate dynamically allocated resources
+=== Standards
+
+* CERT - https://wiki.sei.cmu.edu/confluence/x/Gns-BQ[MEM51-CPP. Properly deallocate dynamically allocated resources]
+
+=== Related rules
+
+* S5025 - recomments to avoid manual memory management
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -90,7 +90,7 @@ std::string _pChar{100, '\0'};
 
 === Related rules
 
-* S5025 - recomments to avoid manual memory management
+* S5025 recommends to avoid manual memory management
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -1,8 +1,19 @@
-Use the same form to deallocate objects as used to allocate them to avoid segmentation faults and memory leaks.
+Use the matching way of deallocating the objects to the one used to allocate them to avoid segmentation faults and memory leaks.
 
 == Why is this an issue?
 
 The same form that was used to create an object should always be used to delete it.
+Specifically, deallocation should correspond to allocation as per the table below.
+
+.Matching allocation and deallocation ways
+[options="header"]
+|============================================
+|Allocation                   | Deallocation
+|`p = new T();`               | `delete p;`
+|`+p = new T[5];+`            | `+delete[] p;+`
+|`p = malloc(sizeof(int)*5);` | `free(p);`
+|============================================
+
 Specifically, arrays should be deleted with `+delete []+` and objects should be deleted with `delete`.
 
 This is also true for the memory allocated with `+malloc+` or one of its variants.
@@ -22,11 +33,14 @@ Practically, you can observe the following effects:
   delete and deallocate only the first element of the array.
 - Freeing with `free()` the underlying memory for an object constructed with `new`
   will skip the destructor call, most likely leading to a memory leak.
-  An automatic mechanism, such as RAII,
-  might still invoke later the destructor on the freed memory causing a segmentation fault.
+  Additionally, a destructor might still be called on freed memory causing further undefined behavior.
 - Deleting with `delete` an memory block allocated with `operator new`
   will lead to a destructor invocation on an "object" that was never constructed
   so the destructor might hit an unsatisfied assumption.
+
+=== Why does the rule apply to `::operator new(std::size_t count)`?
+
+TODO:
 
 == How to fix it
 

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -28,13 +28,32 @@ Practically, you can observe the following effects:
 - Freeing with `free()` the underlying memory for an object constructed with `new`
   will skip the destructor call, most likely leading to a memory leak.
   Additionally, a destructor might still be called on freed memory causing further undefined behavior.
-- Deleting with `delete` an memory block allocated with `operator new`
-  will lead to a destructor invocation on an "object" that was never constructed
-  so the destructor might hit an unsatisfied assumption.
 
-=== Why does the rule apply to `::operator new(std::size_t count)`?
+=== Why is the issue raised for a type with a trivial destructor?
 
 TODO:
+
+----
+struct TrivialClass {};
+
+
+TrivialClass* p = new TrivialClass();
+free(p); // no destructor is called.
+----
+
+
+----
+int* p = malloc(10 * sizeof(int));
+delete[] p; // expect array coookie
+----
+
+
+TODO `::operator new(std::size_t count)`
+
+----
+::operator new(10 * sizeof(int));
+free()
+----
 
 == How to fix it
 
@@ -74,7 +93,7 @@ free(_pChar); // Compliant: free the memory C-style
 Manually allocating and deallocating memory is a code smell
 because of the issue covered by this rule, and because it is easy to leak memory.
 
-Whenever possible, prefer the RAII (resource acquisition is allocation) {cpp} idiom.
+Whenever possible, prefer the RAII (Resource Acquisition Is Initialization) {cpp} idiom.
 
 If, in the example above, you use the appropriate standard objects,
 you do not need to remember how and when to deallocate them:
@@ -104,6 +123,9 @@ std::string _pChar{100, '\0'};
 
 * S5025 recommends avoiding manual memory management
 
+=== Documentation
+
+* {cpp} Reference - https://en.cppreference.com/w/cpp/language/raii[RAII (Resource Acquisition Is Initialization)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -38,8 +38,8 @@ Use the deallocation mechanism that matches the allocation.
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-string* _pString1 = new string;
-string* _pString2 = new string[100];
+std::string* _pString1 = new std::string;
+std::string* _pString2 = new std::string[100];
 char* _pChar = (char *) malloc(100);
 
 delete [] _pString1; // Noncompliant: an object was declared, but array deletion is attempted
@@ -52,8 +52,8 @@ delete _pChar; // Noncompliant
 
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
-string* _pString1 = new string;
-string* _pString2 = new string[100];
+std::string* _pString1 = new std::string;
+std::string* _pString2 = new std::string[100];
 char* _pChar = (char *) malloc(100);
 
 delete _pString1; // Compliant: delete the object
@@ -73,8 +73,12 @@ you do not need to remember how and when to deallocate them:
 
 [source,cpp]
 ----
-auto _pString1 = std::make_unique<std::string>();
-auto _pString2 = std::make_unique<std::string[]>(100);
+std::string _pString1a; // A local variable often is enough
+
+// Use a smart pointer when you do need heap allocation
+auto _pString1b = std::make_unique<std::string>();
+
+std::vector<std::string> _pString2(100);
 std::string _pChar{100, '\0'};
 
 // No need to call "delete" or "free".


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

