### PR TITLE
Modify rule S6666: Quote method's name in rule title

### DIFF
--- a/rules/S6666/javascript/metadata.json
+++ b/rules/S6666/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Spread syntax should be used instead of apply()",
+  "title": "Spread syntax should be used instead of \"apply()\"",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

