### PR TITLE
Add VS code schema support for manifest.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,13 @@
             "language": "asciidoc",
             "scheme": "file"
         }
+    ],
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/rules/**/metadata.json"
+            ],
+            "url": "./rspec-tools/rspec_tools/validation/rule-metadata-schema.json"
+        }
     ]
 }


### PR DESCRIPTION
Adds json schema support for VS Code (especially [IntelliSense and validation](https://code.visualstudio.com/docs/languages/json#_intellisense-and-validation)):

![image](https://github.com/SonarSource/rspec/assets/103252490/45145852-08d2-4bf3-af82-7f176afb29c6)
