### PR TITLE
Modify rule S2737: Add links to documentation

### DIFF
--- a/rules/S2737/javascript/rule.adoc
+++ b/rules/S2737/javascript/rule.adoc
@@ -6,6 +6,12 @@
 
 include::../description.adoc[]
 
+== Resources
+=== Documentation
+
+* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[MDN - ``++try...catch++``]
+* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - ``++throw++``]
+
 ifdef::env-github,rspecator-view[]
 
 '''


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

