### PR TITLE
Diff blocks: fix incorrect use for cloudformation

### DIFF
--- a/rules/S4423/cloudformation/how-to-fix-it/opensearch.adoc
+++ b/rules/S4423/cloudformation/how-to-fix-it/opensearch.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,cloudformation,diff-id=1,diff-type=noncompliant]
+[source,cloudformation,diff-id=21,diff-type=noncompliant]
 ----
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
@@ -19,7 +19,7 @@ Resources:
 
 ==== Compliant solution
 
-[source,cloudformation,diff-id=1,diff-type=compliant]
+[source,cloudformation,diff-id=21,diff-type=compliant]
 ----
 AWSTemplateFormatVersion: 2010-09-09
 Resources:


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.