### PR TITLE
Modify S3466,S3598,S3927(vbnet): Fix diff typos

### DIFF
--- a/rules/S3466/vbnet/rule.adoc
+++ b/rules/S3466/vbnet/rule.adoc
@@ -6,7 +6,7 @@ include::../description.adoc[]
 
 ==== Noncompliant code example
 
-[source,vbnet,diff-id=1,diff-type=noncompliant]]
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 Public Class BaseClass
     Public Overridable Sub MyMethod(ByVal Optional i As Integer = 1)
@@ -31,7 +31,7 @@ End Class
 
 ==== Compliant solution
 
-[source,vbnet,diff-id=1,diff-type=compliant]]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 Public Class BaseClass
     Public Overridable Sub MyMethod(ByVal Optional i As Integer = 1)

--- a/rules/S3598/vbnet/rule.adoc
+++ b/rules/S3598/vbnet/rule.adoc
@@ -19,7 +19,7 @@ End Interface
 
 ==== Compliant solution
 
-[source,vbnet,diff-id=1,diff-type=noncompliant]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 <ServiceContract>
 Interface IMyService

--- a/rules/S3927/vbnet/rule.adoc
+++ b/rules/S3927/vbnet/rule.adoc
@@ -34,7 +34,7 @@ End Class
 
 ==== Compliant solution
 
-[source,vbnet,diff-id=1,diff-type=noncompliant]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 <Serializable>
 Public Class Foo


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

