### PR TITLE
S3870 Update metadata

### DIFF
--- a/rules/S3807/cfamily/metadata.json
+++ b/rules/S3807/cfamily/metadata.json
@@ -21,9 +21,17 @@
   "ruleSpecification": "RSPEC-3807",
   "sqKey": "S3807",
   "scope": "All",
+  "securityStandards": {
+    "CWE": [
+      476
+    ],
+    "CERT": [
+      "EXP01-J."
+    ]
+  },
   "defaultQualityProfiles": [
     "Sonar way",
     "MISRA C++ 2008 recommended"
   ],
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }

--- a/rules/S3807/cfamily/rule.adoc
+++ b/rules/S3807/cfamily/rule.adoc
@@ -115,7 +115,6 @@ int process_string() {
 
 === Documentation
 
-* MITRE - https://cwe.mitre.org/data/definitions/476[CWE-476 NULL Pointer Dereference]
 
 The list of functions considered by this rule is shown in the following:
 
@@ -145,8 +144,9 @@ wcsnlen, wcsnrtombs, wcsrtombs, wcstombs, wcswidth, wcsxfrm, wcsxfrm_l,
 wmemchr, wmemcmp, wmemcpy, wmemmove, wmemcpy, wmemset, write, writev
 ----
 
-=== External coding guidelines
+=== Standards
 
+* CWE - https://cwe.mitre.org/data/definitions/476[476 NULL Pointer Dereference]
 * CERT - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[EXP01-J. Do not use a null in a case where an object is required]
 
 


### PR DESCRIPTION
Few updates I have missed during review, and just realized when saw sonar-cpp PR:
 * we should check quickfix, and mark if infeasible if we think that one could be provided
 * metadata now contains links to security standards, so I updated it
 * pre https://github.com/SonarSource/rspec/blob/master/docs/link_formatting.adoc, CWE should start with CWE
 * I think that CWE and CERT are put under standard, external conding guidelines are use for MISRA and CoreGuidlines.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

