### PR TITLE
Modify rule S3799: Use let instead of var in noncompliant snippet

### DIFF
--- a/rules/S3799/javascript/rule.adoc
+++ b/rules/S3799/javascript/rule.adoc
@@ -5,7 +5,7 @@ Destructuring is a convenient way of extracting multiple values from data stored
 
 [source,javascript,diff-id=1,diff-type=noncompliant]
 ----
-var {a: {}} = myObj; // Noncompliant: this does not create any variable
+let {a: {}} = myObj; // Noncompliant: this does not create any variable
 function foo({p: []}) { // Noncompliant: this does not define any parameter
   // ...
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

