### PR TITLE
cyn/modify-S2696-layc-ltypo

### DIFF
--- a/rules/S2696/csharp/rule.adoc
+++ b/rules/S2696/csharp/rule.adoc
@@ -2,7 +2,7 @@ This rule raises an issue each time a `static` field is updated from a non-stati
 
 == Why is this an issue?
 
-Updating a `static` field from a non-`static` method introduces ignificant challenges and potential bugs. Multiple class instances and threads can access and modify the `static` field concurrently, leading to unintended consequences for other instances or threads (unexpected behavior, https://www.c-sharpcorner.com/UploadFile/1d42da/race-conditions-in-threading-C-Sharp/[race conditions] and synchronization problems).
+Updating a `static` field from a non-`static` method introduces significant challenges and potential bugs. Multiple class instances and threads can access and modify the `static` field concurrently, leading to unintended consequences for other instances or threads (unexpected behavior, https://www.c-sharpcorner.com/UploadFile/1d42da/race-conditions-in-threading-C-Sharp/[race conditions] and synchronization problems).
 
 [source,csharp]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

