### PR TITLE
Modify rule S5485: Expand and adjust for LaYC

### DIFF
--- a/rules/S5485/cfamily/metadata.json
+++ b/rules/S5485/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Appropriate arguments should be passed to stream functions",
+  "title": "Only valid arguments should be passed to stream functions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S5485/cfamily/metadata.json
+++ b/rules/S5485/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Appropriate arguments should be passed to stream functions",
+  "title": "Sufficiently restricted arguments should be passed to stream functions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
@@ -22,9 +22,17 @@
   "ruleSpecification": "RSPEC-5485",
   "sqKey": "S5485",
   "scope": "All",
+  "securityStandards": {
+    "CWE": [
+      476
+    ],
+    "CERT": [
+      "EXP01-J."
+    ]
+  },
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"
   ],
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }

--- a/rules/S5485/cfamily/metadata.json
+++ b/rules/S5485/cfamily/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Sufficiently restricted arguments should be passed to stream functions",
+  "title": "Appropriate arguments should be passed to stream functions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S5485/cfamily/rule.adoc
+++ b/rules/S5485/cfamily/rule.adoc
@@ -1,16 +1,18 @@
-Passing inappropriate arguments to standard C library functions for handling I/O streams results in undefined behavior.
+Passing insufficiently restricted arguments to standard C library functions for handling I/O streams results in undefined behavior.
 
 == Why is this an issue?
 
 The standard C library includes a number of functions for handling I/O streams.
-These functions require appropriate parameters.
-For instance, passing ``++NULL++`` for the ``++FILE*++`` parameter to ``++fseek++``, ``++ftell++``, ``++rewind++``, etc. will result in undefined behavior.
+These functions put certain restrictions on the values of their parameters, which are listed in the following:
 
-Furthermore, failing to pass either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++`` as a third parameter to ``++fseek++`` will also result in undefined behavior.
+* The value for the ``++FILE*++``-typed parameter may _not_ be ``++NULL++``
+* The third argument of ``++fseek++`` must be either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
+
+Failing to pass correctly restricted parameters will result in undefined behavior.
 
 Consider the following code.
 The call to ``++fopen++`` may fail and return ``++NULL++`` to indicate the failure.
-Passing the returned value to ``++fseek++`` without checking its value and handling an error appropriately, results in undefined behavior if the file cannot be opened correctly.
+Passing the returned value to ``++fseek++`` and ``++ftell++`` without checking its value and handling an error appropriately, results in undefined behavior if the file cannot be opened correctly.
 There are a multitude of reasons while opening a file might fail.
 
 [source,cpp]
@@ -20,7 +22,7 @@ There are a multitude of reasons while opening a file might fail.
 size_t get_file_size() {
   FILE *f = fopen("example_file.txt", "r");
   fseek(f, 0L, SEEK_END); // Leads to undefined behavior, if `f` is NULL.
-  size_t size = ftell(f);
+  size_t size = ftell(f); // Leads to undefined behavior, if `f` is NULL.
   fclose(f);
   return size;
 }
