### PR TITLE
Diff blocks: fix some incorrect use for javascript

### DIFF
--- a/rules/S1314/javascript/rule.adoc
+++ b/rules/S1314/javascript/rule.adoc
@@ -4,21 +4,21 @@ include::../description.adoc[]
 
 Additionally, these literals will throw SyntaxError in strict mode. 0-prefixed octal literals have been deprecated since ECMAScript 5 and should not be used in modern JavaScript code.
 
-[source,javascript,diff-id=1,diff=type=noncompliant]
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 const myNumber = 010; // Noncompliant: Deprecated format
 ----
 
 Use decimal syntax when possible as it is more readable.
 
-[source,javascript,diff-id=1,diff=type=compliant]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 const myNumber = 8;
 ----
 
 If octal notation is required, use the standard syntax: a leading zero followed by a lowercase or uppercase Latin letter "O" (`0o` or `0O`).
 
-[source,javascript,diff-id=1,diff=type=compliant]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 const myNumber = 0o10;
 ----

--- a/rules/S2076/javascript/how-to-fix-it/ssh2.adoc
+++ b/rules/S2076/javascript/how-to-fix-it/ssh2.adoc
@@ -6,12 +6,12 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 const { Client } = require('ssh2')
 
 const conn = new Client()
-    
+
 conn.on('ready', () => {
     conn.exec(req.query.cmd, (err, stream) => {}) // Noncompliant
 })
