### PR TITLE
Modify rule S107: Do not count TypeScript parameter properties

### DIFF
--- a/rules/S107/javascript/rule.adoc
+++ b/rules/S107/javascript/rule.adoc
@@ -4,17 +4,17 @@ include::../rule.adoc[]
 
 === Exceptions
 
-The rule ignores constructors where parameters are *all* parameter properties:
+The rule ignores TypeScript parameter properties when counting parameters:
 
 [source,javascript]
 ----
 class C {
   constructor(
-    private param1: number,
-    private param2: boolean,
-    private param3: string,
-    private param4: string[],
-    private param5: number | string
+    private param1: number,     // ignored
+    param2: boolean,            // counted
+    public param3: string,      // ignored
+    readonly param4: string[],  // ignored
+    param5: number | string     // counted
   ) {} // Compliant by exception
 }
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

