### PR TITLE
Modify rule S108: Fix exceptions section and replace 'var' with 'let'

### DIFF
--- a/rules/S108/javascript/code-example.adoc
+++ b/rules/S108/javascript/code-example.adoc
@@ -1,4 +1,4 @@
 [source,javascript]
 ----
-for (var i = 0; i < length; i++) {}  // Noncompliant: is the block empty on purpose, or is code missing?
+for (let i = 0; i < length; i++) {}  // Noncompliant: is the block empty on purpose, or is code missing?
 ----

--- a/rules/S108/javascript/rule.adoc
+++ b/rules/S108/javascript/rule.adoc
@@ -5,6 +5,7 @@ include::../description.adoc[]
 === Exceptions
 
 The rule ignores:
+
 * code blocks that contain comments
 * `catch` blocks
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

