### PR TITLE
Diff blocks: fix incorrect use for cfamily

### DIFF
--- a/rules/S1265/cfamily/rule.adoc
+++ b/rules/S1265/cfamily/rule.adoc
@@ -24,7 +24,7 @@ Each override of the `operator new` should have a matching overridden `operator 
 
 Imagine a custom allocator `MyAllocator`:
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp]
 ----
 class MyAllocator {
 public:

--- a/rules/S3584/cfamily/rule.adoc
+++ b/rules/S3584/cfamily/rule.adoc
@@ -107,7 +107,7 @@ bool fire(Point pos, Direction dir, State const& s) {
 
 Use a local object
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 bool fire(Point pos, Direction dir, State const& s) {
   Bullet bullet{pos, dir};


### PR DESCRIPTION
Fix the remaining issues in cfamily.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

