### PR TITLE
Modify rule S6645: Fix noncompliant comments and links' titles

### DIFF
--- a/rules/S6645/javascript/rule.adoc
+++ b/rules/S6645/javascript/rule.adoc
@@ -4,8 +4,8 @@ Initializing a variable to `undefined` is unnecessary and should be avoided. A v
 
 [source,javascript]
 ----
-var foo = undefined; // Non-compliant, replace with var foo;
-let bar = undefined; // Non-compliant, replace with let foo;
+var foo = undefined; // Noncompliant: replace with var foo;
+let bar = undefined; // Noncompliant: replace with let foo;
 ----
 
 
@@ -13,7 +13,7 @@ let bar = undefined; // Non-compliant, replace with let foo;
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[MDN - undefined]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - let]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - var]
+* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[MDN - ``++undefined++``]
+* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - ``++let++``]
+* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - ``++var++``]
 * https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[MDN - hoisting]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

