### PR TITLE
Diff blocks: fix some incorrect use for php

### DIFF
--- a/rules/S2076/php/how-to-fix-it/symfony.adoc
+++ b/rules/S2076/php/how-to-fix-it/symfony.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 public function unsafe(Request $request): JsonResponse
 {
@@ -19,7 +19,7 @@ public function unsafe(Request $request): JsonResponse
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 public function safe(Request $request): JsonResponse
 {

--- a/rules/S2078/php/how-to-fix-it/symfony.adoc
+++ b/rules/S2078/php/how-to-fix-it/symfony.adoc
@@ -7,7 +7,7 @@ concatenated to an LDAP query without prior sanitization or validation.
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 use Symfony\Component\Ldap\Ldap;
 use Symfony\Component\Ldap\LdapInterface;
@@ -25,7 +25,7 @@ private function userLookup(Ldap $conn, Request $request)
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 use Symfony\Component\Ldap\Ldap;
 use Symfony\Component\Ldap\LdapInterface;
@@ -46,7 +46,7 @@ private function userLookup(Ldap $conn, Request $request)
 include::../../common/fix/validation.adoc[]
 
 For Symfony, the LDAP component method
-https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Ldap/LdapInterface.php#L45[`escape`] allows sanitizing these characters. 
+https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Ldap/LdapInterface.php#L45[`escape`] allows sanitizing these characters.
 
 In the compliant solution example, the
 `Ldap::escape` method is used with the `ESCAPE_FILTER` flag, which sanitizes potentially malicious characters in the search filter. The function can also be used with the

--- a/rules/S3649/php/how-to-fix-it/laravel.adoc
+++ b/rules/S3649/php/how-to-fix-it/laravel.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 namespace App\Http\Controllers;
 
@@ -36,7 +36,7 @@ class UserController extends Controller
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 namespace App\Http\Controllers;
 

--- a/rules/S4830/php/how-to-fix-it/curl.adoc
+++ b/rules/S4830/php/how-to-fix-it/curl.adoc
@@ -23,7 +23,7 @@ curl_close($curl);
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=1,diff-type=compliant]
 ----
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_URL, 'https://example.com/');

--- a/rules/S5131/php/how-to-fix-it/laravel.adoc
+++ b/rules/S5131/php/how-to-fix-it/laravel.adoc
@@ -9,14 +9,14 @@ For example, you can use the `json` method of the `Response` class to safely ret
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 $response = response(json_encode(['data' => $input]), 200);
 ----
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 $response = response()->json(['data' => $input]);
 ----
@@ -25,14 +25,14 @@ It is also possible to set the content-type header manually using the `header` m
 
 ==== Noncompliant code example
 
-[source,php,diff-id=2,diff-type=noncompliant]
+[source,php,diff-id=12,diff-type=noncompliant]
 ----
 $response = response($input, 200);
 ----
 
 ==== Compliant solution
 
-[source,php,diff-id=2,diff-type=compliant]
+[source,php,diff-id=12,diff-type=compliant]
 ----
 $response = response($input, 200)->header('Content-Type', 'text/plain');
 ----

--- a/rules/S5131/php/how-to-fix-it/symfony.adoc
+++ b/rules/S5131/php/how-to-fix-it/symfony.adoc
@@ -9,7 +9,7 @@ For example, you can use the class `JsonResponse` to return JSON messages safely
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=21,diff-type=noncompliant]
 ----
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,7 +19,7 @@ $response->setContent(json_encode(['data' => $input]));
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=21,diff-type=compliant]
 ----
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -30,7 +30,7 @@ It is also possible to set the content-type manually using the `headers` attribu
 
 ==== Noncompliant code example
 
-[source,php,diff-id=2,diff-type=noncompliant]
+[source,php,diff-id=22,diff-type=noncompliant]
 ----
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,7 +40,7 @@ $response->setContent($input);
 
 ==== Compliant solution
 
-[source,php,diff-id=2,diff-type=compliant]
+[source,php,diff-id=22,diff-type=compliant]
 ----
 use Symfony\Component\HttpFoundation\Response;
 

