### PR TITLE
Diff blocks: fix incorrect use for python

### DIFF
--- a/rules/S2076/python/how-to-fix-it/python.adoc
+++ b/rules/S2076/python/how-to-fix-it/python.adoc
@@ -9,7 +9,7 @@ shell control characters, the expected `ping` command behavior will be changed.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 def ping():
     cmd = "ping -c 1 %s" % request.args.get("host", "www.google.com")
@@ -19,7 +19,7 @@ def ping():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 def safe_ping():
     host = request.args.get("host", "www.google.com")

--- a/rules/S2091/python/how-to-fix-it/python.adoc
+++ b/rules/S2091/python/how-to-fix-it/python.adoc
@@ -8,7 +8,7 @@ supports a subset of XPath syntax, exploitation can still be possible.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from xml.etree import ElementTree
 from flask import request
@@ -34,7 +34,7 @@ where `[.!='][@pass=']` and `[.!='XXXXX']` should match on everything, resulting
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 import re
 from xml.etree import ElementTree

--- a/rules/S2755/python/how-to-fix-it/std.adoc
+++ b/rules/S2755/python/how-to-fix-it/std.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 import xml.sax
 
@@ -22,7 +22,7 @@ parser.parse('xxe.xml')
 The SAX parser does not process general external entities by default since
 version 3.7.1.
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 import xml.sax
 

--- a/rules/S3329/python/how-to-fix-it/pycryptodome.adoc
+++ b/rules/S3329/python/how-to-fix-it/pycryptodome.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
@@ -21,7 +21,7 @@ cipher.encrypt(pad(data, AES.block_size))  # Noncompliant
 
 include::../../common/fix/explicit-fix.adoc[]
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes

--- a/rules/S3649/python/how-to-fix-it/sqlite3.adoc
+++ b/rules/S3649/python/how-to-fix-it/sqlite3.adoc
@@ -8,7 +8,7 @@ directly into a query string: The application assumes that incoming data
 always has a specific range of characters and ignores that some characters may
 change the query logic to a malicious one.
 
-In this particular case, the query can be exploited with the following string: 
+In this particular case, the query can be exploited with the following string:
 
 ----
 ' OR '1'='1
@@ -19,7 +19,7 @@ other tables and combine the returned data within the same query result.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from flask import request
 
@@ -34,7 +34,7 @@ def get_users():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from flask import request
 
@@ -43,7 +43,7 @@ def get_users():
     user = request.args["user"]
     sql = """SELECT user FROM users WHERE user = (?)"""
     value = (user,)
-    
+
     conn = sqlite3.connect('example')
     conn.cursor().execute(sql, value)
 ----

--- a/rules/S4423/python/how-to-fix-it/openssl.adoc
+++ b/rules/S4423/python/how-to-fix-it/openssl.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from OpenSSL import SSL
 
@@ -13,7 +13,7 @@ SSL.Context(SSL.SSLv3_METHOD)  # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from OpenSSL import SSL
 

--- a/rules/S4423/python/how-to-fix-it/ssl.adoc
+++ b/rules/S4423/python/how-to-fix-it/ssl.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=21,diff-type=noncompliant]
 ----
 import ssl
 
@@ -13,7 +13,7 @@ ssl.SSLContext(ssl.PROTOCOL_SSLv3) # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=21,diff-type=compliant]
 ----
 import ssl
 

--- a/rules/S4830/python/how-to-fix-it/openssl.adoc
+++ b/rules/S4830/python/how-to-fix-it/openssl.adoc
@@ -21,7 +21,7 @@ ctx2.set_verify(SSL.VERIFY_NONE, verify_callback) # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=1,diff-type=compliant]
 ----
 from OpenSSL import SSL
 

--- a/rules/S4830/python/how-to-fix-it/requests.adoc
+++ b/rules/S4830/python/how-to-fix-it/requests.adoc
@@ -21,7 +21,7 @@ requests.request('GET', 'https://example.com', verify=False) # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=11,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 import requests
 

--- a/rules/S4830/python/how-to-fix-it/requests.adoc
+++ b/rules/S4830/python/how-to-fix-it/requests.adoc
@@ -12,7 +12,7 @@ include::../../common/fix/code-rationale-setting.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 import requests
 
@@ -21,7 +21,7 @@ requests.request('GET', 'https://example.com', verify=False) # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 import requests
 

