### PR TITLE
Modify rule S935: Fix ruleSpecification value in metadata

### DIFF
--- a/rules/S935/python/metadata.json
+++ b/rules/S935/python/metadata.json
@@ -18,7 +18,7 @@
     ]
   },
   "defaultSeverity": "Blocker",
-  "ruleSpecification": "RSPEC-S935",
+  "ruleSpecification": "RSPEC-935",
   "sqKey": "S935",
   "scope": "All",
   "defaultQualityProfiles": [


### PR DESCRIPTION
There was an "S" in front of the rule number in the "ruleSpecification" value for the python version of the rule. I.e. "RSPEC-S935" -> "RSPEC-935".

This caused problems with the deployment of the rules marketing website: http://rules.sonarsource.com/

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

