### PR TITLE
Diff blocks: fix incorrect use for cfamily

### DIFF
--- a/rules/S2755/cfamily/how-to-fix-it/xerces.adoc
+++ b/rules/S2755/cfamily/how-to-fix-it/xerces.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=11,diff-type=noncompliant]
 ----
 #include "xercesc/parsers/XercesDOMParser.hpp"
 
@@ -21,7 +21,7 @@ void parse() {
 
 By default, entities resolution is enabled for `XMLReaderFactory::createXMLReader`.
 
-[source,cpp,diff-id=2,diff-type=noncompliant]
+[source,cpp,diff-id=12,diff-type=noncompliant]
 ----
 #include "xercesc/sax2/SAX2XMLReader.hpp"
 
@@ -35,7 +35,7 @@ void parse() {
 
 By default, entities resolution is enabled for `SAXParser`.
 
-[source,cpp,diff-id=3,diff-type=noncompliant]
+[source,cpp,diff-id=13,diff-type=noncompliant]
 ----
 #include "xercesc/parsers/SAXParser.hpp"
 
@@ -52,7 +52,7 @@ void parse() {
 
 By default, `XercesDOMParser` is safe.
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=11,diff-type=compliant]
 ----
 #include "xercesc/parsers/XercesDOMParser.hpp"
 
@@ -65,7 +65,7 @@ void parse() {
 }
 ----
 
-[source,cpp,diff-id=2,diff-type=compliant]
+[source,cpp,diff-id=12,diff-type=compliant]
 ----
 #include "xercesc/sax2/SAX2XMLReader.hpp"
 
@@ -77,7 +77,7 @@ void parse() {
 }
 ----
 
-[source,cpp,diff-id=3,diff-type=compliant]
+[source,cpp,diff-id=13,diff-type=compliant]
 ----
 #include "xercesc/parsers/SAXParser.hpp"
 

--- a/rules/S4423/cfamily/how-to-fix-it/curl.adoc
+++ b/rules/S4423/cfamily/how-to-fix-it/curl.adoc
@@ -1,4 +1,4 @@
-== How to fix it in cURL 
+== How to fix it in cURL
 
 === Code examples
 
@@ -9,11 +9,11 @@ The following code samples attempt to create an HTTP request.
 This sample uses Curl's default TLS algorithms, which are weak
 cryptographical algorithms: TLSv1.0 and LTSv1.1.
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=11,diff-type=noncompliant]
 ----
 #include <curl/curl.h>
 
-void encrypt() { 
+void encrypt() {
     CURL *curl;
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
@@ -26,7 +26,7 @@ void encrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=11,diff-type=compliant]
 ----
 #include <curl/curl.h>
 

--- a/rules/S4423/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S4423/cfamily/how-to-fix-it/openssl.adoc
@@ -1,5 +1,5 @@
 
-== How to fix it in OpenSSL 
+== How to fix it in OpenSSL
 
 === Code examples
 
@@ -10,7 +10,7 @@ The following code samples attempt to create an OpenSSL TLS Client.
 This sample uses OpenSSL's default TLS algorithms, which are weak
 cryptographical algorithms (TLSv1.0 and LTSv1.1).
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <openssl/ssl.h>
 
@@ -25,7 +25,7 @@ void encrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <openssl/ssl.h>
 

--- a/rules/S4426/cfamily/how-to-fix-it/cryptopp.adoc
+++ b/rules/S4426/cfamily/how-to-fix-it/cryptopp.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/rsa.adoc[]
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <cryptopp/rsa.h>
 #include <cryptopp/rng.h>
@@ -21,7 +21,7 @@ void encrypt() {
 
 include::../../common/fix/dsa.adoc[]
 
-[source,cpp,diff-id=2,diff-type=noncompliant]
+[source,cpp,diff-id=22,diff-type=noncompliant]
 ----
 #include <cryptopp/dsa.h>
 #include <cryptopp/rng.h>
@@ -34,7 +34,7 @@ dsa_private_key.GenerateRandomWithKeySize(rng, 1024); // Noncompliant
 
 include::../../common/fix/dh.adoc[]
 
-[source,cpp,diff-id=3,diff-type=noncompliant]
+[source,cpp,diff-id=23,diff-type=noncompliant]
 ----
 #include <cryptopp/dh.h>
 #include <cryptopp/rng.h>
@@ -47,7 +47,7 @@ dh.AccessGroupParameters().GenerateRandomWithKeySize(rng, 1024); // Noncompliant
 
 include::../../common/fix/ec.adoc[]
 
-[source,cpp,diff-id=4,diff-type=noncompliant]
+[source,cpp,diff-id=24,diff-type=noncompliant]
 ----
 #include <cryptopp/osrng.h>
 
@@ -58,7 +58,7 @@ void ecnrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <cryptopp/rsa.h>
 #include <cryptopp/rng.h>
@@ -71,7 +71,7 @@ void encrypt() {
 }
 ----
 
-[source,cpp,diff-id=2,diff-type=compliant]
+[source,cpp,diff-id=22,diff-type=compliant]
 ----
 #include <cryptopp/dsa.h>
 #include <cryptopp/rng.h>
@@ -82,7 +82,7 @@ cryptopp::dsa::privatekey      dsa_private_key;
 dsa_private_key.GenerateRandomWithKeySize(rng, 2048);
 ----
 
-[source,cpp,diff-id=3,diff-type=compliant]
+[source,cpp,diff-id=23,diff-type=compliant]
 ----
 #include <cryptopp/dh.h>
 #include <cryptopp/rng.h>
@@ -93,7 +93,7 @@ CryptoPP::DH                   dh;
 dh.AccessGroupParameters().GenerateRandomWithKeySize(rng, 2048);
 ----
 
-[source,cpp,diff-id=4,diff-type=compliant]
+[source,cpp,diff-id=24,diff-type=compliant]
 ----
 #include <cryptopp/osrng.h>
 

--- a/rules/S4426/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S4426/cfamily/how-to-fix-it/openssl.adoc
@@ -8,7 +8,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 include::../../common/fix/rsa.adoc[]
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=31,diff-type=noncompliant]
 ----
 #include <openssl/rsa.h>
 
@@ -23,7 +23,7 @@ void encrypt() {
 
 include::../../common/fix/dsa.adoc[]
 
-[source,cpp,diff-id=2,diff-type=noncompliant]
+[source,cpp,diff-id=32,diff-type=noncompliant]
 ----
 #include <openssl/dsa.h>
 
@@ -35,7 +35,7 @@ void encrypt() {
 
 include::../../common/fix/dh.adoc[]
 
-[source,cpp,diff-id=3,diff-type=noncompliant]
+[source,cpp,diff-id=33,diff-type=noncompliant]
 ----
 #include <openssl/dh.h>
 
@@ -47,7 +47,7 @@ void encrypt() {
 
 include::../../common/fix/ec.adoc[]
 
-[source,cpp,diff-id=4,diff-type=noncompliant]
+[source,cpp,diff-id=34,diff-type=noncompliant]
 ----
 #include <botan/ec_group.h>
 
@@ -58,7 +58,7 @@ void encrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=31,diff-type=compliant]
 ----
 #include <openssl/rsa.h>
 
@@ -71,7 +71,7 @@ void encrypt() {
 }
 ----
 
-[source,cpp,diff-id=2,diff-type=compliant]
+[source,cpp,diff-id=32,diff-type=compliant]
 ----
 #include <openssl/dsa.h>
 
@@ -81,7 +81,7 @@ void encrypt() {
 }
 ----
 
-[source,cpp,diff-id=3,diff-type=compliant]
+[source,cpp,diff-id=33,diff-type=compliant]
 ----
 #include <openssl/dh.h>
 
@@ -91,7 +91,7 @@ void encrypt() {
 }
 ----
 
-[source,cpp,diff-id=4,diff-type=compliant]
+[source,cpp,diff-id=34,diff-type=compliant]
 ----
 #include <botan/ec_group.h>
 

--- a/rules/S4830/cfamily/how-to-fix-it/curl.adoc
+++ b/rules/S4830/cfamily/how-to-fix-it/curl.adoc
@@ -12,34 +12,34 @@ include::../../common/fix/code-rationale-setting.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <curl/curl.h>
 
 void connect() {
     CURL *curl;
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    
+
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L); // Noncompliant
-    
+
     curl_easy_perform(curl);
 }
 ----
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <curl/curl.h>
 
 void connect() {
     CURL *curl;
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    
+
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-    
+
     curl_easy_perform(curl);
 }
 ----

--- a/rules/S4830/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S4830/cfamily/how-to-fix-it/openssl.adoc
@@ -10,11 +10,11 @@ include::../../common/fix/code-rationale-override.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=31,diff-type=noncompliant]
 ----
 #include <openssl/ssl.h>
 
-static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx) { return 1; } 
+static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx) { return 1; }
 
 void connect() {
     const SSL_METHOD *method = TLS_method();
@@ -28,7 +28,7 @@ void connect() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=31,diff-type=compliant]
 ----
 #include <openssl/ssl.h>
 

