### PR TITLE
Modify rule S6676: Quote methods' names in rule title

### DIFF
--- a/rules/S6676/javascript/metadata.json
+++ b/rules/S6676/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Calls to .call() and .apply() methods should not be redundant",
+  "title": "Calls to \".call()\" and \".apply()\" methods should not be redundant",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

