### PR TITLE
Modify S125: Set quickfix field for C#

### DIFF
--- a/rules/S125/csharp/metadata.json
+++ b/rules/S125/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "quickfix": "partial" 
 }


### PR DESCRIPTION
Fix I forgot to do when merging [the PR](https://github.com/SonarSource/sonar-dotnet/pull/6966) that implemented the codefix.