--- a/rules/S5527/cfamily/how-to-fix-it/curl.adoc
+++ b/rules/S5527/cfamily/how-to-fix-it/curl.adoc
@@ -4,7 +4,7 @@
 
 include::../../common/fix/code-rationale.adoc[]
 
-:cert_variable_name: CURLOPT_SSL_VERIFYHOST 
+:cert_variable_name: CURLOPT_SSL_VERIFYHOST
 :cert_variable_unsafe_value: 0L
 :cert_variable_safe_value: 1L
 
@@ -12,14 +12,14 @@ include::../../common/fix/code-rationale-setting.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <curl/curl.h>
 
 void connect() {
     CURL *curl;
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    
+
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L); // Noncompliant
 
@@ -29,17 +29,17 @@ void connect() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <curl/curl.h>
 
 void connect() {
     CURL *curl;
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    
+
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
-    
+
     curl_easy_perform(curl);
 }
 ----

--- a/rules/S5527/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S5527/cfamily/how-to-fix-it/openssl.adoc
@@ -5,7 +5,7 @@
 include::../../common/fix/code-rationale.adoc[]
 
 :cert_variable_name: SSL_set1_host
-:cert_variable_safe_value: the name of the expected host 
+:cert_variable_safe_value: the name of the expected host
 
 include::../../common/fix/code-rationale-explicit.adoc[]
 
