### PR TITLE
Modify rule S2323: LaYC format

### DIFF
--- a/rules/S2323/cfamily/rule.adoc
+++ b/rules/S2323/cfamily/rule.adoc
@@ -1,26 +1,55 @@
 == Why is this an issue?
 
-Line-splicing occurs when the \ character is immediately followed by a new-line character. If the source line containing a ``++//++`` comment ends with a '\', the next line becomes part of the comment. This may result in unintentional removal of code.
+When a line of code ends with the `\` (backslash) character, the newline character is deleted.
+The compiler considers the next line a continuation of the current line, resulting in only one logical line of code.
 
+This source code transformation, known as _line-splicing_, occurs during the second phase of C and {cpp} translation.
 
-=== Noncompliant code example
+_Line-splicing_ does not apply inside {cpp}11 raw string literal.
+Furthermore, it is often harmless and used to improve the readability of macros:
+
+[source,c]
+----
+#define LOG_FAILURE(CONDITION, MESSAGE) \
+  do {                                  \
+    if (!(CONDITION)) {                 \
+      log(MESSAGE);                     \
+    }                                   \
+  } while (0)
+----
+
+However, the effect of _line-splicing_ in single-line comments (`//`) can be surprising, leading to unintentional code removal and possibly undefined behavior.
+
+In the following example, the `return` expression is considered part of the previous comment.
+The function has undefined behavior because it exits without returning a value.
 
 [source,cpp]
 ----
-void f ( void )
+bool isSpecialCharacter(char c)
 {
-  int x = 0; // comment \
-  if (x)
-  {
-    ++x; /* This is always executed */
-  }
+  // Noncompliant comment: it ends with a backslash.
+  // Character considered special: [ ] \
+  return 91 <= c && c <= 93;
 }
 ----
 
+Compilers may also delete whitespace characters between a backslash and the newline characters.
+This practice is standard-compliant since {cpp}23.
+In other words, trailing whitespace does not disable _line-splicing_.
 
 == Resources
 
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/translation_phases[Phases of translation]
+
+=== External coding guidelines
+
 * MISRA C:2012, 3.2 - Line-splicing shall not be used in // comments
+
+=== Related rules
+
+* S1916 is a companion rule and detects trailing whitespace after `\`.
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2323/cfamily/rule.adoc
+++ b/rules/S2323/cfamily/rule.adoc
@@ -5,8 +5,7 @@ The compiler considers the next line a continuation of the current line, resulti
 
 This source code transformation, known as _line-splicing_, occurs during the second phase of C and {cpp} translation.
 
-_Line-splicing_ does not apply inside {cpp}11 raw string literal.
-Furthermore, it is often harmless and used to improve the readability of macros:
+_Line-splicing_ is often harmless and is sometimes used to improve the readability of macros:
 
 [source,c]
 ----
@@ -18,6 +17,8 @@ Furthermore, it is often harmless and used to improve the readability of macros:
   } while (0)
 ----
 
+Furthermore, _line-splicing_ does not apply inside {cpp}11 raw string literal.
+
 However, the effect of _line-splicing_ in single-line comments (`//`) can be surprising, leading to unintentional code removal and possibly undefined behavior.
 
 In the following example, the `return` expression is considered part of the previous comment.
@@ -28,7 +29,7 @@ The function has undefined behavior because it exits without returning a value.
 bool isSpecialCharacter(char c)
 {
   // Noncompliant comment: it ends with a backslash.
-  // Character considered special: [ ] \
+  // Characters considered special: [ ] \
   return 91 <= c && c <= 93;
 }
 ----


### PR DESCRIPTION
I felt the "how to fix it" section was unnecessary given how trivial this is. Let me know if you disagree.

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

