### PR TITLE
Modify rule S6647: Add diff-tag and fix noncompliant comment

### DIFF
--- a/rules/S6647/javascript/rule.adoc
+++ b/rules/S6647/javascript/rule.adoc
@@ -2,14 +2,14 @@
 
 If the class declaration does not include a constructor, one is automatically created, so there is no need to provide an empty constructor, or one that just delegates to the parent class.
 
-[source,javascript]
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 class Foo {
     constructor() {}  // Noncompliant, empty
 }
 
 class Bar extends Foo {
-    constructor(params) { // Noncompliant, just delegates to the parent
+    constructor(params) { // Noncompliant: just delegates to the parent
         super(params);
     } 
 }
@@ -17,7 +17,7 @@ class Bar extends Foo {
 
 Instead, you can safely remove the empty constructor without affecting the functionality.
 
-[source,javascript]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 class Foo {}
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

