### PR TITLE
Modify rule S6328: Remove Noncompliant section

### DIFF
--- a/rules/S6328/javascript/rule.adoc
+++ b/rules/S6328/javascript/rule.adoc
@@ -16,8 +16,6 @@ If the second argument of ``++String.prototype.replace()++`` references non-exis
 
 This rule checks that all referenced groups exist when replacing a pattern with a replacement string using ``++String.prototype.replace()++`` or ``++String.prototype.replaceAll()++`` methods.
 
-=== Noncompliant code example
-
 [source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 const str = 'John Doe';


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