--- a/rules/S4830/python/how-to-fix-it/std.adoc
+++ b/rules/S4830/python/how-to-fix-it/std.adoc
@@ -10,7 +10,7 @@ create a secure context that validates certificates.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=21,diff-type=noncompliant]
 ----
 import ssl
 
@@ -23,7 +23,7 @@ ctx3.verify_mode = ssl.CERT_NONE # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=21,diff-type=compliant]
 ----
 import ssl
 

--- a/rules/S5131/python/how-to-fix-it/dtl.adoc
+++ b/rules/S5131/python/how-to-fix-it/dtl.adoc
@@ -6,7 +6,7 @@ The following code is vulnerable to cross-site scripting because auto-escaping o
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from django.shortcuts import render
 
@@ -16,7 +16,7 @@ def hello(request):
         return render(request, 'hello.html', {'hello': hello})
 ----
 
-[source,html,diff-id=2,diff-type=noncompliant]
+[source,html,diff-id=12,diff-type=noncompliant]
 ----
 <!doctype html>
 {% autoescape false %}
@@ -26,7 +26,7 @@ def hello(request):
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from django.shortcuts import render
 
@@ -35,7 +35,7 @@ def hello(request):
         return render(request, 'hello.html', {'name': name})
 ----
 
-[source,html,diff-id=2,diff-type=compliant]
+[source,html,diff-id=12,diff-type=compliant]
 ----
 <!doctype html>
 <h1>Hello {{ name }}</h1>
@@ -55,7 +55,7 @@ Auto-escaping can also be disabled at the application level and introduce XSS vu
 
 ==== Noncompliant code example
 
-[source,python,diff-id=3,diff-type=noncompliant]
+[source,python,diff-id=13,diff-type=noncompliant]
 ----
 # settings.py
 TEMPLATES = [
@@ -71,7 +71,7 @@ TEMPLATES = [
 
 ==== Compliant solution
 
-[source,python,diff-id=3,diff-type=compliant]
+[source,python,diff-id=13,diff-type=compliant]
 ----
 # settings.py
 TEMPLATES = [
@@ -96,7 +96,7 @@ Another option is to use the `++json_script++` filter to insert a data structure
 
 ===== Noncompliant code example
 
-[source,html,diff-id=4,diff-type=noncompliant]
+[source,html,diff-id=14,diff-type=noncompliant]
 ----
 <!doctype html>
 <script> var name = '{{ name }}';</script>
@@ -104,7 +104,7 @@ Another option is to use the `++json_script++` filter to insert a data structure
 
 ===== Compliant solution
 
-[source,html,diff-id=4,diff-type=compliant]
+[source,html,diff-id=14,diff-type=compliant]
 ----
 <!doctype html>
 {{ name|json_script:"name-data" }}

--- a/rules/S5131/python/how-to-fix-it/flask.adoc
+++ b/rules/S5131/python/how-to-fix-it/flask.adoc
@@ -9,7 +9,7 @@ For example, you can use the `jsonify` class to return JSON messages safely.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=21,diff-type=noncompliant]
 ----
 from flask import make_response, request
 import json
@@ -22,7 +22,7 @@ def index():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=21,diff-type=compliant]
 ----
 from flask import jsonify, request
 
@@ -35,7 +35,7 @@ It is also possible to set the content-type manually with the `mimetype` paramet
 
 ==== Noncompliant code example
 
-[source,python,diff-id=2,diff-type=noncompliant]
+[source,python,diff-id=22,diff-type=noncompliant]
 ----
 from flask import make_response, request
 
@@ -46,7 +46,7 @@ def index():
 
 ==== Compliant solution
 
-[source,python,diff-id=2,diff-type=compliant]
+[source,python,diff-id=22,diff-type=compliant]
 ----
 from flask import make_response, request
 

--- a/rules/S5131/python/how-to-fix-it/jinja.adoc
+++ b/rules/S5131/python/how-to-fix-it/jinja.adoc
@@ -7,7 +7,7 @@ The recommended way to fix this code is to move the HTML content to the template
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=31,diff-type=noncompliant]
 ----
 from flask import render_template
 
@@ -17,7 +17,7 @@ def hello(name=None):
     return render_template('hello.html', hello=hello)
 ----
 
-[source,html,diff-id=2,diff-type=noncompliant]
+[source,html,diff-id=32,diff-type=noncompliant]
 ----
 <!doctype html>
 {% autoescape false %}
