### PR TITLE
Diff blocks: fix some incorrect use for java

### DIFF
--- a/rules/S1214/java/rule.adoc
+++ b/rules/S1214/java/rule.adoc
@@ -35,7 +35,7 @@ In some cases, enums are not a suitable option because the concrete constant val
 Then you should check whether it is appropriate to move them to a specific existing class,
 for example, if that class is the primary user of the constants:
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=2,diff-type=noncompliant]
 ----
 interface AuxiliaryConstants { // Noncompliant, implementation detail of WordPacker
   int BITS_PER_WORD = 16;
@@ -55,7 +55,7 @@ class WordPacker {
 }
 ----
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=2,diff-type=compliant]
 ----
 class WordPacker { // Compliant
   private static final int BITS_PER_WORD = 16;

--- a/rules/S1602/java/rule.adoc
+++ b/rules/S1602/java/rule.adoc
@@ -40,14 +40,14 @@ functional programming style and is regarded as more readable.
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=2,diff-type=noncompliant]
 ----
 x -> {System.out.println(x+1);} // Noncompliant, replace code block with statement
 ----
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=2,diff-type=compliant]
 ----
 x -> System.out.println(x+1)    // Compliant
 ----

--- a/rules/S2076/java/how-to-fix-it/java-se.adoc
+++ b/rules/S2076/java/how-to-fix-it/java-se.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 @Controller
 public class ExampleController
@@ -20,7 +20,7 @@ public class ExampleController
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 @Controller
 public class ExampleController

