### PR TITLE
Modify rule S2734: Python: Don't replace with S935

### DIFF
--- a/rules/S2734/python/metadata.json
+++ b/rules/S2734/python/metadata.json
@@ -9,14 +9,6 @@
   "tags": [
 
   ],
-  "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
-  },
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-2734",
   "sqKey": "S2734",

--- a/rules/S2734/python/metadata.json
+++ b/rules/S2734/python/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "\"__init__\" should not return a value",
   "type": "BUG",
-  "status": "superseded",
+  "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"
@@ -11,7 +11,7 @@
   ],
   "extra": {
     "replacementRules": [
-      "RSPEC-935"
+
     ],
     "legacyKeys": [
 


### PR DESCRIPTION
S935 has been merged with S6658.
As part of that merge, S935 has been restricted to a specific set of special functions for now, not including `__init__`.

Hence, we keep S2734 at the moment, until S935 is extended to cover more functions.

See also
* https://github.com/SonarSource/sonar-python/pull/1529#discussion_r1282759218
* https://github.com/SonarSource/sonar-python/pull/1528
* https://sonarsource.slack.com/archives/CFUS31LRE/p1690534750237959

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

