### PR TITLE
Diff blocks: fix incorrect use for kotlin

### DIFF
--- a/rules/S6632/kotlin/rule.adoc
+++ b/rules/S6632/kotlin/rule.adoc
@@ -46,7 +46,7 @@ myCustomExtension.flag = true
 
 
 **./buildSrc/src/main/kotlin/mypackage/MyCustomTask.kt**
-[source,kotlin,diff-id=1,diff-type=compliant]
+[source,kotlin]
 ----
 package mypackage
 
@@ -58,7 +58,7 @@ open class MyCustomTask : DefaultTask() {
 ----
 
 **./buildSrc/src/main/kotlin/mypackage/MyCustomExtension.kt**
-[source,kotlin,diff-id=1,diff-type=compliant]
+[source,kotlin]
 ----
 package mypackage
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

