### PR TITLE
Modify rule S3034: added some missing backticks

### DIFF
--- a/rules/S3034/java/rule.adoc
+++ b/rules/S3034/java/rule.adoc
@@ -2,7 +2,7 @@
 
 In Java, numeric promotions happen when two operands of an arithmetic expression have different sizes.
 More specifically, narrower operands get promoted to the type of wider operands.
-For instance, an operation between a byte and an `int`, will trigger a promotion of the byte operand, converting it into an `int`.
+For instance, an operation between a `byte` and an `int`, will trigger a promotion of the `byte` operand, converting it into an `int`.
 
 When this happens, the sequence of 8 bits that represents the `byte` will need to be extended to match the 32-bit long sequence that represents the `int` operand.
 Since Java uses two's complement notation for signed number types, the promotion will fill the missing leading bits with zeros or ones, depending on the sign of the value.
@@ -15,7 +15,7 @@ When performing shifting or bitwise operations without considering that bytes ar
 This rule raises an issue any time a `byte` value is used as an operand combined with shifts without being masked.
 
 To prevent such accidental value conversions, you can mask promoted bytes to only consider the least significant 8 bits.
-Masking can be achieved with the bitwise AND operator `&` and the appropriate mask of `0xff` (255 in decimal and 0b1111_1111 in binary) or, since Java 8, with the more convenient `Byte.toUnsignedInt(byte b)` or `Byte.toUnsignedLong(byte b)`.
+Masking can be achieved with the bitwise AND operator `&` and the appropriate mask of `0xff` (255 in decimal and `0b1111_1111` in binary) or, since Java 8, with the more convenient `Byte.toUnsignedInt(byte b)` or `Byte.toUnsignedLong(byte b)`.
 
 === Code examples
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