@@ -29,12 +31,14 @@ size_t get_file_size() {
 
 == What is the potential impact?
 
-Using the standard C library's functions for handling I/O streams with inappropriate arguments leads to *undefined behavior*.
+Using the standard C library's functions for handling I/O streams with insufficiently restricted arguments leads to *undefined behavior*.
 
-For programs that comprise undefined behavior, the compiler is no longer bound to the language specification.
-The application may crash or, even worse, the application appears to execute correctly while losing data or producing incorrect results, for instance.
+When a program comprises undefined behavior, the compiler no longer needs to adhere to the language standard, and the program has no meaning assigned to it.
 
-Besides the aforementioned availability issues of the application, any attempts to dereference a ``++NULL++`` pointer made by the C library functions can, in rare circumstances, also results in security issues.
+Due to the resulting NULL pointer dereferences in the C library functions, the application might just crash, but in the worst case, the application may appear to execute correctly, while losing data or producing incorrect results.
+
+Besides affecting the application's availability, NULL pointer dereferences may lead to code execution, in rare circumstances.
+If NULL is equivalent to the 0x0 memory address that can be accessed by privileged code, writing and reading memory is possible, which compromises the integrity and confidentiality of the application.
 
 
 == Hot to fix it
@@ -130,12 +134,9 @@ int process_tmp_file() {
 
 == Resources
 
-=== Documentation
+=== Standards
 
-* MITRE - https://cwe.mitre.org/data/definitions/476[CWE-476 NULL Pointer Dereference]
-
-=== External coding guidelines
-
+* CWE - https://cwe.mitre.org/data/definitions/476[476 NULL Pointer Dereference]
 * CERT - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[EXP01-J. Do not use a null in a case where an object is required]
 
 === Related rules

--- a/rules/S5485/cfamily/rule.adoc
+++ b/rules/S5485/cfamily/rule.adoc
@@ -1,15 +1,15 @@
-Passing inappropriate arguments to standard C library functions for handling I/O streams results in undefined behavior.
+Passing invalid arguments to standard C library functions for handling I/O streams results in undefined behavior.
 
 == Why is this an issue?
 
 The standard C library includes a number of functions for handling I/O streams.
-These functions put certain restrictions on the values of their parameters.
-The restrictions include the following:
+These functions put certain constraints on the values of their parameters.
+The constraints include the following:
 
 * The value for the ``++FILE*++``-typed parameter may _not_ be ``++NULL++``
 * The third argument of ``++fseek++`` must be either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
 
-Failing to pass correctly restricted parameters will result in undefined behavior.
+Failing to pass correctly constrained parameters renders them invalid and will result in undefined behavior.
 
 [source,cpp]
 ----
@@ -28,7 +28,7 @@ size_t get_file_size() {
 
 == What is the potential impact?
 
-Using the standard C library's functions for handling I/O streams with insufficiently restricted arguments leads to *undefined behavior*.
+Using the standard C library's functions for handling I/O streams with invalid arguments leads to *undefined behavior*.
 
 When a program comprises undefined behavior, the compiler no longer needs to adhere to the language standard, and the program has no meaning assigned to it.
 

--- a/rules/S5485/cfamily/rule.adoc
+++ b/rules/S5485/cfamily/rule.adoc
@@ -3,13 +3,10 @@ Passing inappropriate arguments to standard C library functions for handling I/O
 == Why is this an issue?
 
 The standard C library includes a number of functions for handling I/O streams.
-If not called correctly, these functions can introduce undefined behavior.
-More specifically:
+These functions require appropriate parameters.
+For instance, passing ``++NULL++`` for the ``++FILE*++`` parameter to ``++fseek++``, ``++ftell++``, ``++rewind++``, etc. will result in undefined behavior.
 
-* ``++FILE*++`` should be checked for ``++NULL++`` before being used in a function that accesses the file's contents
-* The third argument of ``++fseek++`` must be either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
-
-Failing to provide these parameters correctly introduces undefined behavior to the application.
+Furthermore, failing to pass either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++`` as a third parameter to ``++fseek++`` will also result in undefined behavior.
 
 Consider the following code.
 The call to ``++fopen++`` may fail and return ``++NULL++`` to indicate the failure.
@@ -42,7 +39,7 @@ Besides the aforementioned availability issues of the application, any attempts 
 
 == Hot to fix it
 
-Ensure that the pointer parameters passed to the standard C library's I/O stream handling functions are non-``++NULL++`` and also any other parameters such as the third argument of ``++fseek++`` carry appropriate values.
+Ensure that the ``++FILE*++``-typed pointer parameters passed to the standard C library's I/O stream handling functions are non-``++NULL++`` and also any other parameters such as the third argument of ``++fseek++`` carry appropriate values, namely any of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``.
 
 
 === Code examples

--- a/rules/S5485/cfamily/rule.adoc
+++ b/rules/S5485/cfamily/rule.adoc
@@ -1,45 +1,150 @@
+Passing inappropriate arguments to standard C library functions for handling I/O streams results in undefined behavior.
+
 == Why is this an issue?
 
-The standard C library includes a number of functions for handling streams. If not called correctly, these functions can have undefined behavior. More specifically:
+The standard C library includes a number of functions for handling I/O streams.
+If not called correctly, these functions can introduce undefined behavior.
+More specifically:
 
-* ``++FILE*++`` should be checked for null before being used in a function that accesses the file content
-* The third argument of ``++fseek++`` must be ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
+* ``++FILE*++`` should be checked for ``++NULL++`` before being used in a function that accesses the file's contents
+* The third argument of ``++fseek++`` must be either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
 
+Failing to provide these parameters correctly introduces undefined behavior to the application.
 
-=== Noncompliant code example
-
-[source,cpp]
-----
-FILE *file1 = fopen("myFile", "r");
-fseek(file1, 1, SEEK_SET); // Noncompliant, file could be NULL
-fclose(file1);
-
-FILE *file2 = tmpfile();
-ftell(file2); // Noncompliant, file could be NULL
-if (file2) {
-  fseek(file2, 1, 3); // Noncompliant, third argument should either be SEEK_SET, SEEK_CUR or SEEK_END
-}
-fclose(file2);
-----
-
-
-=== Compliant solution
+Consider the following code.
+The call to ``++fopen++`` may fail and return ``++NULL++`` to indicate the failure.
+Passing the returned value to ``++fseek++`` without checking its value and handling an error appropriately, results in undefined behavior if the file cannot be opened correctly.
+There are a multitude of reasons while opening a file might fail.
 
 [source,cpp]
 ----
-FILE *file1 = fopen("myFile", "r");
-if (file1) {
-  fseek(file1, 1, SEEK_SET);
-  fclose(file1);
-}
+#include <stdio.h>
 
-FILE *file2 = tmpfile();
-if (file2) {
-  ftell(file2);
-  fseek(file2, 1, SEEK_END);
-  fclose(file2);
+size_t get_file_size() {
+  FILE *f = fopen("example_file.txt", "r");
+  fseek(f, 0L, SEEK_END); // Leads to undefined behavior, if `f` is NULL.
+  size_t size = ftell(f);
+  fclose(f);
+  return size;
 }
 ----
+
+
+== What is the potential impact?
+
+Using the standard C library's functions for handling I/O streams with inappropriate arguments leads to *undefined behavior*.
+
+For programs that comprise undefined behavior, the compiler is no longer bound to the language specification.
+The application may crash or, even worse, the application appears to execute correctly while losing data or producing incorrect results, for instance.
+
+Besides the aforementioned availability issues of the application, any attempts to dereference a ``++NULL++`` pointer made by the C library functions can, in rare circumstances, also results in security issues.
+
+
+== Hot to fix it
+
+Ensure that the pointer parameters passed to the standard C library's I/O stream handling functions are non-``++NULL++`` and also any other parameters such as the third argument of ``++fseek++`` carry appropriate values.
+
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+#include <stdio.h>
+#include <stdlib.h>
+
+int process_file(const char *fname) {
+  FILE *f = fopen(fname, "r");
+  fseek(f, 0L, SEEK_END);
+  size_t size = ftell(f);
+  rewind(f);
+  char *buf = (char *)malloc(size);
+  // Read file into buffer ...
+  fclose(f);
+  // Process buffer ...
+  free(buf);
+  return 0;
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+#include <stdio.h>
+#include <stdlib.h>
+
+int process_file(const char *fname) {
+  FILE *f = fopen(fname, "r");
+  if (!f) {
+    printf("Could not open file!\n");
+    return 1;
+  }
+  fseek(f, 0L, SEEK_END);
+  size_t size = ftell(f);
+  rewind(f);
+  char *buf = (char *)malloc(size);
+  // Read file into buffer ...
+  fclose(f);
+  // Process buffer ...
+  free(buf);
+  return 0;
+}
+----
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
+#include <stdio.h>
+#include <stdlib.h>
+
+void process_tmp_file() {
+  FILE *f = tmpfile();
+  size_t pos_indicator = ftell(f); // Noncompliant: `f` could be NULL.
+  fseek(f, 0L, 3); // Noncompliant: 3rd argument should either be SEEK_SET, SEEK_CUR or SEEK_END.
+  // Further file processing ...
+  fclose(f);
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+#include <stdio.h>
+#include <stdlib.h>
+
+int process_tmp_file() {
+  FILE *f = tmpfile();
+  if (!f) {
+    printf("Could not create temporary file!\n");
+    return 1;
+  }
+  size_t pos_indicator = ftell(f); // Compliant: `f` cannot be NULL here.
+  fseek(f, 0L, SEEK_END); // Compliant: 3rd argument is now a valid value.
+  // Further file processing ...
+  fclose(f);
+  return 0;
+}
+----
+
+
+== Resources
+
+=== Documentation
+
+* MITRE - https://cwe.mitre.org/data/definitions/476[CWE-476 NULL Pointer Dereference]
+
+=== External coding guidelines
+
+* CERT - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[EXP01-J. Do not use a null in a case where an object is required]
+
+=== Related rules
+
+* S3807 ensures that appropriate arguments are passed to C standard library functions
+* S5488 ensures that appropriate arguments are passed to UNIX/POSIX functions
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5485/cfamily/rule.adoc
+++ b/rules/S5485/cfamily/rule.adoc
@@ -1,19 +1,15 @@
-Passing insufficiently restricted arguments to standard C library functions for handling I/O streams results in undefined behavior.
+Passing inappropriate arguments to standard C library functions for handling I/O streams results in undefined behavior.
 
 == Why is this an issue?
 
 The standard C library includes a number of functions for handling I/O streams.
-These functions put certain restrictions on the values of their parameters, which are listed in the following:
+These functions put certain restrictions on the values of their parameters.
+The restrictions include the following:
 
 * The value for the ``++FILE*++``-typed parameter may _not_ be ``++NULL++``
 * The third argument of ``++fseek++`` must be either of ``++SEEK_SET++``, ``++SEEK_END++``, or ``++SEEK_CUR++``
 
 Failing to pass correctly restricted parameters will result in undefined behavior.
-
-Consider the following code.
-The call to ``++fopen++`` may fail and return ``++NULL++`` to indicate the failure.
-Passing the returned value to ``++fseek++`` and ``++ftell++`` without checking its value and handling an error appropriately, results in undefined behavior if the file cannot be opened correctly.
-There are a multitude of reasons while opening a file might fail.
 
 [source,cpp]
 ----
@@ -21,6 +17,7 @@ There are a multitude of reasons while opening a file might fail.
 
 size_t get_file_size() {
   FILE *f = fopen("example_file.txt", "r");
+  // `f` may be NULL if `fopen` fails.
   fseek(f, 0L, SEEK_END); // Leads to undefined behavior, if `f` is NULL.
   size_t size = ftell(f); // Leads to undefined behavior, if `f` is NULL.
   fclose(f);


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

