### PR TITLE
Modify rule S6416: Also check for IllegalStateException

### DIFF
--- a/rules/S6416/java/metadata.json
+++ b/rules/S6416/java/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Calls to methods should not trigger an IllegalArgumentException",
+  "title": "Calls to methods should not trigger an exception",
   "type": "BUG",
   "code": {
     "impacts": {

--- a/rules/S6416/java/rule.adoc
+++ b/rules/S6416/java/rule.adoc
@@ -1,10 +1,15 @@
 == Why is this an issue?
 
-It's common for methods to check the value of their parameters and throw an `IllegalArgumentException`
-when one of them doesn't match a given condition.
+It is common for methods to check the value of their parameters or the state of
+their associated object and throw an exception when one of them does not match a
+given condition.
 Those conditions are usually mentioned in the javadoc of the method.
 
-This rule raises an issue when it detects that a method call has an argument which will trigger an `IllegalArgumentException`.
+This rule raises an issue when it detects that a method call will trigger one of
+the following exceptions:
+
+* `java.lang.IllegalArgumentException`,
+* `java.lang.IllegalStateException`.
 
 
 === Noncompliant code example


### PR DESCRIPTION
`IllegalStateException`s are thrown in situations very similar to `IllegalArgumentException`, except that they usually depend on conditions regarding the fields of an object instead of a method's parameters.

This PR adjusts the rule to include `IllegalStateException` as DBD is currently working on an implementation of said extension. 

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

