### PR TITLE
Fix rule coverage on a rule page: include all rule keys to metadata

### DIFF
--- a/frontend/src/deployment/__tests__/metadata.test.ts
+++ b/frontend/src/deployment/__tests__/metadata.test.ts
@@ -278,4 +278,34 @@ describe('metadata generation', () => {
       });
     });
   });
+
+  test('allKeys include the sqKey overridden in all languages', () => {
+    return withTestDir((srcPath) => {
+      createFiles(srcPath, {
+        'S100/metadata.json': JSON.stringify({
+          sqKey: 'S100',
+        }),
+        'S100/java/metadata.json': JSON.stringify({
+          sqKey: 'S100-Java'
+        }),
+        'S100/python/metadata.json': JSON.stringify({
+          sqKey: 'S100-python'
+        }),
+      });
+      return withTestDir(async (dstPath) => {
+        generateRulesMetadata(srcPath, dstPath);
+        const javaStrMetadata = fs.readFileSync(`${dstPath}/S100/java-metadata.json`);
+        const javaMetadata = JSON.parse(javaStrMetadata.toString());
+        expect(javaMetadata).toMatchObject({
+          allKeys: ['S100-Java', 'S100-python', 'S100']
+        });
+
+        const pythonStrMetadata = fs.readFileSync(`${dstPath}/S100/python-metadata.json`);
+        const pythonMetadata = JSON.parse(pythonStrMetadata.toString());
+        expect(pythonMetadata).toMatchObject({
+          allKeys: ['S100-Java', 'S100-python', 'S100']
+        });
+      });
+    });
+  });
 });

--- a/frontend/src/deployment/metadata.ts
+++ b/frontend/src/deployment/metadata.ts
@@ -69,7 +69,16 @@ export function generateOneRuleMetadata(srcDir: string, dstDir: string, branch: 
   const languageSupports =
     allMetadata.map(m => ({ name: m.language, status: m.metadata.status } as LanguageSupport));
 
-  const allKeys = getAllKeys(allMetadata);
+  // Needed to fetch the sqKey, that might be overridden with a legacy key in each language
+  const genericMetadata = getRuleMetadata(srcDir);
+  var metadatasWithAllKeys = [...allMetadata];
+
+  // The rule directory might contain an empty metadata.json
+  if ('sqKey' in genericMetadata) {
+    metadatasWithAllKeys.push({ 'language': 'default', 'metadata': genericMetadata });
+  }
+
+  const allKeys = getAllKeys(metadatasWithAllKeys);
   allMetadata.forEach(({ metadata }) => {
     metadata.allKeys = allKeys;
     if (prUrl) {

--- a/frontend/src/deployment/metadata.ts
+++ b/frontend/src/deployment/metadata.ts
@@ -71,7 +71,7 @@ export function generateOneRuleMetadata(srcDir: string, dstDir: string, branch: 
 
   // Needed to fetch the sqKey, that might be overridden with a legacy key in each language
   const genericMetadata = getRuleMetadata(srcDir);
-  var metadatasWithAllKeys = [...allMetadata];
+  let metadatasWithAllKeys = [...allMetadata];
 
   // The rule directory might contain an empty metadata.json
   if ('sqKey' in genericMetadata) {


### PR DESCRIPTION
For some rules, rule-specific metadata.json overridden the `sqKey` for all languages, so when the predeployment script collected all keys, it did not list the actual, most canonical key "S****".
This leads to the incorrect display of coverage information on a rule page that relies on the `allKeys` precomputed property to retrieve the version of the analyzer that implements the rule.

The fix includes the generic rule metadata.json file into the aggregator that computes `allKeys`, thus propagating it to every language-specific metadata.