### PR TITLE
Diff blocks: fix some incorrect use for csharp

### DIFF
--- a/rules/S2187/csharp/how-nunit.adoc
+++ b/rules/S2187/csharp/how-nunit.adoc
@@ -14,7 +14,7 @@ include::how.adoc[]
 
 ==== Noncompliant code example
 
-[source,csharp,diff-id=1,diff-type=noncompliant]
+[source,csharp,diff-id=11,diff-type=noncompliant]
 ----
 [TestFixture]
 public class SomeClassTest { } // Noncompliant: no test
@@ -22,7 +22,7 @@ public class SomeClassTest { } // Noncompliant: no test
 
 ==== Compliant solution
 
-[source,csharp,diff-id=1,diff-type=compliant]
+[source,csharp,diff-id=11,diff-type=compliant]
 ----
 [TestFixture]
 public class SomeClassTest

--- a/rules/S3649/csharp/how-to-fix-it/entity-framework.adoc
+++ b/rules/S3649/csharp/how-to-fix-it/entity-framework.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,csharp,diff-id=1,diff-type=noncompliant]
+[source,csharp,diff-id=11,diff-type=noncompliant]
 ----
 public class ExampleController : Controller
 {
@@ -32,7 +32,7 @@ public class ExampleController : Controller
 
 ==== Compliant solution
 
-[source,csharp,diff-id=1,diff-type=compliant]
+[source,csharp,diff-id=11,diff-type=compliant]
 ----
 public class ExampleController : Controller
 {

--- a/rules/S3877/csharp/rule.adoc
+++ b/rules/S3877/csharp/rule.adoc
@@ -2,11 +2,11 @@
 
 The rule is reporting when an exception is thrown from certain methods and constructors. These methods are expected to behave in a specific way and throwing an exception from them can lead to unexpected behavior and break the calling code.
 
-[source,csharp,diff-type=noncompliant]
+[source,csharp]
 ----
 public override string ToString()
 {
-  if (string.IsNullOrEmpty(Name)) 
+  if (string.IsNullOrEmpty(Name))
   {
     throw new ArgumentException(nameof(Name));  // Noncompliant
   }
@@ -14,7 +14,7 @@ public override string ToString()
 }
 ----
 
-An issue is raised when an exception is thrown from any of the following: 
+An issue is raised when an exception is thrown from any of the following:
 
 * https://learn.microsoft.com/en-us/dotnet/api/system.object.tostring[ToString]
 * https://learn.microsoft.com/en-us/dotnet/api/system.object.equals[Object.Equals]

--- a/rules/S5131/csharp/how-to-fix-it/razor.adoc
+++ b/rules/S5131/csharp/how-to-fix-it/razor.adoc
@@ -7,7 +7,7 @@ The recommended way to fix this code is to move the HTML content to the template
 
 ==== Noncompliant code example
 
-[source,csharp,diff-id=1,diff-type=noncompliant]
+[source,csharp,diff-id=11,diff-type=noncompliant]
 ----
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,14 +21,14 @@ public class HelloController : Controller
 }
 ----
 
-[source,html,diff-id=2,diff-type=noncompliant]
+[source,html,diff-id=12,diff-type=noncompliant]
 ----
 @Html.Raw(ViewData["Hello"])
 ----
 
 ==== Compliant solution
 
-[source,csharp,diff-id=1,diff-type=compliant]
+[source,csharp,diff-id=11,diff-type=compliant]
 ----
 using Microsoft.AspNetCore.Mvc;
 
@@ -42,7 +42,7 @@ public class HelloController : Controller
 }
 ----
 
-[source,html,diff-id=2,diff-type=compliant]
+[source,html,diff-id=12,diff-type=compliant]
 ----
 <h1>@ViewData["Name"]</h1>
 ----

--- a/rules/S5547/csharp/how-to-fix-it/dot-net.adoc
+++ b/rules/S5547/csharp/how-to-fix-it/dot-net.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,csharp,diff-id=1,diff-type=noncompliant]
+[source,csharp,diff-id=11,diff-type=noncompliant]
 ----
 using System.Security.Cryptography;
 
@@ -18,7 +18,7 @@ public void encrypt()
 
 ==== Compliant solution
 
-[source,csharp,diff-id=1,diff-type=compliant]
+[source,csharp,diff-id=11,diff-type=compliant]
 ----
 using System.Security.Cryptography;
 


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Remove an obviously unused diff block.

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).