--- a/rules/S5135/php/how-to-fix-it/laminas.adoc
+++ b/rules/S5135/php/how-to-fix-it/laminas.adoc
@@ -7,7 +7,7 @@ deserializes HTTP data without validating it first.
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 $serializer = new Adapter\PhpSerialize();
 $session = $serializer->unserialize($_COOKIE['session']); // Noncompliant
@@ -18,7 +18,7 @@ return new ViewModel([
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 $serializer = new Adapter\Json();
 $session = $serializer->unserialize($_COOKIE['session']);
@@ -33,7 +33,7 @@ include::../../common/fix/introduction.adoc[]
 
 include::../../common/fix/safer-serialization.adoc[]
 
-The example compliant code uses the `Json` adapter to perform the 
+The example compliant code uses the `Json` adapter to perform the
 deserialization. This one will not carry out any automatic object instantiation
 and is thus safer than its `PhpSerialize` counterpart.
 

--- a/rules/S5144/php/how-to-fix-it/guzzle.adoc
+++ b/rules/S5144/php/how-to-fix-it/guzzle.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 use GuzzleHttp\Client;
 
@@ -20,7 +20,7 @@ $client->request('GET', $url); // Noncompliant
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 use GuzzleHttp\Client;
 

--- a/rules/S5146/php/how-to-fix-it/laravel.adoc
+++ b/rules/S5146/php/how-to-fix-it/laravel.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 Route::get('/router', function () {
     $route = Input::get('route');
@@ -16,7 +16,7 @@ Route::get('/router', function () {
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 Route::get('/router', function () {
     $route = Input::get('route');

--- a/rules/S5146/php/how-to-fix-it/symfony.adoc
+++ b/rules/S5146/php/how-to-fix-it/symfony.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=21,diff-type=noncompliant]
 ----
 function route(): RedirectResponse {
     $route = $request->get('route');
@@ -16,7 +16,7 @@ function route(): RedirectResponse {
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=21,diff-type=compliant]
 ----
 function route(): RedirectResponse {
     $route = $request->get('route');

--- a/rules/S5542/php/how-to-fix-it/openssl.adoc
+++ b/rules/S5542/php/how-to-fix-it/openssl.adoc
@@ -6,7 +6,7 @@
 
 include::../../common/fix/aes-noncompliant-example.adoc[]
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 openssl_encrypt($plaintext, "BF-ECB", $key, $options=OPENSSL_RAW_DATA, $iv); // Noncompliant
 ----
@@ -15,7 +15,7 @@ openssl_encrypt($plaintext, "BF-ECB", $key, $options=OPENSSL_RAW_DATA, $iv); // 
 
 include::../../common/fix/aes-compliant-example.adoc[]
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 openssl_encrypt($plaintext, "aes-256-gcm", $key, $options=OPENSSL_RAW_DATA, $iv);
 ----

--- a/rules/S5547/php/how-to-fix-it/openssl.adoc
+++ b/rules/S5547/php/how-to-fix-it/openssl.adoc
@@ -6,14 +6,14 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 openssl_encrypt($plaintext, "des-ofb", $key, $options=OPENSSL_RAW_DATA, $iv); // Noncompliant
 ----
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 openssl_encrypt($plaintext, "aes-256-gcm", $key, $options=OPENSSL_RAW_DATA, $iv);
 ----

--- a/rules/S6287/php/how-to-fix-it/laravel.adoc
+++ b/rules/S6287/php/how-to-fix-it/laravel.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=11,diff-type=noncompliant]
 ----
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
@@ -23,7 +23,7 @@ Route::get("/checkcookie", function (Request $request) {
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=11,diff-type=compliant]
 ----
 use Illuminate\Http\Request;
 

--- a/rules/S6287/php/how-to-fix-it/symfony.adoc
+++ b/rules/S6287/php/how-to-fix-it/symfony.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,php,diff-id=1,diff-type=noncompliant]
+[source,php,diff-id=21,diff-type=noncompliant]
 ----
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +28,7 @@ public function checkCookie(Request $request): Response
 
 ==== Compliant solution
 
-[source,php,diff-id=1,diff-type=compliant]
+[source,php,diff-id=21,diff-type=compliant]
 ----
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` were fixed. 

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).