### PR TITLE
Modify rule S5912: LaYC format

### DIFF
--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -10,7 +10,6 @@ The following example illustrates the unintended loss of information.
 struct PartData {
   int uuid;
   std::string manufacturer;
-  std::string description;
 };
 
 // Use inheritance to share common data definitions.

--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -31,11 +31,10 @@ void orderBike(TireData tire, ...) {
 
 == How to fix it
 
-This code defect is usually the consequence of not using polymorphism correctly.
-
-Instead of working with values and incomplete copies, polymorphism is achieved by casting a reference or a pointer to an object of the derived class to a reference or a pointer to an object of a base class.
+This code defect usually results from using values instead of references or pointers to pass polymorphic objects to functions.
 
 It is usually a good idea to design a base class so that slicing cannot happen: it can be abstract or non-copiable.
+The standard library follows this practice and prevents copying, for example, `std::ostream` objects.
 
 === Code examples
 
@@ -84,7 +83,6 @@ void application(int userId) {
 
 To prevent slicing from happening, the base class can be made non-copyable.
 This implies passing a reference instead of a copy to `writeAll`.
-The same strategy is applied for `std::ostream` and co.
 
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
@@ -123,6 +121,11 @@ void application(int userId) {
 }
 ----
 
+=== Going the extra mile
+
+When slicing is actually required, it is best to make it explicit to avoid the element of surprise.
+You can create a dedicated member function for this purpose, with its own documentation.
+This goes well in hand with non-copyable classes.
 
 == Resources
 

--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -130,5 +130,6 @@ This goes well in hand with non-copyable classes.
 
 === External coding guidelines
 
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/efbc482f0d10555c6a8827906af71430a3023bd2/CppCoreGuidelines.md#es63-dont-slice[ES.63 Don't slice]
+* {cpp} Core Guidelines - 
+https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#es63-dont-slice[ES.63 Don't slice]
 

--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -39,7 +39,9 @@ Instead of working with values and incomplete copies, polymorphism is achieved b
 
 It is usually a good idea to design a base class so that slicing cannot happen: it can be abstract or non-copiable.
 
-=== Noncompliant code example
+=== Code examples
+
+==== Noncompliant code example
 
 This example illustrates the problem with a `FileStream` concrete class and a derived buffered implementation, `BufferedFileStream`.
 
@@ -79,7 +81,7 @@ void application(int userId) {
 }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
 In the noncompliant example above, the `stream` gets sliced when calling `writeAll`, and its `buffer` may be lost or written out-of-sequence.
 

--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -19,15 +19,13 @@ struct TireData : PartData {
   TireType type;
 };
 
-std::vector<PartData> orderBike(TireData tire, ...) {
+void orderBike(TireData tire, ...) {
   std::vector<PartData> parts;
 
   // Noncompliant: the vector does not store the tire color and type.
   parts.push_back(tire);
 
   // ...
-
-  return parts;
 }
 ----
 
@@ -77,15 +75,14 @@ void application(int userId) {
 
   std::vector<int> data = getData();
 
-  writeAll(stream, data); // Noncompliant: stream is sliced.
+  writeAll(stream, data); // Noncompliant: stream is sliced, and its buffer may be lost or written out-of-sequence
 }
 ----
 
 ==== Compliant solution
 
-In the noncompliant example above, the `stream` gets sliced when calling `writeAll`, and its `buffer` may be lost or written out-of-sequence.
 
-To prevent this from happening, the base class can be made non-copyable.
+To prevent slicing from happening, the base class can be made non-copyable.
 This implies passing a reference instead of a copy to `writeAll`.
 The same strategy is applied for `std::ostream` and co.
 

--- a/rules/S5912/cfamily/rule.adoc
+++ b/rules/S5912/cfamily/rule.adoc
@@ -1,44 +1,133 @@
 == Why is this an issue?
 
-Slicing is what happens when an object from a derived type is cast to an object of one of its base classes. When this happens, the newly created object will not have any of the member variables that are specific to the derived type. This is usually not what was intended. Most of the time, polymorphism is achieved by casting a reference or a pointer to an object of the derived class to a reference or a pointer to an object of a base class.
+Slicing happens when an object from a derived type is cast to an object of one of its base classes.
+When this happens, the new object will not have the data member variables specific to the derived type.
 
-
-Note that it's usually a good idea to design a base class so that slicing cannot happen (it can be _abstract_, or _non-copiable_).
-
-
-=== Noncompliant code example
+The following example illustrates the unintended loss of information.
 
 [source,cpp]
 ----
-struct Shape {
-  Point position;
-  virtual ~Shape() = default;
-};
-struct Circle : public Shape {
-  double radius;
+struct PartData {
+  int uuid;
+  std::string manufacturer;
+  std::string description;
 };
 
-void f() {
-  vector<Shape> myShapes;
-  Circle c;
-  myShapes.push_back(c); // Noncompliant. What will be in the vector is a Shape, not a Circle, and won't contain any radius
+// Use inheritance to share common data definitions.
+struct TireData : PartData {
+  Color color;
+  TireType type;
+};
+
+std::vector<PartData> orderBike(TireData tire, ...) {
+  std::vector<PartData> parts;
+
+  // Noncompliant: the vector does not store the tire color and type.
+  parts.push_back(tire);
+
+  // ...
+
+  return parts;
 }
 ----
 
+== How to fix it
+
+This code defect is usually the consequence of not using polymorphism correctly.
+
+Instead of working with values and incomplete copies, polymorphism is achieved by casting a reference or a pointer to an object of the derived class to a reference or a pointer to an object of a base class.
+
+It is usually a good idea to design a base class so that slicing cannot happen: it can be abstract or non-copiable.
+
+=== Noncompliant code example
+
+This example illustrates the problem with a `FileStream` concrete class and a derived buffered implementation, `BufferedFileStream`.
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+class FileStream {
+  // ...
+
+public:
+  FileStream(std::string_view file_path);
+  virtual ~Stream() = default;
+  virtual void write(int x);
+};
+
+class BufferedFileStream : public FileStream {
+  std::array<char, 1024> buffer;
+  // ...
+
+public:
+  BufferedFileStream(std::string_view file_path);
+  ~BufferedFileStream() { flushBuffer(); }
+  void write(int x) {
+    // Write to the buffer; flush if it is full.
+    // ...
+  }
+};
+
+void writeAll(FileStream stream, std::vector<int> const& ints);
+
+void application(int userId) {
+  BufferedFileStream stream;
+  stream.write(userId);
+
+  std::vector<int> data = getData();
+
+  writeAll(stream, data); // Noncompliant: stream is sliced.
+}
+----
 
 === Compliant solution
 
-[source,cpp]
+In the noncompliant example above, the `stream` gets sliced when calling `writeAll`, and its `buffer` may be lost or written out-of-sequence.
+
+To prevent this from happening, the base class can be made non-copyable.
+This implies passing a reference instead of a copy to `writeAll`.
+The same strategy is applied for `std::ostream` and co.
+
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
-void f() {
-  vector<unique_ptr<Shape>> myShapes;
-  auto c = make_unique<Circle>();
-  myShapes.push_back(move(c)); // Compliant. A pointer to Shape that happens to point to a Circle
+class FileStream {
+  // ...
+
+public:
+  FileStream(std::string_view file_path);
+  FileStream(FileStream const&) = delete;
+  virtual ~Stream() = default;
+  virtual void write(int x);
+};
+
+class BufferedFileStream : public FileStream {
+  std::array<char, 1024> buffer;
+  // ...
+
+public:
+  BufferedFileStream(std::string_view file_path);
+  ~BufferedFileStream() { flushBuffer(); }
+  void write(int x) {
+    // Write to the buffer; flush if it is full.
+    // ...
+  }
+};
+
+void writeAll(FileStream& stream, std::vector<int> const& ints);
+
+void application(int userId) {
+  BufferedFileStream stream;
+  stream.write(userId);
+
+  std::vector<int> data = getData();
+
+  writeAll(stream, data); // Compliant, no slicing, no dataloss.
 }
 ----
 
 
 == Resources
 
-* https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es63-dont-slice[{cpp} Core Guidelines ES.63] - Don’t slice
+=== External coding guidelines
+
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/efbc482f0d10555c6a8827906af71430a3023bd2/CppCoreGuidelines.md#es63-dont-slice[ES.63 Don't slice]
 


### PR DESCRIPTION
Given the nature of the bug is easy to understand, I didn't feel it was worth explicitly mentioning this is makes the application unreliable. Let me know if you disagree.

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

