### PR TITLE
Diff blocks: fix some incorrect use for docker

### DIFF
--- a/rules/S4423/docker/how-to-fix-it/wget.adoc
+++ b/rules/S4423/docker/how-to-fix-it/wget.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,docker,diff-id=1,diff-type=noncompliant]
+[source,docker,diff-id=11,diff-type=noncompliant]
 ----
 FROM ubuntu:22.04
 
@@ -14,7 +14,7 @@ RUN wget --secure-protocol TLSv1_1 https://example.com/downloads/install.sh
 
 ==== Compliant solution
 
-[source,docker,diff-id=1,diff-type=compliant]
+[source,docker,diff-id=11,diff-type=compliant]
 ----
 FROM ubuntu:22.04
 

--- a/rules/S6579/docker/rule.adoc
+++ b/rules/S6579/docker/rule.adoc
@@ -34,7 +34,7 @@ In this case when Dockerfile will be built with the flag `--build-arg SETTINGS=-
 
 ==== Noncompliant code example
 
-[source,docker,diff-id=1,diff-type=noncompliant]
+[source,docker,diff-id=2,diff-type=noncompliant]
 ----
 ARG SETTINGS="--default-settings"
 FROM busybox
@@ -45,7 +45,7 @@ In this case the `$SETTINGS` variable will be not evaluated, just the text `$SET
 
 ==== Compliant solution
 
-[source,docker,diff-id=1,diff-type=compliant]
+[source,docker,diff-id=2,diff-type=compliant]
 ----
 ARG SETTINGS="--default-settings"
 FROM busybox


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule. 

Obvious typos around `diff-id` were fixed.

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).