### PR TITLE
Modify rule S2107: Expand and adjust for LaYC

### DIFF
--- a/rules/S2107/cfamily/metadata.json
+++ b/rules/S2107/cfamily/metadata.json
@@ -1,5 +1,7 @@
 {
   "title": "Member variables should be initialized",
+  "type": "BUG",
+  "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"
@@ -9,9 +11,21 @@
     "bad-practice",
     "pitfall"
   ],
+  "extra": {
+    "replacementRules": [
+
+    ],
+    "legacyKeys": [
+
+    ]
+  },
   "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-2107",
+  "sqKey": "S2107",
+  "scope": "Main",
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"
-  ]
+  ],
+  "quickfix": "infeasible"
 }

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -4,12 +4,13 @@ and might lead to hard-to-catch bugs.
 == Why is this an issue?
 
 In a {cpp} class,
-all member variables of a type with an implicit or explicit constructor will be automatically initialized.
+all member variables of a type with an explicit constructor
+or of non-trivial type with a default constructor will be automatically initialized.
 This is not the case for the others:
 if no initialization is explicitly written,
 the variable will be left uninitialized.
 Trivial types with a ``++default++``ed or implicit default constructor follow the aggregate initialization syntax:
-if you omit their initialization, they will not be initialized.
+if you omit them in the initialization list, they will not be initialized.
 
 [source,cpp]
 ----
@@ -17,7 +18,6 @@ struct Trivial {
   int x;
   int y;
 };
-
 struct Container {
   Trivial t;
   int arr[2];
@@ -39,7 +39,6 @@ struct Container {
     // this->arr is initialized to {1, 0}
   }
 };