@@ -25,7 +25,7 @@ conn.connect({
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const { Client } = require('ssh2')
 const shell = require('shell-escape-tag')

--- a/rules/S2083/javascript/how-to-fix-it/node.adoc
+++ b/rules/S2083/javascript/how-to-fix-it/node.adoc
@@ -8,7 +8,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 const path = require('path');
 const fs   = require('fs');
@@ -23,7 +23,7 @@ function (req, res) {
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const path = require('path');
 const fs   = require('fs');

--- a/rules/S2999/javascript/rule.adoc
+++ b/rules/S2999/javascript/rule.adoc
@@ -8,7 +8,7 @@ To create a new instance of an object using the constructor function, you use th
 
 The ``++new++`` keyword should only be used with objects that define a constructor function. Attempting to use it with an object or a variable that is not a constructor will raise a ``++TypeError++``.
 
-[source,javascript,diff-id=1;diff-type=noncompliant]
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 function MyClass() {
   this.foo = 'bar';
@@ -16,13 +16,13 @@ function MyClass() {
 
 const someClass = 1;
 
-const obj1 = new someClass;    // Noncompliant: someClass is a variable 
+const obj1 = new someClass;    // Noncompliant: someClass is a variable
 const obj2 = new MyClass();    // Noncompliant if parameter considerJSDoc is true. Compliant when considerJSDoc is false
 ----
 
 Always use the ``++new++`` keyword with constructor functions or classes.
 
-[source,javascript,diff-id=1;diff-type=compliant]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 /**
  * @constructor

--- a/rules/S3649/javascript/how-to-fix-it/sequelize.adoc
+++ b/rules/S3649/javascript/how-to-fix-it/sequelize.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 async function index(req, res) {
     const { db, User } = req.app.get('sequelize');
@@ -25,7 +25,7 @@ async function index(req, res) {
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 async function index(req, res) {
     const { db, User, QueryTypes } = req.app.get('sequelize');

--- a/rules/S4423/javascript/how-to-fix-it/node-js.adoc
+++ b/rules/S4423/javascript/how-to-fix-it/node-js.adoc
@@ -10,7 +10,7 @@ are used and are used in other third-party libraries as well.
 
 The first is `secureProtocol`:
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 const https = require('node:https');
 const tls   = require('node:tls');
@@ -26,7 +26,7 @@ let socket = tls.connect(443, "www.example.com", options, () => { });
 The second is the combination of `minVersion` and `maxVerison`. Note that they
 cannot be specified along with the `secureProtocol` option:
 
-[source,javascript,diff-id=2,diff-type=noncompliant]
+[source,javascript,diff-id=12,diff-type=noncompliant]
 ----
 const https = require('node:https');
 const tls   = require('node:tls');
@@ -44,17 +44,17 @@ And `secureOptions`, which in this example instructs the OpenSSL protocol to
 turn off some algorithms altogether. In general, this option might trigger side
 effects and should be used carefully, if used at all.
 
-[source,javascript,diff-id=3,diff-type=noncompliant]
+[source,javascript,diff-id=13,diff-type=noncompliant]
 ----
 const https     = require('node:https');
 const tls       = require('node:tls');
 const constants = require('node:crypto'):
 
 let options = {
-  secureOptions: 
-    constants.SSL_OP_NO_SSLv2 
-    | constants.SSL_OP_NO_SSLv3 
-    | constants.SSL_OP_NO_TLSv1 
+  secureOptions:
+    constants.SSL_OP_NO_SSLv2
+    | constants.SSL_OP_NO_SSLv3
+    | constants.SSL_OP_NO_TLSv1
 }; // Noncompliant
 
 let req    = https.request(options, (res) => { });
@@ -63,7 +63,7 @@ let socket = tls.connect(443, "www.example.com", options, () => { });
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const https = require('node:https');
 const tls   = require('node:tls');
@@ -76,7 +76,7 @@ let req    = https.request(options, (res) => { });
 let socket = tls.connect(443, "www.example.com", options, () => { });
 ----
 
-[source,javascript,diff-id=2,diff-type=compliant]
+[source,javascript,diff-id=12,diff-type=compliant]
 ----
 const https = require('node:https');
 const tls   = require('node:tls');
@@ -94,16 +94,16 @@ let socket = tls.connect(443, "www.example.com", options, () => { });
 Here, the goal is to turn on only TLSv1.2 and higher, by turning off all lower
 versions:
 
-[source,javascript,diff-id=3,diff-type=compliant]
+[source,javascript,diff-id=13,diff-type=compliant]
 ----
 const https = require('node:https');
 const tls   = require('node:tls');
 
 let options = {
-  secureOptions: 
-    constants.SSL_OP_NO_SSLv2 
-    | constants.SSL_OP_NO_SSLv3 
-    | constants.SSL_OP_NO_TLSv1 
+  secureOptions:
+    constants.SSL_OP_NO_SSLv2
+    | constants.SSL_OP_NO_SSLv3
+    | constants.SSL_OP_NO_TLSv1
     | constants.SSL_OP_NO_TLSv1_1
 };
 

--- a/rules/S4830/javascript/how-to-fix-it/request.adoc
+++ b/rules/S4830/javascript/how-to-fix-it/request.adoc
@@ -12,7 +12,7 @@ include::../../common/fix/code-rationale-setting.adoc[]
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 const request = require('request');
 
@@ -25,7 +25,7 @@ let socket = request.get({
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const request = require('request');
 

--- a/rules/S5147/javascript/how-to-fix-it/mongoose.adoc
+++ b/rules/S5147/javascript/how-to-fix-it/mongoose.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 const mongoose = require('mongoose');
 
@@ -19,7 +19,7 @@ function(req, res) {
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const mongoose = require('mongoose');
 

--- a/rules/S5334/javascript/how-to-fix-it/node.adoc
+++ b/rules/S5334/javascript/how-to-fix-it/node.adoc
@@ -7,7 +7,7 @@ runs JavaScript code built from untrusted data.
 
 ==== Noncompliant code example
 
-[source,javascript,diff-id=1,diff-type=noncompliant]
+[source,javascript,diff-id=11,diff-type=noncompliant]
 ----
 function (req, res) {
     let operation = req.query.operation
@@ -18,7 +18,7 @@ function (req, res) {
 
 ==== Compliant solution
 
-[source,javascript,diff-id=1,diff-type=compliant]
+[source,javascript,diff-id=11,diff-type=compliant]
 ----
 const allowed = ["add", "remove", "update"]
 
@@ -36,4 +36,4 @@ include::../../common/fix/parameters.adoc[]
 
 include::../../common/fix/allowlist.adoc[]
 
-The example compliant code uses such a binding approach. 
+The example compliant code uses such a binding approach.

--- a/rules/S6439/javascript/rule.adoc
+++ b/rules/S6439/javascript/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Logical AND (`&&`) operator is sometimes used to conditionally render in React (aka short-circuit evaluation). For example, `myCondition && <MyElement />` will return `<MyElement />` if `myCondition` is `true` and `false` otherwise. 
+Logical AND (`&&`) operator is sometimes used to conditionally render in React (aka short-circuit evaluation). For example, `myCondition && <MyElement />` will return `<MyElement />` if `myCondition` is `true` and `false` otherwise.
 
 React considers `false` as a 'hole' in the JSX tree, just like `null` or `undefined`, and doesn't render anything in its place. But if the condition has a `falsy` non-boolean value (e.g. `0`), that value will leak into the rendered result.
 
@@ -8,7 +8,7 @@ This rule will report when the condition has type `number` or `bigint`.
 
 In the case of React Native, the type `string` will also raise an error, as your render method will crash if you render `0`, `''`, or `NaN`.
 
-[source,javascript,diff-id=1,type=noncompliant]
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 function Profile(props) {
   return <div>
@@ -18,9 +18,9 @@ function Profile(props) {
 }
 ----
 
-Instead, make the left-hand side a boolean to avoid accidental renderings. 
+Instead, make the left-hand side a boolean to avoid accidental renderings.
 
-[source,javascript,diff-id=1,type=compliant]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 function Profile(props) {
   return <div>
@@ -32,7 +32,7 @@ function Profile(props) {
 
 Another alternative to achieve conditional rendering is using the ternary operator (`myCondition ? <MyElement /> : null`), which is less error-prone in this case as both return values are explicit.
 
-[source,javascript,diff-id=1,type=compliant]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 function Profile(props) {
   return <div>


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` were fixed. 

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).