### PR TITLE
Diff blocks: fix incorrect use for swift

### DIFF
--- a/rules/S5547/swift/how-to-fix-it/cryptoswift.adoc
+++ b/rules/S5547/swift/how-to-fix-it/cryptoswift.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,swift,diff-id=1,diff-type=noncompliant]
+[source,swift,diff-id=21,diff-type=noncompliant]
 ----
 import CryptoSwift
 
@@ -15,7 +15,7 @@ let blowfish = try Blowfish(key: key, blockMode: GCM(iv: iv, mode: .combined), p
 
 ==== Compliant solution
 
-[source,swift,diff-id=1,diff-type=compliant]
+[source,swift,diff-id=21,diff-type=compliant]
 ----
 import CryptoSwift
 

--- a/rules/S5547/swift/how-to-fix-it/idzswiftcommoncrypto.adoc
+++ b/rules/S5547/swift/how-to-fix-it/idzswiftcommoncrypto.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,swift,diff-id=1,diff-type=noncompliant]
+[source,swift,diff-id=31,diff-type=noncompliant]
 ----
 import IDZSwiftCommonCrypto
 
@@ -15,7 +15,7 @@ let algorithm = .des // Noncompliant
 
 ==== Compliant solution
 
-[source,swift,diff-id=1,diff-type=compliant]
+[source,swift,diff-id=31,diff-type=compliant]
 ----
 import IDZSwiftCommonCrypto
 


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.