-
 struct DefaultedContainer {
   Trivial t;
   int arr[2];

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -18,8 +18,7 @@ This comes with all the risks associated with uninitialized variables,
 and these risks propagate to all the classes using the faulty class as a type
 as a base class or a data member.
 This is all the more surprising
-that most programmers expect a constructor to correctly initialize the members of its class
-(this is its raison d'être after all).
+that most programmers expect a constructor to correctly initialize the members of its class.
 
 include::../../../shared_content/cfamily/garbage_value_impact.adoc[]
 

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -40,7 +40,7 @@ For this reason, constructors should always initialize all data members of a cla
 While in some cases data members are initialized by their default constructor,
 in others, they are left with garbage.
 
-Trivial types with a ``++default++``ed or implicit default constructor follow the aggregate initialization syntax:
+Types with a ``++default++``ed or implicit trivial default constructor follow the aggregate initialization syntax:
 if you omit them in the initialization list, they will not be initialized.
 
 [source,cpp]
@@ -78,7 +78,7 @@ struct DefaultedContainer {
 };
 ----
 
-The same is true for an explicit ``++default++``ed default constructor.
+The same is true for an ``++default++``ed default constructor.
 [source,cpp]
 ----
 struct Defaulted {

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -8,6 +8,88 @@ all member variables of a type with an implicit or explicit constructor will be 
 This is not the case for the others:
 if no initialization is explicitly written,
 the variable will be left uninitialized.
+Trivial types with a ``++default++``ed or implicit default constructor follow the aggregate initialization syntax:
+if you omit their initialization, they will not be initialized.
+
+[source,cpp]
+----
+struct Trivial {
+  int x;
+  int y;
+};
+
+struct Container {
+  Trivial t;
+  int arr[2];
+  Container() {
+    // Noncompliant
+    // this->t is not initialized
+    // this->t.x and this->t.y contain garbage
+    // this->arr contains garbage
+  }
+  Container(int) :t{}, arr{} {
+    // Compliant
+    // this->t.x and this->t.y are initialized to 0
+    // this->arr is initialized to {0, 0}
+  }
+  Container(int, int) :t{1}, arr{1} {
+    // Compliant
+    // this->t.x is 1
+    // this->t.y is 0
+    // this->arr is initialized to {1, 0}
+  }
+};
+
+struct DefaultedContainer {
+  Trivial t;
+  int arr[2];
+  DefaultedContainer() = default; // Noncompliant
+  // this->t and this->arr are not initialized
+};
+----
+
+The same is true for an explicit ``++default++``ed default constructor.
+[source,cpp]
+----
+struct Defaulted {
+  int x;
+  Defaulted() = default;
+};
+struct ContainerDefaulted {
+  Defaulted d;
+  ContainerDefaulted() {
+    // Noncompliant this->d.x is not initialized
+  }
+};
+----
+
+
+Even if some of the members have class initializers,
+the other members are still not initialized by default.
+
+[source,cpp]
+----
+struct Partial {
+  int x;
+  int y = 1;
+  int z;
+};
+struct ContainerPartial {
+  Partial p;
+  ContainrePartial() {
+    // Noncompliant
+    // this->p.x is not initialized
+    // this->p.y is initialized to 1
+    // this->p.z is not initialized
+  }
+  ContainrePartial(bool) :p{3} {
+    // Compliant
+    // this->p.x is initialized to 3
+    // this->p.y is initialized to 1
+    // this->p.z is initialized to 0
+  }
+};
+----
 
 It is a common expectation that an object be in a fully-initialized state after its construction.
 A partially initialized object breaks this assumption.
@@ -117,6 +199,38 @@ public:
   T t;
 
   U() : t() { t.s.j = 0; }  // Compliant
+};
+----
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
+struct Partial {
+  int x;
+  int y = 1;
+};
+struct ContainerPartial {
+  Partial p;
+  ContainrePartial() {
+    // Noncompliant: this->p.x is not initialized
+  }
+};
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+struct Partial {
+  int x = 0;
+  int y = 1;
+};
+struct ContainerPartial {
+  Partial p;
+  ContainrePartial() {
+    // Compliant
+  }
 };
 ----
 

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -20,7 +20,7 @@ This is all the more surprising
 that most programmers expect a constructor to correctly initialize the members of its class
 (this is its raison d'être after all).
 
-include::../../../shared_content/cfamily/garbage_value_impact.adoc
+include::../../../shared_content/cfamily/garbage_value_impact.adoc[]
 
 === Exceptions
 
@@ -103,7 +103,7 @@ public:
 
 class T_fixed {
 public:
-  S _fixed s;
+  S_fixed s;
 
   T_fixed() : s() {}  // Compliant
   T_fixed(bool b) : s(b) {}

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -27,7 +27,7 @@ struct PartInit {
 };
 ----
 
-This leads to a garbage being printed in benign-looking code like this:
+This leads to garbage being printed in benign-looking code like this:
 
 [source,cpp]
 ----
@@ -37,8 +37,8 @@ std::cout <<pi.y;
 
 For this reason, constructors should always initialize all data members of a class.
 
-While in some cases data-members are initialized by their default constructor,
-in others they are left with garbage.
+While in some cases data members are initialized by their default constructor,
+in others, they are left with garbage.
 
 Trivial types with a ``++default++``ed or implicit default constructor follow the aggregate initialization syntax:
 if you omit them in the initialization list, they will not be initialized.
@@ -152,7 +152,7 @@ all non `+class+`-type fields should always be initialized (in order of preferen
 
 See rule S3230 for more details about this order.
 
-If none of the above places are a good fit for a data member,
+If none of the above places is a good fit for a data member,
 ask yourself whether it belongs to this class.
 Instead of a data member, it might be more appropriate to keep the value
 

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -1,12 +1,37 @@
+Partially-initialized objects are surprising to the `clasa` users
+and might lead to hard-to-catch bugs.
+
 == Why is this an issue?
 
-In a {cpp} class, all member variables of a type with an implicit or explicit constructor will be automatically initialized. This is not the case for the others: if no initialization is explicitly written, the variable will be left uninitialized.
+In a {cpp} class,
+all member variables of a type with an implicit or explicit constructor will be automatically initialized.
+This is not the case for the others:
+if no initialization is explicitly written,
+the variable will be left uninitialized.
 
+It is a common expectation that an object be in a fully-initialized state after its construction.
+A partially initialized object breaks the common assumption that class users attach to it.
 
-This comes with all the risks associated with uninitialized variables, and these risks propagate to all the classes using the faulty class as a type. This is all the more surprising that most programmers expect a constructor to correctly initialize the members of its class (this is its raison d'être after all).
+=== What is the potential impact?
 
+This comes with all the risks associated with uninitialized variables,
+and these risks propagate to all the classes using the faulty class as a type.
+This is all the more surprising
+that most programmers expect a constructor to correctly initialize the members of its class
+(this is its raison d'être after all).
 
-To avoid such situations, all non class type fields should always be initialized (in order of preference):
+include::../../../shared_content/cfamily/garbage_value_impact.adoc
+
+=== Exceptions
+
+Aggregate classes do not initialize most of their data members
+but allow their users to use nice and flexible initialization syntax.
+They will be ignored by this rule (but are the subject of S5558).
+
+== How to fix it
+
+To avoid partially-initialized objects,
+all non `+class+`-type fields should always be initialized (in order of preference):
 
 * With an in-class initializer
 * In the initialization list of a constructor
@@ -14,7 +39,17 @@ To avoid such situations, all non class type fields should always be initialized
 
 See S3230 for more details about this order.
 
-=== Noncompliant code example
+If none of the above places are a good fit for a data member,
+ask yourself whether it belongs to this class.
+Instead of a data member, it might be more appropriate to keep the value
+
+- in a delegate class,
+- in a (`static`) local variable of a member function, or
+- in a parameter of a member function.
+
+=== Code examples
+
+==== Noncompliant code example
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----
@@ -48,7 +83,7 @@ public:
 };
 ----
 
-=== Compliant solution
+==== Compliant solution
 
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
@@ -82,17 +117,17 @@ public:
 };
 ----
 
-=== Exceptions
-
-Aggregate classes do not initialize most of their data members, but allow their users to use nice and flexible initialization syntax. They will be ignored by this rule (but are the subject of S5558).
-
 == Resources
+
+=== External coding guidelines
 
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c41-a-constructor-should-create-a-fully-initialized-object[C.41: A constructor should create a fully initialized object]
 
 === Related rules
 
 * S836 detects the uses of uninitialized variables.
+* S3230 describes the preferred place for initializing class data members.
+
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -119,7 +119,7 @@ all non `+class+`-type fields should always be initialized (in order of preferen
 * In the initialization list of a constructor
 * In the constructor body
 
-See S3230 for more details about this order.
+See rule S3230 for more details about this order.
 
 If none of the above places are a good fit for a data member,
 ask yourself whether it belongs to this class.

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -1,4 +1,4 @@
-Partially-initialized objects are surprising to the `clasa` users
+Partially-initialized objects are surprising to the `class` users
 and might lead to hard-to-catch bugs.
 
 == Why is this an issue?
@@ -10,12 +10,13 @@ if no initialization is explicitly written,
 the variable will be left uninitialized.
 
 It is a common expectation that an object be in a fully-initialized state after its construction.
-A partially initialized object breaks the common assumption that class users attach to it.
+A partially initialized object breaks this assumption.
 
 === What is the potential impact?
 
 This comes with all the risks associated with uninitialized variables,
-and these risks propagate to all the classes using the faulty class as a type.
+and these risks propagate to all the classes using the faulty class as a type
+as a base class or a data member.
 This is all the more surprising
 that most programmers expect a constructor to correctly initialize the members of its class
 (this is its raison d'être after all).
@@ -44,7 +45,7 @@ ask yourself whether it belongs to this class.
 Instead of a data member, it might be more appropriate to keep the value
 
 - in a delegate class,
-- in a (`static`) local variable of a member function, or
+- in a (potentially `static`) local variable of a member function, or
 - in a parameter of a member function.
 
 === Code examples

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -246,7 +246,9 @@ struct ContainerPartial {
 
 === Documentation
 
-* {cpp} reference - https://en.cppreference.com/w/cpp/language/value_initialization[Value Initialization]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/aggregate_initialization[Aggregate initialization]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/direct_initialization[Direct initialization]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/value_initialization[Value initialization]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -27,12 +27,14 @@ struct PartInit {
 };
 ----
 
-This leads to garbage being printed in benign-looking code like this:
+This leads to undefined behavior in benign-looking code like on the example below.
+In this particular case, garbage value may be printed,
+or a compiler may optimize away the print statement completely.
 
 [source,cpp]
 ----
 PartInit pi(1);
-std::cout <<pi.y;
+std::cout <<pi.y; // Undefined behavior
 ----
 
 For this reason, constructors should always initialize all data members of a class.
@@ -78,7 +80,7 @@ struct DefaultedContainer {
 };
 ----
 
-The same is true for an ``++default++``ed default constructor.
+The same is true for a ``++default++``ed default constructor.
 [source,cpp]
 ----
 struct Defaulted {

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -1,14 +1,45 @@
 Partially-initialized objects are surprising to the `class` users
 and might lead to hard-to-catch bugs.
+``class``es with constructors are expected to have all members initialized after their constructor finishes.
+
+This rule raises an issue when some members are left uninitialized after a constructor finishes.
 
 == Why is this an issue?
 
-In a {cpp} class,
-all member variables of a type with an explicit constructor
-or of non-trivial type with a default constructor will be automatically initialized.
-This is not the case for the others:
-if no initialization is explicitly written,
-the variable will be left uninitialized.
+In the following example, `PartInit::x` is left uninitialized after the constructor finishes.
+
+[source,cpp]
+----
+struct AutomaticallyInitialized {
+  int x;
+  AutomaticallyInitialized() : x(0) {}
+};
+
+struct PartInit {
+  AutomaticallyInitialized ai;
+  int x;
+  int y;
+  PartInit(int n) :y(n) {
+    // this->ai is initialized
+    // this->y is initialized
+    // Noncompliant: this->x is left uninitialized
+  }
+};
+----
+
+This leads to a garbage being printed in benign-looking code like this:
+
+[source,cpp]
+----
+PartInit pi(1);
+std::cout <<pi.y;
+----
+
+For this reason, constructors should always initialize all data members of a class.
+
+While in some cases data-members are initialized by their default constructor,
+in others they are left with garbage.
+
 Trivial types with a ``++default++``ed or implicit default constructor follow the aggregate initialization syntax:
 if you omit them in the initialization list, they will not be initialized.
 
@@ -90,10 +121,10 @@ struct ContainerPartial {
 };
 ----
 
+=== What is the potential impact?
+
 It is a common expectation that an object be in a fully-initialized state after its construction.
 A partially initialized object breaks this assumption.
-
-=== What is the potential impact?
 
 This comes with all the risks associated with uninitialized variables,
 and these risks propagate to all the classes using the faulty class as a type
@@ -108,7 +139,7 @@ include::../../../shared_content/cfamily/garbage_value_impact.adoc[]
 Aggregate classes do not initialize most of their data members
 (unless you explicitly value initialize them with `x{}` or `x()`)
 but allow their users to use nice and flexible initialization syntax.
-They will be ignored by this rule (but are the subject of S5558).
+They will be ignored by this rule (but are the subject of rule S5558).
 
 == How to fix it
 
@@ -125,8 +156,8 @@ If none of the above places are a good fit for a data member,
 ask yourself whether it belongs to this class.
 Instead of a data member, it might be more appropriate to keep the value
 
-- in a member of the class of a dats member
-  (delegating initialization to the member type),
+- as part of the class of a data member
+  (delegating initialization to the constructor of the member type),
 - in a derived class (delegating initialization to the derived class),
 - in a (potentially `static`) local variable of a member function, or
 - in a parameter of a member function.

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -3,7 +3,7 @@
 In a {cpp} class, all member variables of a type with an implicit or explicit constructor will be automatically initialized. This is not the case for the others: if no initialization is explicitly written, the variable will be left uninitialized.
 
 
-This comes with all the risks associated with uninitialized variables, and these risks propagate to all the classes using  the faulty class as a type. This is all the more surprising that most programmers expect a constructor to correctly initialize the members of its class (this is its raison d'être after all).
+This comes with all the risks associated with uninitialized variables, and these risks propagate to all the classes using the faulty class as a type. This is all the more surprising that most programmers expect a constructor to correctly initialize the members of its class (this is its raison d'être after all).
 
 
 To avoid such situations, all non class type fields should always be initialized (in order of preference):
@@ -16,7 +16,7 @@ See S3230 for more details about this order.
 
 === Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 class C {
   int val = 42;
@@ -50,7 +50,7 @@ public:
 
 === Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 class C {
   int val = 42;
@@ -88,7 +88,11 @@ Aggregate classes do not initialize most of their data members, but allow their 
 
 == Resources
 
-* https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c41-a-constructor-should-create-a-fully-initialized-object[{cpp} Core Guidelines C.41]: A constructor should create a fully initialized object
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c41-a-constructor-should-create-a-fully-initialized-object[C.41: A constructor should create a fully initialized object]
+
+=== Related rules
+
+* S836 detects the uses of uninitialized variables.
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2107/cfamily/rule.adoc
+++ b/rules/S2107/cfamily/rule.adoc
@@ -25,6 +25,7 @@ include::../../../shared_content/cfamily/garbage_value_impact.adoc[]
 === Exceptions
 
 Aggregate classes do not initialize most of their data members
+(unless you explicitly value initialize them with `x{}` or `x()`)
 but allow their users to use nice and flexible initialization syntax.
 They will be ignored by this rule (but are the subject of S5558).
 
@@ -43,7 +44,9 @@ If none of the above places are a good fit for a data member,
 ask yourself whether it belongs to this class.
 Instead of a data member, it might be more appropriate to keep the value
 
-- in a delegate class,
+- in a member of the class of a dats member
+  (delegating initialization to the member type),
+- in a derived class (delegating initialization to the derived class),
 - in a (potentially `static`) local variable of a member function, or
 - in a parameter of a member function.
 
@@ -127,6 +130,10 @@ public:
 
 * S836 detects the uses of uninitialized variables.
 * S3230 describes the preferred place for initializing class data members.
+
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/value_initialization[Value Initialization]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2107/java/metadata.json
+++ b/rules/S2107/java/metadata.json
@@ -1,0 +1,24 @@
+{
+  "title": "Class fields should be initialized",
+  "type": "BUG",
+  "status": "closed",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "15min"
+  },
+  "tags": [
+    "pitfall"
+  ],
+  "extra": {
+    "replacementRules": [],
+    "legacyKeys": []
+  },
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-2107",
+  "sqKey": "S2107",
+  "scope": "Main",
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ],
+  "quickfix": "unknown"
+}

--- a/rules/S2107/java/rule.adoc
+++ b/rules/S2107/java/rule.adoc
@@ -1,0 +1,87 @@
+*This rule was deprecated for Java before it was implemented.*
+
+> in Java the members are initialized to default values (i.e. zero and null), so the rule doesn’t bring much value.
+
+https://discuss.sonarsource.com/t/is-the-rule-s2107-implemented-planned-duplicate-for-java/15217/2[discuss post]
+
+== Why is this an issue?
+
+Class members that are not assigned a default value and are not initialized in a constructor will be set to null by the compiler. Even if code exists to properly set those members, there is a risk that they will be dereferenced before it is called, resulting in a ``++NullPointerException++``. 
+
+
+Because you cannot guarantee that such classes will always be used properly, class members should always be initialized.
+
+
+This rule flags members which have no default value and which are left uninitialized by at least one class constructor, but which are unconditionally dereferenced somewhere in the code.
+
+
+=== Noncompliant code example
+
+[source,text]
+----
+public class Team {
+
+  int limit = 30;
+  List<Player> roster;  // Noncompliant; no default & not initialized by constructor
+  Person coach;
+
+  public Team (Person coach) { // roster is left uninitialized
+    this.coach = coach;
+  }
+
+  public void add(Player p) {
+    if (roster == null) {
+      roster = new ArrayList<Player>();
+    }
+    roster.add(p);
+  }
+
+  public boolean isFull() {  // NPE if called before add()
+    return roster.size() < limit;
+  }
+}
+----
+
+
+=== Compliant solution
+
+[source,text]
+----
+public class Team {
+
+  int limit = 30;
+  List<Player> roster = new ArrayList<Player>();
+  Person coach;
+
+  public Team (Person coach) {
+    this.coach = coach;
+  }
+
+  public void add(Player p) {
+    roster.add(p);
+  }
+
+  // ...
+----
+or 
+
+[source,text]
+----
+public class Team {
+
+  int limit = 30;
+  List<Player> roster;
+  Person coach;
+
+  public Team (Person coach) {
+    this.coach = coach;
+    this.roster = new ArrayList<Player>();
+  }
+
+  public void add(Player p) {
+    roster.add(p);
+  }
+
+  // ...
+----
+

--- a/rules/S2107/metadata.json
+++ b/rules/S2107/metadata.json
@@ -1,28 +1,2 @@
 {
-  "title": "Class fields should be initialized",
-  "type": "BUG",
-  "status": "ready",
-  "remediation": {
-    "func": "Constant\/Issue",
-    "constantCost": "15min"
-  },
-  "tags": [
-    "pitfall"
-  ],
-  "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
-  },
-  "defaultSeverity": "Major",
-  "ruleSpecification": "RSPEC-2107",
-  "sqKey": "S2107",
-  "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
-  "quickfix": "unknown"
 }

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -62,7 +62,7 @@ void usingNew() {
 
 === What is the potential impact?
 
-include::../../../shared_content/cfamily/garbage_value_impact.adoc
+include::../../../shared_content/cfamily/garbage_value_impact.adoc[]
 
 === Why is there an issue for a class with a default constructor?
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -62,24 +62,7 @@ void usingNew() {
 
 === What is the potential impact?
 
-Using garbage values will cause the program to behave
-nondeterministically at runtime.
-The program may produce a different output or crash depending
-on the run.
-
-In some situations, loading a variable may expose a sensitive
-data, such as a password that was previously stored in the same
-location, leading to a vulnerability that uses such a defect
-as a gadget for extracting information from the instance
-of the program.
-
-Finally, in {cpp}, outside of a few exceptions related to the uses
-of `unsigned char` or `std::byte`, loading data from an uninitialized
-variable causes undefined behavior. This means that the compiler
-is not bound by the language standard anymore, and the program
-has no meaning assigned to it. As a consequence, the impact
-of such a defect is not limited to the use of garbage values.
-
+include::../../../shared_content/cfamily/garbage_value_impact.adoc
 
 === Why is there an issue for a class with a default constructor?
 

--- a/shared_content/cfamily/garbage_value_impact.adoc
+++ b/shared_content/cfamily/garbage_value_impact.adoc
@@ -1,0 +1,17 @@
+
+Using garbage values will cause the program to behave
+nondeterministically at runtime.
+The program may produce a different output or crash depending on the run.
+
+In some situations, loading a variable may expose a sensitive data,
+such as a password that was previously stored in the same location,
+leading to a vulnerability that uses such a defect
+as a gadget for extracting information from the instance
+of the program.
+
+Finally, in {cpp}, outside of a few exceptions related to the uses of `unsigned char` or `std::byte`,
+loading data from an uninitialized variable causes undefined behavior.
+This means that the compiler is not bound by the language standard anymore,
+and the program has no meaning assigned to it.
+As a consequence,
+the impact of such a defect is not limited to the use of garbage values.


### PR DESCRIPTION
I moved and closed the Java rule description because they do not plan to implement it, but it is nice to preserve the description for posterity.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

