### PR TITLE
Modify rule S2638: LaYC format

### DIFF
--- a/rules/S2638/java/rule.adoc
+++ b/rules/S2638/java/rule.adoc
@@ -1,4 +1,4 @@
-This rule raises an issue when a overriding method changing a contract defined in the superclass.
+This rule raises an issue when an overriding method changes a contract defined in a superclass.
 
 == Why is this an issue?
 

--- a/rules/S2638/java/rule.adoc
+++ b/rules/S2638/java/rule.adoc
@@ -1,11 +1,14 @@
+This rule raises an issue when a overriding method changing a contract defined in the superclass.
+
 == Why is this an issue?
 
 Because a subclass instance may be cast to and treated as an instance of the superclass, overriding methods should uphold the aspects of the superclass contract that relate to the Liskov Substitution Principle. Specifically, if the parameters or return type of the superclass method are marked with any of the following: ``++@Nullable++``, ``++@CheckForNull++``, ``++@NotNull++``, ``++@NonNull++``, and ``++@Nonnull++``, then subclass parameters are not allowed to tighten the contract, and return values are not allowed to loosen it.
 
+=== Code examples
 
-=== Noncompliant code example
+==== Noncompliant code example
 
-[source,java]
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 public class Fruit {
 
@@ -23,21 +26,51 @@ public class Fruit {
 
 public class Raspberry extends Fruit {
 
-  public void setRipe(@NotNull Season ripe) {  // Noncompliant
+  public void setRipe(@NotNull Season ripe) {  // Noncompliant: the ripe argument annotated as @Nullable in parent class
     this.ripe = ripe;
   }
 
-  public @Nullable Integer getProtein() {  // Noncompliant
+  public @Nullable Integer getProtein() {  // Noncompliant: the return type annotated as @NotNull in parent class
     return null;
   }
 }
 ----
 
+==== Compliant solution
+
+[source,java,diff-id=1,diff-type=compliant]
+----
+public class Fruit {
+
+  private Season ripe;
+  private String color;
+
+  public void setRipe(@Nullable Season ripe) {
+    this.ripe = ripe;
+  }
+
+  public @NotNull Integer getProtein() {
+    return 12;
+  }
+}
+
+public class Raspberry extends Fruit {
+
+  public void setRipe(@Nullable Season ripe) {
+    this.ripe = ripe;
+  }
+
+  public @NotNull Integer getProtein() {
+    return 12;
+  }
+}
+----
 
 == Resources
 
-* https://en.wikipedia.org/wiki/Liskov_substitution_principle[Wikipedia - Liskov substitution principle]
+=== Documentation
 
+* SOLID - https://en.wikipedia.org/wiki/Liskov_substitution_principle[Wikipedia - Liskov substitution principle]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2638/python/rule.adoc
+++ b/rules/S2638/python/rule.adoc
@@ -2,10 +2,10 @@ This rule raises an issue when an overriding method changes a contract defined i
 
 == Why is this an issue?
 
-Because a subclass instance may be used as an instance of the superclass, overriding methods should uphold the aspects of the superclass contract that relate to the Liskov Substitution Principle. Specifically, an overriding method should be callable with the same parameters as the overriden one.
+Because a subclass instance may be used as an instance of the superclass, overriding methods should uphold the aspects of the superclass contract that relate to the https://en.wikipedia.org/wiki/Liskov_substitution_principle[Liskov Substitution Principle]. Specifically, an overriding method should be callable with the same parameters as the overriden one.
 
 
-The following modifications are ok:
+The following modifications are OK:
 
 * Adding an optional parameter, i.e. with a default value, as long as they don't change the order of positional parameters.
 * Renaming a positional-only parameter.
@@ -16,7 +16,7 @@ The following modifications are ok:
 * Adding a vararg parameter (``++*args++``).
 * Adding a keywords parameter (``++**kwargs++``).
 
-The following modifications are not ok:
+The following modifications are not OK:
 
 * Removing parameters, even when they have default values.
 * Adding mandatory parameters, i.e. without a default value.

--- a/rules/S2638/python/rule.adoc
+++ b/rules/S2638/python/rule.adoc
@@ -1,4 +1,4 @@
-This rule raises an issue when a overriding method changing a contract defined in the superclass.
+This rule raises an issue when an overriding method changes a contract defined in a superclass.
 
 == Why is this an issue?
 
@@ -30,9 +30,9 @@ This rule raises an issue when the signature of an overriding method does not ac
 
 === Exceptions
 
-In theory renaming parameters also breaks Liskov Substitution Principle. Arguments can't be passed via keyword arguments anymore. However, https://www.python.org/dev/peps/pep-0570/#consistency-in-subclasses[as PEP-570 says], it is common to rename parameters when it improves code readability and when arguments are always passed by position.
+In theory, renaming parameters also breaks Liskov Substitution Principle. Arguments can't be passed via keyword arguments anymore. However, https://www.python.org/dev/peps/pep-0570/#consistency-in-subclasses[PEP-570] indicates it is common to rename parameters when it improves code readability and when arguments are always passed by position.
 
-"Positional-Only Parameters" were introduced in python 3.8 to solve this problem. As most programs will need to support older versions of python, this rule won't raise an issue on renamed parameters.
+"Positional-Only Parameters" were introduced in Python 3.8 to solve this problem. As most programs will need to support older versions of Python, this rule won't raise an issue on renamed parameters.
 
 [source,python]
 ----

--- a/rules/S2638/python/rule.adoc
+++ b/rules/S2638/python/rule.adoc
@@ -1,3 +1,5 @@
+This rule raises an issue when a overriding method changing a contract defined in the superclass.
+
 == Why is this an issue?
 
 Because a subclass instance may be used as an instance of the superclass, overriding methods should uphold the aspects of the superclass contract that relate to the Liskov Substitution Principle. Specifically, an overriding method should be callable with the same parameters as the overriden one.
@@ -26,9 +28,28 @@ The following modifications are not ok:
 
 This rule raises an issue when the signature of an overriding method does not accept the same parameters as the overriden one. Only instance methods are considered, class methods and static methods are ignored.
 
-=== Noncompliant code example
+=== Exceptions
+
+In theory renaming parameters also breaks Liskov Substitution Principle. Arguments can't be passed via keyword arguments anymore. However, https://www.python.org/dev/peps/pep-0570/#consistency-in-subclasses[as PEP-570 says], it is common to rename parameters when it improves code readability and when arguments are always passed by position.
+
+"Positional-Only Parameters" were introduced in python 3.8 to solve this problem. As most programs will need to support older versions of python, this rule won't raise an issue on renamed parameters.
 
 [source,python]
+----
+class ParentClass(object):
+    def mymethod(self, param1):
+        pass
+
+class ChildClassRenamed(ParentClass):
+    def mymethod(self, renamed): # No issue but this is suspicious. Rename this parameter as "param1" or use positional only arguments if possible.
+        pass
+----
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,python,diff-id=1,diff-type=noncompliant]
 ----
 class ParentClass(object):
     def mymethod(self, param1):
@@ -50,9 +71,9 @@ class ChildClassReordered(ParentClass):
         pass
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,python]
+[source,python,diff-id=1,diff-type=compliant]
 ----
 class ParentClass(object):
     def mymethod(self, param1):
@@ -71,26 +92,11 @@ class ChildClassReordered(ParentClass):
         pass
 ----
 
-=== Exceptions
-
-In theory renaming parameters also breaks Liskov Substitution Principle. Arguments can't be passed via keyword arguments anymore. However, https://www.python.org/dev/peps/pep-0570/#consistency-in-subclasses[as PEP-570 says], it is common to rename parameters when it improves code readability and when arguments are always passed by position.
-
-"Positional-Only Parameters" were introduced in python 3.8 to solve this problem. As most programs will need to support older versions of python, this rule won't raise an issue on renamed parameters.
-
-[source,python]
-----
-class ParentClass(object):
-    def mymethod(self, param1):
-        pass
-
-class ChildClassRenamed(ParentClass):
-    def mymethod(self, renamed): # No issue but this is suspicious. Rename this parameter as "param1" or use positional only arguments if possible.
-        pass
-----
-
 == Resources
 
-* https://en.wikipedia.org/wiki/Liskov_substitution_principle[Wikipedia - Liskov substitution principle]
+=== Documentation
+
+* SOLID - https://en.wikipedia.org/wiki/Liskov_substitution_principle[Wikipedia - Liskov substitution principle]
 * Python Enhancement Proposal (PEP) 3102 - https://www.python.org/dev/peps/pep-3102/[Keyword-Only Arguments]
 * Python Enhancement Proposal (PEP) 570 - https://www.python.org/dev/peps/pep-0570/[Python Positional-Only Parameters]
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

