### PR TITLE
Modify rule S1916: LaYC format

### DIFF
--- a/rules/S1916/cfamily/rule.adoc
+++ b/rules/S1916/cfamily/rule.adoc
@@ -1,19 +1,29 @@
 == Why is this an issue?
 
-The standard mentions that the line continuation character (``++\++``) should be immediately followed by a newline or be the very last character of the file in order for the lines to be joined.
+include::../../../shared_content/cfamily/line_splicing.adoc[]
 
+Several compilers have a looser implementation of _line-splicing_ and allow whitespace after the `\` character.
+While this practice was non-portable until {cpp}23, it remains non-portable in C.
+Furthermore, readers can easily be confused about the meaning of these whitespaces.
 
-Several compilers relax this requirement by allowing whitespace after the ``++\++`` character, but this is not portable because other compilers may not do the same.
-
-
-=== Compliant solution
+Therefore, for portability and clarity, `\` should be immediately followed by a newline character, as in the following example.
 
 [source,cpp]
 ----
-// There should be no whitespace after the '\'
+// Compliant: there are no whitespaces after the '\'
 #define FOO BAR \
             BAZ
 ----
+
+== Resources
+
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/translation_phases[Phases of translation]
+
+=== Related rules
+
+* S2323 - Line-splicing should not be used in "//" comments
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1916/cfamily/rule.adoc
+++ b/rules/S1916/cfamily/rule.adoc
@@ -2,7 +2,7 @@
 
 include::../../../shared_content/cfamily/line_splicing.adoc[]
 
-Several compilers have a looser implementation of _line-splicing_ and allow whitespace after the `\` character.
+Several compilers have a loose implementation of _line-splicing_ and allow whitespace after the `\` character.
 While this practice was non-portable until {cpp}23, it remains non-portable in C.
 Furthermore, readers can easily be confused about the meaning of these whitespaces.
 

--- a/rules/S1916/cfamily/rule.adoc
+++ b/rules/S1916/cfamily/rule.adoc
@@ -10,7 +10,7 @@ Therefore, for portability and clarity, `\` should be immediately followed by a 
 
 [source,cpp]
 ----
-// Compliant: there are no whitespaces after the '\'
+// Compliant: there is no whitespace after the '\'
 #define FOO BAR \
             BAZ
 ----

--- a/rules/S2323/cfamily/rule.adoc
+++ b/rules/S2323/cfamily/rule.adoc
@@ -1,9 +1,6 @@
 == Why is this an issue?
 
-When a line of code ends with the `\` (backslash) character, the newline character is deleted.
-The compiler considers the next line a continuation of the current line, resulting in only one logical line of code.
-
-This source code transformation, known as _line-splicing_, occurs during the second phase of C and {cpp} translation.
+include::../../../shared_content/cfamily/line_splicing.adoc[]
 
 _Line-splicing_ is often harmless and is sometimes used to improve the readability of macros:
 
@@ -36,7 +33,7 @@ bool isSpecialCharacter(char c)
 
 Compilers may also delete whitespace characters between a backslash and the newline characters.
 This practice is standard-compliant since {cpp}23.
-In other words, trailing whitespace does not disable _line-splicing_.
+In other words, trailing whitespaces do not disable _line-splicing_.
 
 == Resources
 

--- a/shared_content/cfamily/line_splicing.adoc
+++ b/shared_content/cfamily/line_splicing.adoc
@@ -1,0 +1,4 @@
+When a line of code ends with the `\` (backslash) character, the newline character is deleted.
+The compiler considers the next line a continuation of the current line, resulting in only one logical line of code.
+
+This source code transformation, known as _line-splicing_, occurs during the second phase of C and {cpp} translation.


### PR DESCRIPTION
Share content with S2323.

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