@@ -15,7 +15,7 @@ certificates.
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=31,diff-type=noncompliant]
 ----
 #include <openssl/ssl.h>
 
@@ -30,7 +30,7 @@ void connect() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=31,diff-type=compliant]
 ----
 #include <openssl/ssl.h>
 

--- a/rules/S5542/cfamily/how-to-fix-it/cryptopp.adoc
+++ b/rules/S5542/cfamily/how-to-fix-it/cryptopp.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/aes-noncompliant-example.adoc[]
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <cryptopp/aes.h>
 #include <cryptopp/modes.h>
@@ -18,7 +18,7 @@ voic encrypt() {
 
 include::../../common/fix/rsa-noncompliant-example.adoc[]
 
-[source,cpp,diff-id=2,diff-type=noncompliant]
+[source,cpp,diff-id=22,diff-type=noncompliant]
 ----
 #include <cryptopp/rsa.h>
 
@@ -31,7 +31,7 @@ void encrypt() {
 
 include::../../common/fix/aes-compliant-example.adoc[]
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <cryptopp/aes.h>
 #include <cryptopp/modes.h>
@@ -43,7 +43,7 @@ void encrypt() {
 
 include::../../common/fix/rsa-compliant-example.adoc[]
 
-[source,cpp,diff-id=2,diff-type=compliant]
+[source,cpp,diff-id=22,diff-type=compliant]
 ----
 #include <cryptopp/rsa.h>
 

--- a/rules/S5542/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S5542/cfamily/how-to-fix-it/openssl.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/aes-noncompliant-example.adoc[]
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=31,diff-type=noncompliant]
 ----
 #include <openssl/evp.h>
 
@@ -17,7 +17,7 @@ void encrypt() {
 
 include::../../common/fix/rsa-noncompliant-example.adoc[]
 
-[source,cpp,diff-id=2,diff-type=noncompliant]
+[source,cpp,diff-id=32,diff-type=noncompliant]
 ----
 #include <openssl/rsa.h>
 
@@ -30,7 +30,7 @@ void encrypt() {
 
 include::../../common/fix/aes-compliant-example.adoc[]
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=31,diff-type=compliant]
 ----
 #include <openssl/evp.h>
 
@@ -41,7 +41,7 @@ void encrypt() {
 
 include::../../common/fix/rsa-compliant-example.adoc[]
 
-[source,cpp,diff-id=2,diff-type=compliant]
+[source,cpp,diff-id=32,diff-type=compliant]
 ----
 #include <openssl/rsa.h>
 

--- a/rules/S5547/cfamily/how-to-fix-it/cryptopp.adoc
+++ b/rules/S5547/cfamily/how-to-fix-it/cryptopp.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=21,diff-type=noncompliant]
 ----
 #include <cryptopp/des.h>
 
@@ -17,7 +17,7 @@ void encrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=21,diff-type=compliant]
 ----
 #include <cryptopp/aes.h>
 

--- a/rules/S5547/cfamily/how-to-fix-it/openssl.adoc
+++ b/rules/S5547/cfamily/how-to-fix-it/openssl.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=31,diff-type=noncompliant]
 ----
 #include <openssl/evp.h>
 
@@ -17,7 +17,7 @@ void encrypt() {
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp,diff-id=31,diff-type=compliant]
 ----
 #include <openssl/evp.h>
 

--- a/rules/S5553/cfamily/rule.adoc
+++ b/rules/S5553/cfamily/rule.adoc
@@ -205,7 +205,7 @@ int getTotalScore() {
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=5,diff-type=compliant]
+[source,cpp,diff-id=5,diff-type=noncompliant]
 ----
 #include <string>
 #include <memory>


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` were fixed.