### PR TITLE
Diff blocks: fix some incorrect use for terraform

### DIFF
--- a/rules/S4423/terraform/how-to-fix-it/aws-opensearch.adoc
+++ b/rules/S4423/terraform/how-to-fix-it/aws-opensearch.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,terraform,diff-id=1,diff-type=noncompliant]
+[source,terraform,diff-id=21,diff-type=noncompliant]
 ----
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "example"
@@ -17,7 +17,7 @@ resource "aws_elasticsearch_domain" "example" {
 
 ==== Compliant solution
 
-[source,terraform,diff-id=1,diff-type=compliant]
+[source,terraform,diff-id=21,diff-type=compliant]
 ----
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "example"

--- a/rules/S4423/terraform/how-to-fix-it/azure-mssql.adoc
+++ b/rules/S4423/terraform/how-to-fix-it/azure-mssql.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,terraform,diff-id=1,diff-type=noncompliant]
+[source,terraform,diff-id=31,diff-type=noncompliant]
 ----
 resource "azurerm_mssql_server" "example" {
   name = "example"
@@ -16,7 +16,7 @@ resource "azurerm_mssql_server" "example" {
 
 ==== Compliant solution
 
-[source,terraform,diff-id=1,diff-type=compliant]
+[source,terraform,diff-id=31,diff-type=compliant]
 ----
 resource "azurerm_mssql_server" "example" {
   name = "example"

--- a/rules/S4423/terraform/how-to-fix-it/gcp-lb.adoc
+++ b/rules/S4423/terraform/how-to-fix-it/gcp-lb.adoc
@@ -4,7 +4,7 @@
 
 ==== Noncompliant code example
 
-[source,terraform,diff-id=1,diff-type=noncompliant]
+[source,terraform,diff-id=41,diff-type=noncompliant]
 ----
 resource "google_compute_ssl_policy" "example" {
   name            = "example"
@@ -14,7 +14,7 @@ resource "google_compute_ssl_policy" "example" {
 
 ==== Compliant solution
 
-[source,terraform,diff-id=1,diff-type=compliant]
+[source,terraform,diff-id=41,diff-type=compliant]
 ----
 resource "google_compute_ssl_policy" "example" {
   name            = "example"


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule. 

---

NB: this does not fix _all_ incorrect use of diff blocks, cf. CI log (once #2790 is merged).