### PR TITLE
Modify rule S3871: fix orthography

### DIFF
--- a/rules/S3871/why-dotnet.adoc
+++ b/rules/S3871/why-dotnet.adoc
@@ -4,7 +4,7 @@ The point of having custom exception types is to convey more information than is
 
 If a method throws a non-public exception, the best you can do on the caller's side is to `catch` the closest `public` base of the class. However, you lose all the information that the new exception type carries.
 
-This rule will raise an issue if you directly inherit one of the following excpetion types in a non public class:
+This rule will raise an issue if you directly inherit one of the following exception types in a non-public class:
 
 * https://learn.microsoft.com/en-us/dotnet/api/system.exception[Exception]
 * https://learn.microsoft.com/en-us/dotnet/api/system.systemexception[SystemException]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

