### PR TITLE
Clean ci/validate_asciidoc.sh

### DIFF
--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -49,6 +49,7 @@ fi
 #  * All asciidoc files are used/included.
 
 echo "Testing the following rules: ${affected_rules}"
+supportedLanguages=$(sed 's/ or//' supported_languages.adoc | tr -d '`,')
 for dir in $affected_rules
 do
   if [ ! -d "$dir" ]; then
@@ -83,7 +84,6 @@ do
     fi
     rm -f stuck
 
-    supportedLanguages=$(sed 's/ or//' supported_languages.adoc | tr -d '`,')
     for language in "${dir}"/*/
     do
       language=${language%*/}

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 set -uo pipefail
 
-readonly ALLOWED_RULE_SUB_FOLDERS=['common'];
-
 # Install script dependencies
+(set -e; cd rspec-tools && pipenv install)
+
+# This script runs all tests; it doesn't exit at the first failure.
+exit_code=0
+
+readonly ALLOWED_RULE_SUB_FOLDERS=['common'];
+readonly ROOT=$PWD
+declare -xr PATH_WITH_VARIABLE="$(realpath ./ci/replace_variables_in_path.sh)"
+
+# Validate user-visible rule descriptions
+# i.e., without rspecator-view.
+./ci/generate_html.sh
 cd rspec-tools
-pipenv install
+if pipenv run rspec-tools check-description --d ../out; then
+  echo "Rule descriptions are fine"
+else
+  echo "ERROR: There are invalid rule descriptions"
+  exit_code=1
+fi
 cd ..
 
 # Compute the set of affected rules
@@ -14,31 +29,23 @@ branch_base_sha=$(git merge-base FETCH_HEAD HEAD)
 echo "Comparing against the merge-base: $branch_base_sha"
 changeset=$(git diff --name-only "$branch_base_sha"..HEAD)
 affected_rules=$(printf '%s\n' "$changeset" | grep '/S[0-9]\+/' | sed 's:\(.*/S[0-9]\+\)/.*:\1:' | sort | uniq)
-affected_tooling=$(printf '%s\n' "$changeset" | grep -v '/S[0-9]\+/')
-if [ -n "$affected_tooling" ]; then
-    echo "Some rpec tools are changed, validating all rules"
-    affected_rules=rules/*
+if "$(printf '%s\n' "$changeset" | grep -qv '/S[0-9]\+/')"; then
+  echo "Some rpec tools or shared_content changed, validating all rules"
+  affected_rules=rules/*
 fi
 
-exit_code=0
-
-./ci/generate_html.sh
-
-PATH_WITH_VARIABLE="$(realpath ./ci/replace_variables_in_path.sh)"
-
-cd rspec-tools
-if pipenv run rspec-tools check-description --d ../out; then
-    echo "rule.adoc is fine"
-else
-    echo "ERROR: There are invalid rule.adoc"
-    exit_code=1
-fi
-cd ..
+# Validate some properties of the asciidoc:
+#  * Rules should have at least one language specification,
+#    unless they are closed or deprecated.
+#  * The include:: should have an empty line before and after them.
+#  * Only valid languages can be used as subdirectories in rule directories,
+#    with the exception of ALLOWED_RULE_SUB_FOLDERS.
+#  * Asciidoc files are free or errors and warnings.
+#  * Rule descriptions can include other asciidoc files from the same rule
+#    directory or from shared_content.
+#  * All asciidoc files are used/included.
 
 echo "Testing the following rules: ${affected_rules}"
-
-readonly ROOT=$PWD
-
 for dir in $affected_rules
 do
   if [ ! -d "$dir" ]; then
@@ -47,37 +54,34 @@ do
   fi
   dir=${dir%*/}
 
-  subdircount=$(find "$dir" -maxdepth 1 -type d | wc -l)
-
   # check if there are language specializations
-  if [[ "$subdircount" -eq 1 ]]
+  subdircount=$(find "$dir" -maxdepth 1 -mindepth 1 -type d | wc -l)
+  if [[ "$subdircount" -eq 0 ]]
   then
     # no specializations, that's fine if the rule is deprecated
-    if grep -q '"status": "deprecated"\|"status": "closed"' "$dir/metadata.json"; then
+    if grep -Pq '"status": "(deprecated|closed)"' "$dir/metadata.json"; then
       echo "INFO: deprecated generic rule $dir with no language specializations"
     else
       echo "ERROR: non-deprecated generic rule $dir with no language specializations"
       exit_code=1
     fi
   else