@@ -27,7 +27,7 @@ def hello(name=None):
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=31,diff-type=compliant]
 ----
 from flask import render_template
 
@@ -36,7 +36,7 @@ def hello(name=None):
     return render_template('hello.html', name=name)
 ----
 
-[source,html,diff-id=2,diff-type=compliant]
+[source,html,diff-id=32,diff-type=compliant]
 ----
 <!doctype html>
 <h1>Hello {{ name }}</h1>
@@ -60,7 +60,7 @@ Another option is to use the ``++tojson++`` filter to insert a data structure in
 
 ===== Noncompliant code example
 
-[source,html,diff-id=3,diff-type=noncompliant]
+[source,html,diff-id=33,diff-type=noncompliant]
 ----
 <!doctype html>
 <script> var name = '{{ name }}';</script>
@@ -69,7 +69,7 @@ Another option is to use the ``++tojson++`` filter to insert a data structure in
 
 ===== Compliant solution
 
-[source,html,diff-id=3,diff-type=compliant]
+[source,html,diff-id=33,diff-type=compliant]
 ----
 <!doctype html>
 <script> var name = {{ name | tojson }}</script>

--- a/rules/S5135/python/how-to-fix-it/yaml.adoc
+++ b/rules/S5135/python/how-to-fix-it/yaml.adoc
@@ -36,7 +36,7 @@ prevents the execution of arbitrary or dangerous functions.
 Note that the same level of security can be reached with the `load` method as
 soon as a safe `Loader` component is passed to it.
 
-[source,python,diff-id=11,diff-type=compliant]
+[source,python]
 ----
 yaml.load(untrusted, Loader=yaml.SafeLoader)
 ----

--- a/rules/S5135/python/how-to-fix-it/yaml.adoc
+++ b/rules/S5135/python/how-to-fix-it/yaml.adoc
@@ -7,7 +7,7 @@ deserializes untrusted data without validating it first.
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 def unsafe():
     obj = yaml.load(request.args.get("object"), Loader=yaml.Loader)
@@ -16,7 +16,7 @@ def unsafe():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 def safe():
     obj = yaml.safe_load(request.args.get("object"))
@@ -30,13 +30,13 @@ include::../../common/fix/introduction.adoc[]
 include::../../common/fix/safer-serialization.adoc[]
 
 The example compliant solution uses the `safe_load` method in place of the less
-secure `load` one. It disables loading arbitrary Python object and thus 
+secure `load` one. It disables loading arbitrary Python object and thus
 prevents the execution of arbitrary or dangerous functions.
 
 Note that the same level of security can be reached with the `load` method as
 soon as a safe `Loader` component is passed to it.
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 yaml.load(untrusted, Loader=yaml.SafeLoader)
 ----

--- a/rules/S5144/python/how-to-fix-it/requests.adoc
+++ b/rules/S5144/python/how-to-fix-it/requests.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from flask import request
 import requests
@@ -19,7 +19,7 @@ def example():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from flask import request
 import requests

--- a/rules/S5145/python/how-to-fix-it/python.adoc
+++ b/rules/S5145/python/how-to-fix-it/python.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 import logging
 
@@ -20,7 +20,7 @@ def log():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 import logging
 import base64

--- a/rules/S5146/python/how-to-fix-it/flask.adoc
+++ b/rules/S5146/python/how-to-fix-it/flask.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from flask import Flask, redirect
 
@@ -20,7 +20,7 @@ def redirecting():
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from flask import Flask, redirect, url_for
 

--- a/rules/S5542/python/how-to-fix-it/pycrypto.adoc
+++ b/rules/S5542/python/how-to-fix-it/pycrypto.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/aes-noncompliant-example.adoc[]
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from Crypto.Cipher import AES
 
@@ -15,7 +15,7 @@ AES.new(key, AES.MODE_ECB) # Noncompliant
 
 include::../../common/fix/rsa-noncompliant-example.adoc[]
 
-[source,python,diff-id=2,diff-type=noncompliant]
+[source,python,diff-id=12,diff-type=noncompliant]
 ----
 from Crypto.Cipher import PKCS1_v1_5
 
@@ -29,7 +29,7 @@ In the current context, Cryptodome uses a similar API.
 
 include::../../common/fix/aes-compliant-example.adoc[]
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from Crypto.Cipher import AES
 
@@ -38,7 +38,7 @@ AES.new(key, AES.MODE_GCM)
 
 include::../../common/fix/rsa-compliant-example.adoc[]
 
