### PR TITLE
Use new link format for secret resources

### DIFF
--- a/shared_content/secrets/resources/standards.adoc
+++ b/shared_content/secrets/resources/standards.adoc
@@ -1,5 +1,5 @@
 === Standards
 
-* https://cwe.mitre.org/data/definitions/798[MITRE] - CWE-798 - Use of Hard-coded Credentials
-* https://cwe.mitre.org/data/definitions/259[MITRE] - CWE-259 - Use of Hard-coded Password
-* https://www.sans.org/top25-software-errors/#cat3[SANS] - TOP 25 Most Dangerous Software Errors
+* MITRE - https://cwe.mitre.org/data/definitions/798[CWE-798 - Use of Hard-coded Credentials]
+* MITRE - https://cwe.mitre.org/data/definitions/259[CWE-259 - Use of Hard-coded Password]
+* SANS - https://www.sans.org/top25-software-errors/#cat3[TOP 25 Most Dangerous Software Errors]


### PR DESCRIPTION
To comply with https://github.com/SonarSource/rspec/blob/master/docs/link_formatting.adoc.