-    #validate asciidoc
-
     # Make sure include:: clauses are always more than one line away from the previous content
     # Detect includes stuck to the line before
     find "$dir" -name "*.adoc" -execdir sh -c 'grep -Pzl "\S[ \t]*\ninclude::" $1  | xargs -r -I@ realpath "$PWD/@"' shell {} \; > stuck
     # Detect includes stuck to the line after
     find "$dir" -name "*.adoc" -execdir sh -c 'grep -Pzl "include::[^\[]+\[\]\n[ \t]*[^\n]" $1  | xargs -r -I@ realpath "$PWD/@"' shell {} \; >> stuck
     if [ -s stuck ]; then
-        echo "ERROR: These adoc files contain an include that is stuck to other content."
-        echo "This may result in broken tags and other display issues."
-        echo "Make sure there is an empty line before and after each include:"
-        cat stuck
-        exit_code=1
+      echo "ERROR: These adoc files contain an include that is stuck to other content."
+      echo "This may result in broken tags and other display issues."
+      echo "Make sure there is an empty line before and after each include:"
+      cat stuck
+      exit_code=1
     fi
     rm -f stuck
 
     supportedLanguages=$(sed 's/ or//' supported_languages.adoc | tr -d '`,')
-    for language in $dir/*/
+    for language in "${dir}"/*/
     do
       language=${language%*/}
       if [[ ! "${supportedLanguages[*]}" == *"${language##*/}"* ]]; then
@@ -88,9 +92,10 @@ do
       else
         RULE="$language/rule.adoc"
         if test -f "$RULE"; then
-          # We build this filename that describes the path to workaround the fact that asciidoctor will not tell
-          # us the path of the file in case of error.
-          # We can remove it if https://github.com/asciidoctor/asciidoctor/issues/3414 is fixed.
+          # Errors emitted by asciidoctor don't include the full path.
+          # https://github.com/asciidoctor/asciidoctor/issues/3414
+          # To ease debugging, we copy the rule.adoc into tmp_SXYZ_language.adoc,
+          # with the required header, and run asciidoctor on them instead.
           TMP_ADOC="$language/tmp_$(basename "${dir}")_${language##*/}.adoc"
           echo "== Description" > "$TMP_ADOC"
           cat "$RULE" >> "$TMP_ADOC"
@@ -110,33 +115,34 @@ do
     # Directly included
     find "$dir" -name "*.adoc" ! -name 'tmp_*.adoc' -execdir sh -c 'grep -h "include::" "$1" | grep -Ev "{\w+}" | grep -v "rule.adoc" | sed -r "s/include::(.*)\[\]/\1/" | xargs -r -I@ realpath "$PWD/@"' shell {} \; > included
     # Included through variable
-    VARS_FULL_PATH=$(realpath vars) PATH_WITH_VARIABLE=${PATH_WITH_VARIABLE} find "$dir" ! -name 'tmp_*.adoc' -name "*.adoc" -execdir sh -c 'grep -Eh "include::.*\{" "$1" | xargs -r -I@ $PATH_WITH_VARIABLE $VARS_FULL_PATH "@" | xargs -r -I@ realpath "$PWD/@"' shell {} \; >> included
+    VARS_FULL_PATH=$(realpath vars) find "$dir" ! -name 'tmp_*.adoc' -name "*.adoc" -execdir sh -c 'grep -Eh "include::.*\{" "$1" | xargs -r -I@ $PATH_WITH_VARIABLE $VARS_FULL_PATH "@" | xargs -r -I@ realpath "$PWD/@"' shell {} \; >> included
     # We should only include documents from the same rule or from shared_content
     cross_references=$(grep -vEh "${ROOT}\/${dir}\/|${ROOT}\/shared_content\/" included)
     if [[ -n "$cross_references" ]]; then
-        printf 'ERROR: Rule %s tries to include content from unallowed directory:\n%s\nTo share content between rules, you should use the "shared_content" folder at the root of the repository\n' "$dir" "$cross_references"
-        exit_code=1
+      printf 'ERROR: Rule %s tries to include content from unallowed directory:\n%s\nTo share content between rules, you should use the "shared_content" folder at the root of the repository\n' "$dir" "$cross_references"
+      exit_code=1
     fi
     find "$dir" -name "*.adoc" ! -name 'rule.adoc' ! -name 'tmp*.adoc' -exec sh -c 'realpath $1' shell {} \; > created
     orphans=$(comm -1 -3 <(sort -u included) <(sort -u created))
     if [[ -n "$orphans" ]]; then
