### PR TITLE
Modify rule S2190: fix typo

### DIFF
--- a/rules/S2190/csharp/rule.adoc
+++ b/rules/S2190/csharp/rule.adoc
@@ -20,7 +20,7 @@ public int Sum()
 This can happen in multiple scenarios.
 
 === Loop statements
-`while` and `for` loops with no `break` or `return` statements and with the exit condition that are always `false` will be indefinitely executed.
+`while` and `for` loops with no `break` or `return` statements with exit conditions that are always `false` will be indefinitely executed.
 
 === "goto" statements
 `goto` statement with nothing that stops it from being executed over and over again will prevent the program from the completion.

--- a/rules/S2190/csharp/rule.adoc
+++ b/rules/S2190/csharp/rule.adoc
@@ -20,7 +20,7 @@ public int Sum()
 This can happen in multiple scenarios.
 
 === Loop statements
-`while` and `for` loops with no `break` or `return` statements with exit conditions that are always `false` will be indefinitely executed.
+`while` and `for` loops with no `break` or `return` statements that have exit conditions which are always `false` will be indefinitely executed.
 
 === "goto" statements
 `goto` statement with nothing that stops it from being executed over and over again will prevent the program from the completion.

--- a/rules/S2190/csharp/rule.adoc
+++ b/rules/S2190/csharp/rule.adoc
@@ -20,7 +20,7 @@ public int Sum()
 This can happen in multiple scenarios.
 
 === Loop statements
-`while` and `for` loops with no `break` or `return` statements and with the exit condition always `false` will be indefinitely executed.
+`while` and `for` loops with no `break` or `return` statements and with the exit condition that are always `false` will be indefinitely executed.
 
 === "goto" statements
 `goto` statement with nothing that stops it from being executed over and over again will prevent the program from the completion.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

