### PR TITLE
Modify rule S6214: Convert to LaYC format

### DIFF
--- a/rules/S3520/cfamily/rule.adoc
+++ b/rules/S3520/cfamily/rule.adoc
@@ -8,7 +8,7 @@ A best practice to avoid this bug calls for setting just-freed pointers to ``++N
 
 === Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 void doSomething(int size) {
   char *cp = (char *) malloc(sizeof(char) * size);
@@ -25,7 +25,7 @@ void doSomething(int size) {
 
 === Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 void doSomething(int size) {
   char *cp = (char *) malloc(sizeof(char) * size);

--- a/rules/S3520/cfamily/rule.adoc
+++ b/rules/S3520/cfamily/rule.adoc
@@ -8,7 +8,7 @@ A best practice to avoid this bug calls for setting just-freed pointers to ``++N
 
 === Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp]
 ----
 void doSomething(int size) {
   char *cp = (char *) malloc(sizeof(char) * size);
@@ -25,7 +25,7 @@ void doSomething(int size) {
 
 === Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp]
 ----
 void doSomething(int size) {
   char *cp = (char *) malloc(sizeof(char) * size);

--- a/rules/S6214/cfamily/metadata.json
+++ b/rules/S6214/cfamily/metadata.json
@@ -27,5 +27,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "targeted"
 }

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Compare integers safely using `std::cmp_*` functions to avoid any unexpected results.
+Compare integers of mixed signedness safely using `std::cmp_*` functions to avoid any unexpected results.
 
 == Why is this an issue?
 
@@ -11,7 +11,7 @@ This rule raises an issue when an unsigned integer is compared with a negative v
 
 === What is the potential impact
 
-Integer comparisons are usually used in creating branch conditions.
+Integer comparisons are often used in branch conditions.
 An unexpected result from one of these conditions can lead to hard-to-detect issues.
 
 For example, using container size functions in a comparison can lead to such a problem since these return an unsigned integer value.
@@ -63,7 +63,7 @@ if (0 < v.size() && v.size() < 100) { // Compliant, even though v.size() returns
 == Resources
 
 * S845 - a more generic rule about mixing signed and unsigned values.
-* S6183 - a version of this rule that triggers when signed and unsigned variables are compared.
+* S6183 - a version of this rule that triggers when any signed and unsigned variables are compared.
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -71,6 +71,10 @@ if (0 <= v.size() && v.size() < 100) { // Compliant, even though v.size() return
 
 == Resources
 
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/intcmp[std::cmp_* functions]
+
 === Related rules
 
 * S845 - a more generic rule about mixing signed and unsigned values.

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -26,7 +26,7 @@ For example, `std::cmp_less(2U, -1)` is `false`.
 
 ==== Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 bool less = 2U < -1; // Noncompliant
 
@@ -40,7 +40,7 @@ if (x < y) { // Noncompliant
 
 ==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 bool less = std::cmp_less(2U, -1); // Compliant
 

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -22,7 +22,7 @@ For example, using container size functions in a comparison can lead to such a p
 These functions correctly handle negative numbers and lossy integer conversion.
 For example, `std::cmp_less(2U, -1)` is `false`.
 
-=== Code Examples
+=== Code examples
 
 ==== Noncompliant code example
 

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -4,15 +4,15 @@ Compare integers of mixed signedness safely using `std::cmp_*` functions to avoi
 
 Comparison between `signed` and `unsigned` integers is dangerous because it produces counter-intuitive results due to implicit conversions.
 When a signed integer is compared to an unsigned one, the former might be converted to unsigned.
-The conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result.
+Since {cpp}20, the conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result.
 For example, `2U < -1` is `true`.
 
 This rule raises an issue when an unsigned integer is compared with a negative value.
 
 === What is the potential impact
 
-Integer comparisons are often used in branch conditions.
-An unexpected result from one of these conditions can lead to hard-to-detect issues.
+Integer comparisons are often used in branch and loop conditions.
+An unexpected result from one of these conditions can lead to hard-to-detect issues, such as unexpected infinite loops.
 
 For example, using container size functions in a comparison can lead to such a problem since these return an unsigned integer value.
 

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -62,6 +62,8 @@ if (0 < v.size() && v.size() < 100) { // Compliant, even though v.size() returns
 
 == Resources
 
+=== Related rules
+
 * S845 - a more generic rule about mixing signed and unsigned values.
 * S6183 - a version of this rule that triggers when any signed and unsigned variables are compared.
 

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -12,13 +12,13 @@ This rule raises an issue when an unsigned integer is compared with a negative v
 === What is the potential impact
 
 Integer comparisons are usually used in creating branch conditions.
-Having an unexpected result from one of these conditions can lead to hard-to-detect issues.
+An unexpected result from one of these conditions can lead to hard-to-detect issues.
 
-For example, using container size functions in a comparison can lead to such a problem, since these return an unsigned integer value.
+For example, using container size functions in a comparison can lead to such a problem since these return an unsigned integer value.
 
 == How to fix it
 
-{cpp}20 introduced remedy to this common pitfall: a family of `std::cmp_*` functions defined in the `<utility>` header.
+{cpp}20 introduced a remedy to this common pitfall: a family of `std::cmp_*` functions defined in the `<utility>` header.
 These functions correctly handle negative numbers and lossy integer conversion.
 For example, `std::cmp_less(2U, -1)` is `false`.
 
@@ -63,7 +63,7 @@ if (0 < v.size() && v.size() < 100) { // Compliant, even though v.size() returns
 == Resources
 
 * S845 - a more generic rule about mixing signed and unsigned values.
-* S6183 - a version of this rule that triggers as soon as signed and unsigned variables are compared.
+* S6183 - a version of this rule that triggers when signed and unsigned variables are compared.
 
 
 ifdef::env-github,rspecator-view[]
@@ -76,3 +76,4 @@ ifdef::env-github,rspecator-view[]
 === relates to: S6183
 
 endif::env-github,rspecator-view[]
+

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -1,18 +1,30 @@
+Compare integers safely using `std::cmp_*` functions to avoid any unexpected results.
+
 == Why is this an issue?
 
-Comparison between `signed` and `unsigned` integers is dangerous because it produces counterintuitive results outside of their common range of values.
-
-
-When a signed integer is compared to an unsigned one, the former might be converted to unsigned. The conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result. For example, `2U < -1` is `true`.
-
-
-{cpp}20 introduced remedy to this common pitfall: a family of `std::cmp_*` functions defined in the `<utility>` header. These functions correctly handle negative numbers and lossy integer conversion. For example, `std::cmp_less(2U, -1)` is `false`.
-
+Comparison between `signed` and `unsigned` integers is dangerous because it produces counter-intuitive results due to implicit conversions.
+When a signed integer is compared to an unsigned one, the former might be converted to unsigned.
+The conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result.
+For example, `2U < -1` is `true`.
 
 This rule raises an issue when an unsigned integer is compared with a negative value.
 
+=== What is the potential impact
 
-=== Noncompliant code example
+Integer comparisons are usually used in creating branch conditions.
+Having an unexpected result from one of these conditions can lead to hard-to-detect issues.
+
+For example, using container size functions in a comparison can lead to such a problem, since these return an unsigned integer value.
+
+== How to fix it
+
+{cpp}20 introduced remedy to this common pitfall: a family of `std::cmp_*` functions defined in the `<utility>` header.
+These functions correctly handle negative numbers and lossy integer conversion.
+For example, `std::cmp_less(2U, -1)` is `false`.
+
+=== Code Examples
+
+==== Noncompliant code example
 
 [source,cpp]
 ----
@@ -26,7 +38,7 @@ if (x < y) { // Noncompliant
 ----
 
 
-=== Compliant solution
+==== Compliant solution
 
 [source,cpp]
 ----

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -4,7 +4,7 @@ Compare integers of mixed signedness safely using `std::cmp_*` functions to avoi
 
 Comparison between `signed` and `unsigned` integers is dangerous because it produces counter-intuitive results due to implicit conversions.
 When a signed integer is compared to an unsigned one, the former might be converted to unsigned.
-Since {cpp}20, the conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result.
+Since {cpp}20, the conversion preserves the two's-complement bit pattern of the signed value that always corresponds to a large unsigned result.
 For example, `2U < -1` is `true`.
 
 This rule raises an issue when an unsigned integer is compared with a negative value.

--- a/rules/S6214/cfamily/rule.adoc
+++ b/rules/S6214/cfamily/rule.adoc
@@ -35,6 +35,15 @@ signed y = -1;
 if (x < y) { // Noncompliant
   // ...
 }
+
+bool fun(int x, std::vector<int> const& v) {
+  return x < v.size(); // Noncompliant: if x is negative, it is converted to unsigned, losing its value.
+}
+
+std::vector<int> v = foo();
+if (-1 < v.size() && v.size() < 100) { // Noncompliant: -1 < v.size() is false for all sizes.
+                                       // -1 converted to unsigned is larger than any int value
+}
 ----
 
 
@@ -55,7 +64,7 @@ bool fun(int x, std::vector<int> const& v) {
 }
 
 std::vector<int> v = foo();
-if (0 < v.size() && v.size() < 100) { // Compliant, even though v.size() returns an unsigned integer
+if (0 <= v.size() && v.size() < 100) { // Compliant, even though v.size() returns an unsigned integer
 }
 ----
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

