### PR TITLE
Modify rule S3656: replace use of 'invariants' with 'invariance'

### DIFF
--- a/rules/S3656/cfamily/rule.adoc
+++ b/rules/S3656/cfamily/rule.adoc
@@ -1,9 +1,9 @@
 == Why is this an issue?
 
-Protected member variables are similar to global variables; any derived class can modify them. When protected member variables are used, invariants cannot be enforced. Also, protected member variables are hard to maintain since they can be manipulated through multiple classes in different files.
+Protected member variables are similar to global variables; any derived class can modify them. When protected member variables are used, invariance cannot be enforced. Also, protected member variables are hard to maintain since they can be manipulated through multiple classes in different files.
 
 
-If a class is just a data store without logic, it can safely contain only ``++public++`` member variables and no member functions. Otherwise, data members are tightly coupled to the class' logic, and encapsulation must be used. In this case, having only private member variables enforces invariants for data and ensures that logic is defined only in the member functions of the class. Structuring it this way makes It easier to guarantee integrity and easier for maintainers to understand the code.
+If a class is just a data store without logic, it can safely contain only ``++public++`` member variables and no member functions. Otherwise, data members are tightly coupled to the class' logic, and encapsulation must be used. In this case, having only private member variables enforces invariance for data and ensures that logic is defined only in the member functions of the class. Structuring it this way makes It easier to guarantee integrity and easier for maintainers to understand the code.
 
 
 But when an object provides encapsulation by using ``++protected++`` member variables, data integrity logic can be spread through the class and all its derived class, becoming a source of complexity and that will be error-prone for maintainers and extenders. 
@@ -71,7 +71,7 @@ public:
 
 === Exceptions
 
-Const member variables and reference member variables are ignored since they don't break invariants.
+Const member variables and reference member variables are ignored since they don't break invariance.
 
 
 == Resources


### PR DESCRIPTION
I think this is correct, but I'd appreciate a quick double check please.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

