### PR TITLE
S2931: fix spacing

### DIFF
--- a/rules/S2931/rule.adoc
+++ b/rules/S2931/rule.adoc
@@ -1,57 +1,53 @@
 == Why is this an issue?
 
-An ``++IDisposable++`` object should be disposed (there are some rare exceptions where not disposing is fine, most notably ``++Task++``). If a class has an ``++IDisposable++`` field, there can be two situations:
+An `IDisposable` object should be disposed (there are some rare exceptions where not disposing is fine, most notably `Task`). If a class has an `IDisposable` field, there can be two situations:
 
 * The class observes a field that is under the responsibility of another class. 
-* The class owns the field, and is therefore responsible for calling ``++Dispose++`` on it.
+* The class owns the field, and is therefore responsible for calling `Dispose` on it.
 
-In the second case, the safest way for the class to ensure ``++Dispose++`` is called is to call it in its own ``++Dispose++`` function, and therefore to be itself ``++IDisposable++``. A class is considered to own an ``++IDisposable++`` field resource if it created the object referenced by the field.
-
+In the second case, the safest way for the class to ensure `Dispose` is called is to call it in its own `Dispose` function, and therefore to be itself `IDisposable`. A class is considered to own an `IDisposable` field resource if it created the object referenced by the field.
 
 === Noncompliant code example
 
-[source,text]
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 public class ResourceHolder   // Noncompliant; doesn't implement IDisposable
 {
-  private FileStream fs;  // This member is never Disposed
-  public void OpenResource(string path)
-  {
-    this.fs = new FileStream(path, FileMode.Open); // I create the FileStream, I'm owning it
-  }
-  public void CloseResource()
-  {
-    this.fs.Close();
-  }
+    private FileStream fs;  // This member is never Disposed
+    public void OpenResource(string path)
+    {
+        this.fs = new FileStream(path, FileMode.Open); // I create the FileStream, I'm owning it
+    }
+    public void CloseResource()
+    {
+        this.fs.Close();
+    }
 }
 ----
 
-
 === Compliant solution
 
-[source,text]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 public class ResourceHolder : IDisposable 
-{ 
-  private FileStream fs; 
-  public void OpenResource(string path) 
-  { 
-    this.fs = new FileStream(path, FileMode.Open); // I create the FileStream, I'm owning it
-  } 
-  public void CloseResource() 
-  { 
-    this.fs.Close(); 
-  } 
+{
+    private FileStream fs; 
+    public void OpenResource(string path) 
+    { 
+        this.fs = new FileStream(path, FileMode.Open); // I create the FileStream, I'm owning it
+    } 
+    public void CloseResource() 
+    { 
+        this.fs.Close(); 
+    } 
 
-  public void Dispose() 
-  { 
-    this.fs.Dispose(); 
-  } 
+    public void Dispose() 
+    { 
+        this.fs.Dispose(); 
+    } 
 } 
 ----
-
 
 == Resources
 
 * https://cwe.mitre.org/data/definitions/459[MITRE, CWE-459] - Incomplete Cleanup
-

--- a/rules/S2931/rule.adoc
+++ b/rules/S2931/rule.adoc
@@ -39,8 +39,7 @@ public class ResourceHolder : IDisposable
     public void CloseResource() 
     { 
         this.fs.Close(); 
-    } 
-
+    }
     public void Dispose() 
     { 
         this.fs.Dispose(); 


### PR DESCRIPTION
Fixing tabs on Compliant solution snippet (it was showing `$nbsp;`)

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

