### PR TITLE
Modify rule S5899: Add exception on public static method that return data

### DIFF
--- a/rules/S5899/php/rule.adoc
+++ b/rules/S5899/php/rule.adoc
@@ -3,7 +3,7 @@
 The PHPUnit test runner does execute public methods defined within test classes that have a name starting with _"test"_ or the _@test_ annotation. Methods that do not convey to this will not get executed. 
 
 
-This rule raises an issue on methods marked as test methods (by name or annotation) but do not have a public visibility. An issue is also raised on public methods that are not marked as tests, do contain assertions, and are not called from within another discoverable test method within the class. No issues are raised in abstract classes. 
+This rule raises an issue on methods marked as test methods (by name or annotation) but do not have a public visibility. An issue is also raised on public methods that are not marked as tests, do contain assertions, and are not called from within another discoverable test method within the class. No issues are raised in abstract classes, or on public static method which provides data.
 
 
 === Noncompliant code example


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

