### PR TITLE
Modify rule S1679: LaYC format

### DIFF
--- a/rules/S1679/cfamily/rule.adoc
+++ b/rules/S1679/cfamily/rule.adoc
@@ -13,7 +13,7 @@ The rule raises an issue when the argument of the `throw` expression is an unmod
 
 ==== Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 try {
   throw std::invalid_argument("x");
@@ -25,7 +25,7 @@ try {
 
 ==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 try {
   throw std::invalid_argument("x");
@@ -34,7 +34,6 @@ try {
   throw; // Compliant: rethrows the initial "std::invalid_argument" exception
 }
 ----
-
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1679/cfamily/rule.adoc
+++ b/rules/S1679/cfamily/rule.adoc
@@ -1,8 +1,18 @@
 == Why is this an issue?
 
-Rethrowing an unmodified copy of the caught exception is not a good practice for the following reasons:
+When `throw` is followed by an expression, this expression will be used to create and initialize the exception object. In other words, the exception object is _copy-initialized_ from the expression.
 
-* The exception already exists, so it is best to reuse it for not wasting resources.
+[source,cpp]
+----
+catch (const std::exception& ex) {
+  // ...
+  throw ex; // "throw" copy-initializes the exception object from "ex"
+}
+----
+
+Rethrowing an unmodified copy of the caught exception is not a good practice because:
+
+* The exception already exists, so it is better to reuse it instead of creating a new one and wasting resources.
 * The copy will be an instance of the exception base class rather than the potentially more specific exception class initially caught. So it may lead to a loss of precision.
 
 == How to fix it
@@ -34,6 +44,13 @@ try {
   throw; // Compliant: rethrows the initial "std::invalid_argument" exception
 }
 ----
+
+== Resources
+
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/throw[`throw` expression]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/copy_initialization[Copy initialization]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1679/cfamily/rule.adoc
+++ b/rules/S1679/cfamily/rule.adoc
@@ -1,30 +1,37 @@
 == Why is this an issue?
 
-Rethrowing an unmodified copy of the caught exception is a waste of resources. Additionally, doing so may lead to a loss of precision in the object type and its data, since the copy will be an instance of the base class, rather than of the potentially more specific exception class originally caught.
+Rethrowing an unmodified copy of the caught exception is not a good practice for the following reasons:
 
+* The exception already exists, so it is best to reuse it for not wasting resources.
+* The copy will be an instance of the exception base class rather than the potentially more specific exception class initially caught. So it may lead to a loss of precision.
 
-=== Noncompliant code example
+== How to fix it
+
+The rule raises an issue when the argument of the `throw` expression is an unmodified copy of the caught exception.
+
+=== Code examples
+
+==== Noncompliant code example
 
 [source,cpp]
 ----
 try {
   throw std::invalid_argument("x");
 } catch (const std::exception& ex) {
-  /* ... */
-  throw ex; // Noncompliant; the received "std::invalid_argument" is copied into a less specialized class "std::exception"
+  // ...
+  throw ex; // Noncompliant: the received "std::invalid_argument" exception is copied into a less specialized class "std::exception"
 }
 ----
 
-
-=== Compliant solution
+==== Compliant solution
 
 [source,cpp]
 ----
 try {
   throw std::invalid_argument("x");
 } catch (const std::exception& ex) {
-  /* ... */
-  throw; // rethrows the initial "std::invalid_argument"
+  // ...
+  throw; // Compliant: rethrows the initial "std::invalid_argument" exception
 }
 ----
 

--- a/rules/S1679/cfamily/rule.adoc
+++ b/rules/S1679/cfamily/rule.adoc
@@ -10,7 +10,7 @@ catch (const std::exception& ex) {
 }
 ----
 
-Rethrowing an unmodified copy of the caught exception is not a good practice because:
+Rethrowing an unmodified copy of the caught exception is a bad practice because:
 
 * The exception already exists, so it is better to reuse it instead of creating a new one and wasting resources.
 * The copy will be an instance of the exception base class rather than the potentially more specific exception class initially caught. So it may lead to a loss of precision.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