-[source,python,diff-id=2,diff-type=compliant]
+[source,python,diff-id=12,diff-type=compliant]
 ----
 from Crypto.Cipher import PKCS1_OAEP
 

--- a/rules/S5542/python/how-to-fix-it/pycryptodome.adoc
+++ b/rules/S5542/python/how-to-fix-it/pycryptodome.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/aes-noncompliant-example.adoc[]
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=21,diff-type=noncompliant]
 ----
 from Crypto.Cipher import AES     # pycryptodome
 from Cryptodome.Cipher import AES # pycryptodomex
@@ -16,7 +16,7 @@ AES.new(key, AES.MODE_ECB)  # Noncompliant
 
 include::../../common/fix/rsa-noncompliant-example.adoc[]
 
-[source,python,diff-id=2,diff-type=noncompliant]
+[source,python,diff-id=22,diff-type=noncompliant]
 ----
 from Crypto.Cipher import PKCS1_V1_5     # pycryptodome
 from Cryptodome.Cipher import PKCS1_V1_5 # pycryptodomex
@@ -29,7 +29,7 @@ PKCS1_v1_5.new(key) # Noncompliant
 
 include::../../common/fix/aes-compliant-example.adoc[]
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=21,diff-type=compliant]
 ----
 from Crypto.Cipher import AES     # pycryptodome
 from Cryptodome.Cipher import AES # pycryptodomex
@@ -39,7 +39,7 @@ AES.new(key, AES.MODE_GCM)
 
 include::../../common/fix/rsa-compliant-example.adoc[]
 
-[source,python,diff-id=2,diff-type=compliant]
+[source,python,diff-id=22,diff-type=compliant]
 ----
 from Crypto.Cipher import PKCS1_V1_5     # pycryptodome
 from Cryptodome.Cipher import PKCS1_V1_5 # pycryptodomex

--- a/rules/S5542/python/how-to-fix-it/pydes.adoc
+++ b/rules/S5542/python/how-to-fix-it/pydes.adoc
@@ -4,22 +4,22 @@
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=31,diff-type=noncompliant]
 ----
 import pyDes
 
-pyDes.des(key) # Noncompliant  
+pyDes.des(key) # Noncompliant
 ----
 
 ==== Compliant solution
 
 Since pyDes only provides DES, it is recommended to use another library like pyca.
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=31,diff-type=compliant]
 ----
 from cryptography.hazmat.primitives.ciphers import (
-    Cipher, 
-    algorithms, 
+    Cipher,
+    algorithms,
     modes,
 )
 from cryptography.hazmat.backends import default_backend

--- a/rules/S5547/python/how-to-fix-it/pyca.adoc
+++ b/rules/S5547/python/how-to-fix-it/pyca.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
@@ -16,7 +16,7 @@ cipher = Cipher(algorithms.TripleDES(key), mode=None, backend=default_backend())
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend

--- a/rules/S5547/python/how-to-fix-it/pycrypto.adoc
+++ b/rules/S5547/python/how-to-fix-it/pycrypto.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=21,diff-type=noncompliant]
 ----
 from Crypto.Cipher import DES
 
@@ -17,7 +17,7 @@ cipher = DES.new(key) # Noncompliant
 
 PyCrypto is deprecated, thus it is recommended to use another library like pyca.
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=21,diff-type=compliant]
 ----
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend

--- a/rules/S5547/python/how-to-fix-it/pydes.adoc
+++ b/rules/S5547/python/how-to-fix-it/pydes.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=31,diff-type=noncompliant]
 ----
 import pyDes
 
@@ -17,7 +17,7 @@ cipher = pyDes.des(key) # Noncompliant
 
 Since pyDes only provides DES, it is recommended to use another library like pyca.
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=31,diff-type=compliant]
 ----
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend

--- a/rules/S5659/python/how-to-fix-it/python-jwt.adoc
+++ b/rules/S5659/python/how-to-fix-it/python-jwt.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale-decode.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=1,diff-type=noncompliant]
+[source,python,diff-id=11,diff-type=noncompliant]
 ----
 import python_jwt as jwt
 
@@ -15,7 +15,7 @@ jwt.process_jwt(token) # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=1,diff-type=compliant]
+[source,python,diff-id=11,diff-type=compliant]
 ----
 import python_jwt as jwt
 


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` were fixed.

An obvious extra use of diff blocks was removed.