--- a/rules/S2157/java/rule.adoc
+++ b/rules/S2157/java/rule.adoc
@@ -57,7 +57,7 @@ If you require another copy behavior for some or all of the fields,
 for example, deep copy or certain invariants that need to be true for a field,
 these fields must be patched after `super.clone()`:
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=2,diff-type=compliant]
 ----
 class Entity implements Cloneable {
 
@@ -82,7 +82,7 @@ Be aware that the `Cloneable` / `Object.clone` approach has several drawbacks.
 You might, therefore, also consider resorting to other solutions,
 such as a custom `copy` method or a copy constructor:
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=2,diff-type=compliant]
 ----
 class Entity implements Cloneable {
 

--- a/rules/S2186/java/rule.adoc
+++ b/rules/S2186/java/rule.adoc
@@ -13,7 +13,7 @@ Assertions in `Runnable` tasks should be extracted or executed by the main threa
 === Code examples
 ==== Noncompliant code example
 
-[source,java,diff-id=1,type=noncompliant]
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 class RunnableWithAnAssertion extends Thread {
   @Override
@@ -33,7 +33,7 @@ class RunnableWithAnAssertion extends Thread {
 }
 ----
 ==== Compliant solution
-[source,java,diff-id=1,type=compliant]
+[source,java,diff-id=1,diff-type=compliant]
 ----
 class RunnableWithAnAssertion extends Thread {
   @Override
@@ -73,7 +73,7 @@ Remove this assertion.
 Note that Applicability is marked only for Tests
 
 === on 24 Nov 2014, 19:33:09 Nicolas Peru wrote:
-I am guessing here and so the answer should probably part of the RSPEC : The run method is a run method of a Thread class ? 
+I am guessing here and so the answer should probably part of the RSPEC : The run method is a run method of a Thread class ?
 
 === on 22 Apr 2015, 11:01:15 Ann Campbell wrote:
 Since you're already implementing this [~nicolas.peru], I'm guessing it's okay.

--- a/rules/S2230/java/rule.adoc
+++ b/rules/S2230/java/rule.adoc
@@ -12,7 +12,7 @@ Make the method public or remove the `@Transactional` annotation.
 === Code examples
 ==== Noncompliant code example
 
-[source,java,diff-id=1,type=noncompliant]
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 @Transactional  // Noncompliant
 void doTheThing(ArgClass arg) {
@@ -27,7 +27,7 @@ private void doTheOtherThing(ArgClass arg) {
 
 ==== Compliant solution
 
-[source,java,diff-id=1,type=compliant]
+[source,java,diff-id=1,diff-type=compliant]
 ----
 @Transactional
 public void doTheThing(ArgClass arg) {
@@ -72,7 +72,7 @@ Ok Ann, so I would replace :
 "Therefore marking a private method"
 
 
-by 
+by
 
 
 "Therefore marking for instance a private method"

--- a/rules/S2254/java/rule.adoc
+++ b/rules/S2254/java/rule.adoc
@@ -6,7 +6,7 @@ ____
 Returns the session ID specified by the client. This may not be the same as the ID of the current valid session for this request. If the client did not specify a session ID, this method returns null.
 ____
 
-The session ID it returns is either transmitted in a cookie or a URL parameter so by definition, nothing prevents the end-user from manually updating the value of this session ID in the HTTP request. 
+The session ID it returns is either transmitted in a cookie or a URL parameter so by definition, nothing prevents the end-user from manually updating the value of this session ID in the HTTP request.
 
 
 Here is an example of an updated HTTP header:
@@ -25,7 +25,7 @@ Moreover, this session ID should never be logged as is but logged using a one-wa
 
 === Noncompliant code example
 
-[source,java,diff-id=1,type=noncompliant]
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 if (isActiveSession(request.getRequestedSessionId())) {
   // ...

--- a/rules/S2272/java/rule.adoc
+++ b/rules/S2272/java/rule.adoc
@@ -6,7 +6,7 @@ Any other behavior when the iteration is done could lead to unexpected behavior 
 
 === Noncompliant code example
 
-[source,java,diff-id=1,type=noncompliant]
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 public class MyIterator implements Iterator<String> {
   ...
@@ -22,7 +22,7 @@ public class MyIterator implements Iterator<String> {
 
 === Compliant solution
 
-[source,java,diff-id=1,type=compliant]
+[source,java,diff-id=1,diff-type=compliant]
 ----
 public class MyIterator implements Iterator<String> {
   ...

--- a/rules/S2755/java/how-to-fix-it/jdom2.adoc
+++ b/rules/S2755/java/how-to-fix-it/jdom2.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 import org.jdom2.input.SAXBuilder;
 
@@ -17,12 +17,12 @@ public void decode() {
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import org.jdom2.input.SAXBuilder;
 
 public void decode() {
-    SAXBuilder builder = new SAXBuilder(); 
+    SAXBuilder builder = new SAXBuilder();
     builder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     builder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 }

--- a/rules/S3649/java/how-to-fix-it/java-se.adoc
+++ b/rules/S3649/java/how-to-fix-it/java-se.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 @RestController
 public class ApiController
@@ -38,7 +38,7 @@ public class ApiController
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 @RestController
 public class ApiController

--- a/rules/S3649/java/how-to-fix-it/spring-jdbc.adoc
+++ b/rules/S3649/java/how-to-fix-it/spring-jdbc.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=21,diff-type=noncompliant]
 ----
 @RestController
 public class ApiController
@@ -37,7 +37,7 @@ public class ApiController
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=21,diff-type=compliant]
 ----
 @RestController
 public class ApiController

--- a/rules/S4423/java/how-to-fix-it/okhttp.adoc
+++ b/rules/S4423/java/how-to-fix-it/okhttp.adoc
@@ -5,7 +5,7 @@
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 import okhttp3.ConnectionSpec;
 import okhttp3.TlsVersion;
@@ -19,7 +19,7 @@ public static void main(String[] args) {
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import okhttp3.ConnectionSpec;
 import okhttp3.TlsVersion;

--- a/rules/S5131/java/how-to-fix-it/servlet.adoc
+++ b/rules/S5131/java/how-to-fix-it/servlet.adoc
@@ -9,7 +9,7 @@ If embedded in HTML code, it should be HTML-encoded to prevent the injection of 
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 public void endpoint(HttpServletRequest request, HttpServletResponse response) throws IOException
 {
@@ -22,7 +22,7 @@ public void endpoint(HttpServletRequest request, HttpServletResponse response) t
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import org.owasp.encoder.Encode;
 
@@ -41,7 +41,7 @@ For example, setting the content-type to `text/plain` with the `setContentType` 
 
 ==== Noncompliant code example
 
-[source,java,diff-id=2,diff-type=noncompliant]
+[source,java,diff-id=12,diff-type=noncompliant]
 ----
 public void endpoint(HttpServletRequest request, HttpServletResponse response) throws IOException
 {
@@ -54,7 +54,7 @@ public void endpoint(HttpServletRequest request, HttpServletResponse response) t
 
 ==== Compliant solution
 
-[source,java,diff-id=2,diff-type=compliant]
+[source,java,diff-id=12,diff-type=compliant]
 ----
 public void endpoint(HttpServletRequest request, HttpServletResponse response) throws IOException
 {

--- a/rules/S5131/java/how-to-fix-it/spring.adoc
+++ b/rules/S5131/java/how-to-fix-it/spring.adoc
@@ -9,7 +9,7 @@ For example, you can use the `produces` property of the `GetMapping` annotation.
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=21,diff-type=noncompliant]
 ----
 @RestController
 public class ApiController
@@ -24,7 +24,7 @@ public class ApiController
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=21,diff-type=compliant]
 ----
 @RestController
 public class ApiController

--- a/rules/S5131/java/how-to-fix-it/thymeleaf.adoc
+++ b/rules/S5131/java/how-to-fix-it/thymeleaf.adoc
@@ -8,7 +8,7 @@ User input embedded in HTML code should be HTML-encoded to prevent the injection
 
 ==== Noncompliant code example
 
-[source,html,diff-id=1,diff-type=noncompliant]
+[source,html,diff-id=31,diff-type=noncompliant]
 ----
 <body>
     <p th:utext="Hello, ${input}!" /> <!-- Noncompliant -->
@@ -18,7 +18,7 @@ User input embedded in HTML code should be HTML-encoded to prevent the injection
 
 ==== Compliant solution
 
-[source,html,diff-id=1,diff-type=compliant]
+[source,html,diff-id=31,diff-type=compliant]
 ----
 <body>
     <p th:text="Hello, ${input}!" />

--- a/rules/S5527/java/how-to-fix-it/java-ee.adoc
+++ b/rules/S5527/java/how-to-fix-it/java-ee.adoc
@@ -11,7 +11,7 @@ include::../../common/fix/code-rationale-explicit.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 import java.util.Properties;
 
@@ -23,14 +23,14 @@ public Properties prepareEmailConnection() {
     props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory"); // Noncompliant
     props.put("mail.smtp.auth", "true");
     props.put("mail.smtp.port", "465");
-    
+
     return props;
 }
 ----
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import java.util.Properties;
 
@@ -43,7 +43,7 @@ public Properties prepareEmailConnection() {
     props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
     props.put("mail.smtp.auth", "true");
     props.put("mail.smtp.port", "465");
-    
+
     return props;
 }
 ----

--- a/rules/S5527/java/how-to-fix-it/java-se.adoc
+++ b/rules/S5527/java/how-to-fix-it/java-se.adoc
@@ -10,7 +10,7 @@ include::../../common/fix/code-rationale-override.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=21,diff-type=noncompliant]
 ----
 import java.io.InputStream;
 import java.net.URL;
@@ -35,7 +35,7 @@ public InputStream doRequest() {
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=21,diff-type=compliant]
 ----
 import java.io.InputStream;
 import java.net.URL;

--- a/rules/S5659/java/how-to-fix-it/jjwt.adoc
+++ b/rules/S5659/java/how-to-fix-it/jjwt.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 import io.jsonwebtoken.Jwts;
 
@@ -17,7 +17,7 @@ public void encode() {
 }
 ----
 
-[source,java,diff-id=2,diff-type=noncompliant]
+[source,java,diff-id=12,diff-type=noncompliant]
 ----
 import io.jsonwebtoken.Jwts;
 
@@ -31,7 +31,7 @@ public void decode() {
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import io.jsonwebtoken.Jwts;
 
@@ -46,7 +46,7 @@ public void encode() {
 When using `Jwts.parser()`, make sure to call `parseClaimsJws` instead of `parse`
 as it throws exceptions for invalid or missing signatures.
 
-[source,java,diff-id=2,diff-type=compliant]
+[source,java,diff-id=12,diff-type=compliant]
 ----
 import io.jsonwebtoken.Jwts;
 

--- a/rules/S5883/java/how-to-fix-it/java-se.adoc
+++ b/rules/S5883/java/how-to-fix-it/java-se.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 @Controller
 public class ExampleController
@@ -21,7 +21,7 @@ public class ExampleController
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 @Controller
 public class ExampleController

--- a/rules/S6398/java/how-to-fix-it/gson.adoc
+++ b/rules/S6398/java/how-to-fix-it/gson.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 import com.google.gson.Gson;
 
@@ -21,7 +21,7 @@ public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOExc
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;

--- a/rules/S6398/java/how-to-fix-it/java-se.adoc
+++ b/rules/S6398/java/how-to-fix-it/java-se.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=21,diff-type=noncompliant]
 ----
 import org.json.JSONObject;
 
@@ -23,7 +23,7 @@ public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOExc
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=21,diff-type=compliant]
 ----
 import org.json.JSONObject;
 


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` and `diff-id` were fixed. 

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).