### PR TITLE
APPSEC-843 Modify S3329: Mention FIPS-compliant PRNG

### DIFF
--- a/rules/S3329/common/fix/fix.adoc
+++ b/rules/S3329/common/fix/fix.adoc
@@ -6,7 +6,7 @@ criteria:
 * IVs must be unique for each encryption operation.
 * For CBC and CFB modes, a secure FIPS-compliant random number generator should be used to generate unpredictable IVs.
 
-The IV need not be secret, so the IV or information sufficient to determine the
+The IV does not need be secret, so the IV or information sufficient to determine the
 IV may be transmitted along with the ciphertext.
 
 In the previous non-compliant example, the problem is not that the IV is

--- a/rules/S3329/common/fix/fix.adoc
+++ b/rules/S3329/common/fix/fix.adoc
@@ -1,8 +1,14 @@
 ==== Use unique IVs
 
-To ensure strong security, the initialization vectors for each encryption operation 
-must be unique and random but they do not have to be secret.
+To ensure high security, initialization vectors must meet two important
+criteria:
 
-In the previous non-compliant example, the problem is not that the IV is hard-coded. +
+* IVs must be unique for each encryption operation.
+* For CBC and CFB modes, a secure FIPS-compliant random number generator should be used to generate unpredictable IVs.
+
+The IV need not be secret, so the IV or information sufficient to determine the
+IV may be transmitted along with the ciphertext.
+
+In the previous non-compliant example, the problem is not that the IV is
+hard-coded. +
 It is that the same IV is used for multiple encryption attempts.
-


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

