### PR TITLE
Modify rule S3776: use default remediation

### DIFF
--- a/rules/S3776/csharp/metadata.json
+++ b/rules/S3776/csharp/metadata.json
@@ -1,8 +1,4 @@
 {
   "title": "Cognitive Complexity of methods should not be too high",
-  "remediation": {
-    "func": "Constant\/Issue",
-    "constantCost": "10min"
-  },
   "quickfix": "infeasible"
 }

--- a/rules/S3776/vbnet/metadata.json
+++ b/rules/S3776/vbnet/metadata.json
@@ -1,8 +1,4 @@
 {
-    "title": "Cognitive Complexity of methods should not be too high",
-    "remediation": {
-      "func": "Constant\/Issue",
-      "constantCost": "10min"
-    },    
+    "title": "Cognitive Complexity of methods should not be too high", 
     "quickfix": "infeasible"
 }


### PR DESCRIPTION
Use default remediation, similar to the other rules.

Current default remediation is:
```
"remediation": {
  "func": "Linear with offset",
  "linearDesc": "per complexity point over the threshold",
  "linearOffset": "5min",
  "linearFactor": "1min"
},
```

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