-        printf 'ERROR: These adoc files are not included anywhere:\n-----\n%s\n-----\n' "$orphans"
-        exit_code=1
+      printf 'ERROR: These adoc files are not included anywhere:\n-----\n%s\n-----\n' "$orphans"
+      exit_code=1
     fi
     rm -f included created vars
   fi
 done
 
+# Run asciidoctor and fails when a warning is emitted.
+# Use the tmp_SXYZ_language.adoc files (see note above).
 ADOC_COUNT=$(find rules -name "tmp*.adoc" | wc -l)
-
 if (( ADOC_COUNT > 0 )); then
   if asciidoctor --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
-      if asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
-          echo "${ADOC_COUNT} documents checked with success"
-      else
-          echo "ERROR: malformed asciidoc files in rspecator-view"
-          exit_code=1
-      fi
+    if asciidoctor -a rspecator-view --failure-level=WARNING -o /dev/null rules/*/*/tmp*.adoc; then
+      echo "${ADOC_COUNT} documents checked with success"
+    else
+      echo "ERROR: malformed asciidoc files in rspecator-view"
+      exit_code=1
+    fi
   else
     echo "ERROR: malformed asciidoc files"
     exit_code=1
@@ -144,12 +150,11 @@ if (( ADOC_COUNT > 0 )); then
 else
   echo "No new asciidoc file changed"
 fi
-
 find rules -name "tmp*.adoc" -delete
 
 if (( exit_code == 0 )); then
-    echo "Success"
+  echo "Success"
 else
-    echo "There were errors"
+  echo "There were errors"
 fi
 exit $exit_code

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -2,7 +2,9 @@
 set -uo pipefail
 
 # Install script dependencies
-(set -e; cd rspec-tools && pipenv install)
+set -e
+cd rspec-tools && pipenv install
+set +e
 
 # This script runs all tests; it doesn't exit at the first failure.
 exit_code=0

--- a/ci/validate_asciidoc.sh
+++ b/ci/validate_asciidoc.sh
@@ -9,6 +9,7 @@ exit_code=0
 
 readonly ALLOWED_RULE_SUB_FOLDERS=['common'];
 readonly ROOT=$PWD
+# Declare read-only variable PATH_WITH_VARIABLE and make it available to child processes
 declare -xr PATH_WITH_VARIABLE="$(realpath ./ci/replace_variables_in_path.sh)"
 
 # Validate user-visible rule descriptions
@@ -94,8 +95,9 @@ do
         if test -f "$RULE"; then
           # Errors emitted by asciidoctor don't include the full path.
           # https://github.com/asciidoctor/asciidoctor/issues/3414
-          # To ease debugging, we copy the rule.adoc into tmp_SXYZ_language.adoc,
-          # with the required header, and run asciidoctor on them instead.
+          # To ease debugging, we copy the rule.adoc into tmp_SXYZ_language.adoc
+          # and run asciidoctor on them instead.
+          # We add the implicit header "Description" to prevent an asciidoctor warning.
           TMP_ADOC="$language/tmp_$(basename "${dir}")_${language##*/}.adoc"
           echo "== Description" > "$TMP_ADOC"
           cat "$RULE" >> "$TMP_ADOC"
@@ -132,7 +134,7 @@ do
   fi
 done
 
-# Run asciidoctor and fails when a warning is emitted.
+# Run asciidoctor and fail if a warning is emitted.
 # Use the tmp_SXYZ_language.adoc files (see note above).
 ADOC_COUNT=$(find rules -name "tmp*.adoc" | wc -l)
 if (( ADOC_COUNT > 0 )); then


### PR DESCRIPTION
This PR is a prerequisite for:
 * #2685

---

 * Regroup readonly variable declaration. `declare -xr` is used for exported readonly variable.
 * Use more accurate log messages.
 * Use consistent indentation of 2 spaces.
 * Fail fast if dependencies cannot be installed.
 * Regroup HTML generation & its validation.
 * Document the main validation points.
 * Simplify some commands and address some ShellCheck warnings.
