### PR TITLE
Modify rule S2589: fix missing diff-id

### DIFF
--- a/rules/S2589/vbnet/rule.adoc
+++ b/rules/S2589/vbnet/rule.adoc
@@ -48,7 +48,7 @@ The conditions should be reviewed to decide whether:
 
 ==== Noncompliant code example
 
-[source,vbnet,diff-type=noncompliant]
+[source,vbnet,diff-id=1,diff-type=noncompliant]
 ----
 Public Sub Sample(ByVal b As Boolean, ByVal c As Boolean)
     Dim a = True
@@ -73,7 +73,7 @@ End Sub
 ==== Compliant solution
 
 
-[source,vbnet,diff-type=compliant]
+[source,vbnet,diff-id=1,diff-type=compliant]
 ----
 Public Sub Sample(ByVal b As Boolean, ByVal c As Boolean, ByVal s As String)
     Dim a = IsAllowed()


### PR DESCRIPTION
Related to [this discuss post](https://discuss.sonarsource.com/t/layc-diff-view-validation/15392/2?u=antonio.aversa).

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

