### PR TITLE
Modify rule S3588: Expand and adjust for LaYC

### DIFF
--- a/rules/S3588/cfamily/metadata.json
+++ b/rules/S3588/cfamily/metadata.json
@@ -36,5 +36,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }

--- a/rules/S3588/cfamily/rule.adoc
+++ b/rules/S3588/cfamily/rule.adoc
@@ -1,46 +1,147 @@
-== Why is this an issue?
-
 Using the value of a pointer to a ``++FILE++`` object after the associated file is closed is undefined behavior.
 
+== Why is this an issue?
 
-=== Noncompliant code example
+Once a file has been closed, its corresponding ``++FILE*++`` typed variable becomes invalid and the stream may no longer be accessed through this variable.
+In particular, a pointer to a ``++FILE++`` object may not be passed to ``++fclose++`` more than once.
+
+Using the value of a pointer to a ``++FILE++`` object after the associated file is closed results in undefined behavior.
 
 [source,cpp]
 ----
-void fun() {
-  FILE * pFile;
-  pFile = fopen(fileName, "w");
+#include <stdio.h>
+#include <stdlib.h>
 
-  if (condition) {
-    fclose(pFile);
-    // ...
+int process_file(int print) {
+  FILE *f = fopen("example.txt", "r");
+  if (!f) {
+    perror("fopen() failed");
+    return 1;
   }
 
-  fclose(pFile); // Noncompliant, the file has already been closed
+  if (print) {
+    char buffer[256];
+    while (fgets(buffer, 256, f)) {
+      printf("%s", buffer);
+    }
+    fclose(f);
+  }
+
+  // Further processing ...
+
+  fclose(f); // Noncompliant: file associated with `f` might already be closed.
+  return 0;
 }
 ----
 
+== What is the potential impact?
 
-=== Compliant solution
+If a pointer to a ``++FILE++`` object is used after the associated file is closed, the behavior of the application is undefined.
 
-[source,cpp]
+When a program comprises undefined behavior, the compiler no longer needs to adhere to the language standard, and the program has no meaning assigned to it.
+The application might just crash, but in the worst case, the application may appear to execute correctly, while losing data or producing incorrect results.
+
+
+== How to fix it
+
+Do not use the value of a pointer to a ``++FILE++`` object after the associated file has been closed.
+
+
+=== Code examples
+
+==== Noncompliant code examples
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-void fun() {
-  FILE * pFile;
-  pFile = fopen(fileName, "w");
+#include <stdio.h>
+#include <stdlib.h>
 
-  if (condition) {
-    // ...
+int process_file(int print) {
+  FILE *f = fopen("example.txt", "r");
+  if (!f) {
+    perror("fopen() failed");
+    return 1;
   }
 
-  fclose(pFile);
+  if (print) {
+    char buffer[256];
+    while (fgets(buffer, 256, f)) {
+      printf("%s", buffer);
+    }
+    fclose(f);
+  }
+
+  fclose(f); // Noncompliant: file associated with `f` might already be closed.
+  return 0;
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+#include <stdio.h>
+#include <stdlib.h>
+
+int process_file(int print) {
+  FILE *f = fopen("example.txt", "r");
+  if (!f) {
+    perror("fopen() failed");
+    return 1;
+  }
+
+  if (print) {
+    char buffer[256];
+    while (fgets(buffer, 256, f)) {
+      printf("%s", buffer);
+    }
+  }
+
+  if (fclose(f) == EOF) { // Compliant: file associated with `f` is closed only once.
+    return 1;
+  }
+  return 0;
+}
+----
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
+#include <stdio.h>
+
+int close_stdout() {
+  if (fclose(stdout) == EOF) {
+    return 1;
+  }
+  printf("closed stdout stream!\n"); // Noncompliant: `printf` uses stdout, which was closed.
+  return 0;
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+#include <stdio.h>
+
+int close_stdout() {
+  if (fclose(stdout) == EOF) {
+    return 1;
+  }
+  fprintf(stderr, "closed stdout stream!\n"); // Compliant: printing to `stderr` is fine.
+  return 0;
 }
 ----
 
 
 == Resources
 
-* https://wiki.sei.cmu.edu/confluence/x/QdUxBQ[CERT, FIO46-C.] - Do not access a closed file
+=== Standards
+
+* CERT - https://wiki.sei.cmu.edu/confluence/x/QdUxBQ[FIO46-C. Do not access a closed file]
+
+
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3588/cfamily/rule.adoc
+++ b/rules/S3588/cfamily/rule.adoc
@@ -49,7 +49,7 @@ Do not use the value of a pointer to a ``++FILE++`` object after the associated 
 
 === Code examples
 
-==== Noncompliant code examples
+==== Noncompliant code example
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

