### PR TITLE
Diff blocks: fix incorrect use for vbnet

### DIFF
--- a/rules/S3904/vbnet/rule.adoc
+++ b/rules/S3904/vbnet/rule.adoc
@@ -6,7 +6,7 @@ include::../why.adoc[]
 
 ==== Noncompliant code example
 
-[source,vbnet,diff-id=1,diff=type=noncompliant]
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 Imports System.Reflection
 <Assembly: AssemblyTitle("MyAssembly")> ' Noncompliant
@@ -17,7 +17,7 @@ End Namespace
 
 ==== Compliant solution
 
-[source,vbnet,diff-id=1,diff=type=compliant]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 Imports System.Reflection
 <Assembly: AssemblyTitle("MyAssembly")>

--- a/rules/S5547/vbnet/how-to-fix-it/dot-net.adoc
+++ b/rules/S5547/vbnet/how-to-fix-it/dot-net.adoc
@@ -6,7 +6,7 @@ include::../../common/fix/code-rationale.adoc[]
 
 ==== Noncompliant code example
 
-[source,vbnet,diff-id=1,diff-type=noncompliant]
+[source,vbnet,diff-id=11,diff-type=noncompliant]
 ----
 Imports System.Security.Cryptography
 
@@ -17,7 +17,7 @@ End Sub
 
 ==== Compliant solution
 
-[source,vbnet,diff-id=1,diff-type=compliant]
+[source,vbnet,diff-id=11,diff-type=compliant]
 ----
 Imports System.Security.Cryptography
 


### PR DESCRIPTION
Improvement identified in #2790.

Add a prefix to the diff-id when it is used multiple times in different "how to fix it in XYZ" sections to avoid ambiguity and pedantically follow the spec:

>  A single and unique diff-id should be used only once for each type of code example as shown in the description of a rule.

Obvious typos around `diff-type` were fixed.