### PR TITLE
Modify rule S2259: Expand and adjust for LaYC

### DIFF
--- a/rules/S2259/cfamily/metadata.json
+++ b/rules/S2259/cfamily/metadata.json
@@ -15,5 +15,6 @@
     "CWE": [
       476
     ]
-  }
+  },
+  "quickfix": "infeasible"
 }

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -14,7 +14,7 @@ int deref() {
 ----
 
 In addition to using the `*` operator, accessing a member of a structure (using `->`) or an element of an array (using `[]`) also leads to dereference of the pointer,
-and cause undefined behavior if performed on a pointer to null.
+and causes undefined behavior if performed on a pointer to null.
 
 [source,c]
 ----

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -2,7 +2,7 @@ Dereferencing a null pointer results in undefined behavior.
 
 == Why is this an issue?
 
-A pointer to null, also known as a null pointer, is created by initializing a pointer object to `0`, `NULL`, or in case of C++ `nullptr`.
+A pointer to null, also known as a null pointer, is created by initializing a pointer object to `0`, `NULL`, or in the case of C++ `nullptr`.
 A null pointer does neither point to an object nor to valid memory, and as a consequence dereferencing or accessing the memory pointed by such a pointer is undefined behavior.
 
 [source,c]
@@ -37,18 +37,18 @@ int memberAccess() {
 }
 ----
 
-Finally, invoking a function pointer that holds a null value, dereferences the pointer and too results in undefined behavior.
+Finally, invoking a function pointer that holds a null value, dereferences the pointer, and too results in undefined behavior.
 [source,c]
 ----
 void call() {
   void (*func)(int) = NULL; // func is a pointer to a function
-  func(10); // Noncompliant: invocation of a null function pointer 
+  func(10); // Noncompliant: the invocation of a null function pointer 
 }
 ----
 
 == What is the potential impact?
 
-The behavior of a program that deferences a null pointer results in undefined behavior, 
+A deference a null pointer results in undefined behavior, 
 In that case, the compiler no longer needs to adhere to the language standard
 and the program has no meaning assigned to it.
 

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -1,50 +1,142 @@
+Dereferencing a null pointer results in the undefined behavior.
+
 == Why is this an issue?
 
-include::../description.adoc[]
+A pointer to null, know also as null pointer, is created by initialzing a pointer object to `0`, `NULL` or in case of C++ `nullptr`.
+Such pointer does not point to object or valid memory, and as consequence dereferencing or accessing the memory pointed by such pointer has undefined behavior.
 
-=== Noncompliant code example
+[source,c]
+----
+int deref() {
+  int* ptr = 0;
+  return *ptr; // Noncompliant, deference of null pointer
+}
+----
 
-[source,cpp]
+In addition to using an `*` operator, accessing a member of the structure (using `->`) or element of array (using `[]`) leads to derefence of the pointer,
+and cause undefined behavior if performed on pointer to null.
+
+[source,c]
+----
+int subscript() {
+  int* ptr = 0;
+  return ptr[2]; // Noncompliant, subscript of null pointer
+}
+----
+
+[source,c]
+----
+struct Aggregate {
+  int x;
+  int y;
+};
+
+int memberAccess() {
+  struct Aggregate* ptr = 0;
+  return ptr->x; // Noncompliant, member access on null pointer
+}
+----
+
+Finally, invoking a function pointer that points to null, derefernces the pointer and results in undefined behavior.
+[source,c]
+----
+void call() {
+  void (*func)(int) = NULL; // func is pointer to function
+  func(10); // Noncompliant, invocation of null function pointer 
+}
+----
+
+== What is the potential impact?
+
+The behavior of program that deferences a null pointer results in undefined behavior, 
+in such case the compiler no longer needs to adhere to the language standard, 
+and the program has no meaning assigned to it.
+
+In practive derference of null pointer may lead to program crashes, or application may appear to execute correctly, while losing data or producing incorrect results.
+
+Besides affecting the application's availability, null pointer dereferences may lead to code execution, in rare circumstances.
+If null is equivalent to the ``++0x0++`` memory address that can be accessed by privileged code, writing and reading memory is possible, which compromises the integrity and confidentiality of the application.
+
+== Hot to fix it
+
+Ensure that any pointer that is dereferenced by the program _is not_ null.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,c,diff-id=1,diff-type=noncompliant]
 ----
 char *p1 = ... ;
 if (p1 == NULL && *p1 == '\t') { // Noncompliant, p1 will be dereferenced IFF it is null
   // ...
 }
-
-char *p2 = ... ;
-if (p2 != NULL) {
-    // ...
-}
-*p2 = '\t'; // Noncompliant; potential null-dereference
-
-char *p3, *p4;
-p3 = NULL;
-// ...
-p4 = p3;
-*p4 = 'a';  // Noncompliant
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,cpp]
+[source,c,diff-id=1,diff-type=compliant]
 ----
 char *p1 = ... ;
 if (p1 != NULL && *p1 == '\t') { // Compliant, *p1 cannot be evaluated when p1 is NULL
   // ...
 }
+----
 
+==== Noncompliant code example
+
+[source,c,diff-id=2,diff-type=noncompliant]
+----
 char *p2 = ... ;
 if (p2 != NULL) {
     // ...
-  *p2 = '\t'; // Compliant
+}
+p2[2] = '\t'; // Noncompliant; potential null-dereference
+----
+
+==== Compliant solution
+
+[source,c,diff-id=2,diff-type=compliant]
+----
+char *p2 = ... ;
+if (p2 != NULL) {
+    // ...
+  p2[2] = '\t'; // Compliant
 }
 ----
 
+=== Going the extra mile
+
+In {cpp}, is is preffered to use reference perameter (`Type const&` or `Type&`), or passing object by value (`Type`),
+instead of pointer (`Type const*` or `Type*`), when the argument is expected to never be null.
+
+[source,cpp]
+----
+// Precondition: graph != null
+bool isDAG(Graph const* graph);
+---- 
+
+The prefered signature would be:
+
+[source,cpp]
+----
+bool isDAG(Graph const& graph);
+---- 
+
+
 == Resources
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
-* https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[CERT, EXP34-C.] - Do not dereference null pointers
-* https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
+=== Standards
+
+* CERT - https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[EXP34-C.Do not dereference null pointers]
+* CERT - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[EXP01-J.Do not use a null in a case where an object is required]
+* CWE - https://cwe.mitre.org/data/definitions/476[476 NULL Pointer Dereference]
+
+=== Related rules
+
+* S3807 detects passing of null pointer to of C-library function that requies valid pointer
+* S2637 detects passing of null pointer as argument for parameter that is annotated with `nonnull`
+
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -48,7 +48,7 @@ void call() {
 
 == What is the potential impact?
 
-A deference a null pointer results in undefined behavior, 
+The behavior of a program that dereferences a null pointer is undefined.
 In that case, the compiler no longer needs to adhere to the language standard
 and the program has no meaning assigned to it.
 

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -1,26 +1,26 @@
-Dereferencing a null pointer results in the undefined behavior.
+Dereferencing a null pointer results in undefined behavior.
 
 == Why is this an issue?
 
-A pointer to null, known also as a null pointer, is created by initializing a pointer object to `0`, `NULL`, or in the case of C++ `nullptr`.
-Such a pointer does not point to an object or valid memory, and as a consequence dereferencing or accessing the memory pointed by such a pointer has undefined behavior.
+A pointer to null, also known as a null pointer, is created by initializing a pointer object to `0`, `NULL`, or in case of C++ `nullptr`.
+A null pointer does neither point to an object nor to valid memory, and as a consequence dereferencing or accessing the memory pointed by such a pointer is undefined behavior.
 
 [source,c]
 ----
 int deref() {
   int* ptr = 0;
-  return *ptr; // Noncompliant, deference of null pointer
+  return *ptr; // Noncompliant: deference of a null pointer
 }
 ----
 
-In addition to using an `*` operator, accessing a member of the structure (using `->`) or element of an array (using `[]`) leads to dereference of the pointer,
+In addition to using the `*` operator, accessing a member of a structure (using `->`) or an element of an array (using `[]`) also leads to dereference of the pointer,
 and cause undefined behavior if performed on a pointer to null.
 
 [source,c]
 ----
 int subscript() {
   int* ptr = 0;
-  return ptr[2]; // Noncompliant, subscript of null pointer
+  return ptr[2]; // Noncompliant: subscript operator used on null pointer
 }
 ----
 
@@ -33,31 +33,31 @@ struct Aggregate {
 
 int memberAccess() {
   struct Aggregate* ptr = 0;
-  return ptr->x; // Noncompliant, member access on a null pointer
+  return ptr->x; // Noncompliant: member access on a null pointer
 }
 ----
 
-Finally, invoking a function pointer that points to null, dereferences the pointer and results in undefined behavior.
+Finally, invoking a function pointer that holds a null value, dereferences the pointer and too results in undefined behavior.
 [source,c]
 ----
 void call() {
-  void (*func)(int) = NULL; // func is pointer to function
-  func(10); // Noncompliant, invocation of null function pointer 
+  void (*func)(int) = NULL; // func is a pointer to a function
+  func(10); // Noncompliant: invocation of a null function pointer 
 }
 ----
 
 == What is the potential impact?
 
 The behavior of a program that deferences a null pointer results in undefined behavior, 
-In such case the compiler no longer needs to adhere to the language standard, 
+In that case, the compiler no longer needs to adhere to the language standard
 and the program has no meaning assigned to it.
 
-In practice dereference of null pointer may lead to program crashes, or the application may appear to execute correctly while losing data or producing incorrect results.
+In practice, dereferencing a null pointer may lead to program crashes, or the application may appear to execute correctly while losing data or producing incorrect results.
 
 Besides affecting the application's availability, null pointer dereferences may lead to code execution, in rare circumstances.
 If null is equivalent to the ``++0x0++`` memory address that can be accessed by privileged code, writing, and reading memory is possible, which compromises the integrity and confidentiality of the application.
 
-== Hot to fix it
+== How to fix it
 
 Ensure that any pointer that is dereferenced by the program _is not_ null.
 
@@ -68,7 +68,7 @@ Ensure that any pointer that is dereferenced by the program _is not_ null.
 [source,c,diff-id=1,diff-type=noncompliant]
 ----
 char *p1 = ... ;
-if (p1 == NULL && *p1 == '\t') { // Noncompliant, p1 will be dereferenced IFF it is null
+if (p1 == NULL && *p1 == '\t') { // Noncompliant: p1 will be dereferenced IFF it is null
   // ...
 }
 ----
@@ -78,7 +78,7 @@ if (p1 == NULL && *p1 == '\t') { // Noncompliant, p1 will be dereferenced IFF it
 [source,c,diff-id=1,diff-type=compliant]
 ----
 char *p1 = ... ;
-if (p1 != NULL && *p1 == '\t') { // Compliant, *p1 cannot be evaluated when p1 is NULL
+if (p1 != NULL && *p1 == '\t') { // Compliant: *p1 cannot be evaluated if p1 is NULL
   // ...
 }
 ----
@@ -91,7 +91,7 @@ char *p2 = ... ;
 if (p2 != NULL) {
     // ...
 }
-p2[2] = '\t'; // Noncompliant; potential null-dereference
+p2[2] = '\t'; // Noncompliant: potential null-dereference
 ----
 
 ==== Compliant solution
@@ -101,14 +101,14 @@ p2[2] = '\t'; // Noncompliant; potential null-dereference
 char *p2 = ... ;
 if (p2 != NULL) {
     // ...
-  p2[2] = '\t'; // Compliant
+  p2[2] = '\t'; // Compliant: p2 is known to be non-null
 }
 ----
 
 === Going the extra mile
 
-In {cpp}, it is preferred to use reference parameter (`Type const&` or `Type&`), or passing object by value (`Type`),
-instead of a pointer (`Type const*` or `Type*`), when the argument is expected to never be null.
+In {cpp}, it is preferred to use reference parameters (`Type const&` or `Type&`), or pass objects by value (`Type`),
+instead of a pointer (`Type const*` or `Type*`), if the argument is expected to never be null.
 
 [source,cpp]
 ----
@@ -134,8 +134,8 @@ bool isDAG(Graph const& graph);
 
 === Related rules
 
-* S3807 detects calling a C library function that requires valid pointer, with a null pointer an argument
-* S2637 detects passing of null pointer as an argument for a parameter that is annotated with `nonnull`
+* S3807 detects calls to C library functions that require valid, non-null pointers with null pointer arguments
+* S2637 detects uses of null pointers as arguments for parameters that are annotated with `nonnull`
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2259/cfamily/rule.adoc
+++ b/rules/S2259/cfamily/rule.adoc
@@ -2,8 +2,8 @@ Dereferencing a null pointer results in the undefined behavior.
 
 == Why is this an issue?
 
-A pointer to null, know also as null pointer, is created by initialzing a pointer object to `0`, `NULL` or in case of C++ `nullptr`.
-Such pointer does not point to object or valid memory, and as consequence dereferencing or accessing the memory pointed by such pointer has undefined behavior.
+A pointer to null, known also as a null pointer, is created by initializing a pointer object to `0`, `NULL`, or in the case of C++ `nullptr`.
+Such a pointer does not point to an object or valid memory, and as a consequence dereferencing or accessing the memory pointed by such a pointer has undefined behavior.
 
 [source,c]
 ----
@@ -13,8 +13,8 @@ int deref() {
 }
 ----
 
-In addition to using an `*` operator, accessing a member of the structure (using `->`) or element of array (using `[]`) leads to derefence of the pointer,
-and cause undefined behavior if performed on pointer to null.
+In addition to using an `*` operator, accessing a member of the structure (using `->`) or element of an array (using `[]`) leads to dereference of the pointer,
+and cause undefined behavior if performed on a pointer to null.
 
 [source,c]
 ----
@@ -33,11 +33,11 @@ struct Aggregate {
 
 int memberAccess() {
   struct Aggregate* ptr = 0;
-  return ptr->x; // Noncompliant, member access on null pointer
+  return ptr->x; // Noncompliant, member access on a null pointer
 }
 ----
 
-Finally, invoking a function pointer that points to null, derefernces the pointer and results in undefined behavior.
+Finally, invoking a function pointer that points to null, dereferences the pointer and results in undefined behavior.
 [source,c]
 ----
 void call() {
@@ -48,14 +48,14 @@ void call() {
 
 == What is the potential impact?
 
-The behavior of program that deferences a null pointer results in undefined behavior, 
-in such case the compiler no longer needs to adhere to the language standard, 
+The behavior of a program that deferences a null pointer results in undefined behavior, 
+In such case the compiler no longer needs to adhere to the language standard, 
 and the program has no meaning assigned to it.
 
-In practive derference of null pointer may lead to program crashes, or application may appear to execute correctly, while losing data or producing incorrect results.
+In practice dereference of null pointer may lead to program crashes, or the application may appear to execute correctly while losing data or producing incorrect results.
 
 Besides affecting the application's availability, null pointer dereferences may lead to code execution, in rare circumstances.
-If null is equivalent to the ``++0x0++`` memory address that can be accessed by privileged code, writing and reading memory is possible, which compromises the integrity and confidentiality of the application.
+If null is equivalent to the ``++0x0++`` memory address that can be accessed by privileged code, writing, and reading memory is possible, which compromises the integrity and confidentiality of the application.
 
 == Hot to fix it
 
@@ -107,8 +107,8 @@ if (p2 != NULL) {
 
 === Going the extra mile
 
-In {cpp}, is is preffered to use reference perameter (`Type const&` or `Type&`), or passing object by value (`Type`),
-instead of pointer (`Type const*` or `Type*`), when the argument is expected to never be null.
+In {cpp}, it is preferred to use reference parameter (`Type const&` or `Type&`), or passing object by value (`Type`),
+instead of a pointer (`Type const*` or `Type*`), when the argument is expected to never be null.
 
 [source,cpp]
 ----
@@ -116,7 +116,7 @@ instead of pointer (`Type const*` or `Type*`), when the argument is expected to 
 bool isDAG(Graph const* graph);
 ---- 
 
-The prefered signature would be:
+The preferred signature would be:
 
 [source,cpp]
 ----
@@ -134,8 +134,8 @@ bool isDAG(Graph const& graph);
 
 === Related rules
 
-* S3807 detects passing of null pointer to of C-library function that requies valid pointer
-* S2637 detects passing of null pointer as argument for parameter that is annotated with `nonnull`
+* S3807 detects calling a C library function that requires valid pointer, with a null pointer an argument
+* S2637 detects passing of null pointer as an argument for a parameter that is annotated with `nonnull`
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2259/description.adoc
+++ b/rules/S2259/description.adoc
@@ -1,1 +1,0 @@
-A pointer to null (the 0 memory address) should never be dereferenced/accessed. Doing so will at best cause abrupt program termination, without the ability to run any cleanup processes. At worst, it could expose debugging information that would be useful to an attacker or it could allow an attacker to bypass security measures.

--- a/rules/S3807/cfamily/rule.adoc
+++ b/rules/S3807/cfamily/rule.adoc
@@ -149,6 +149,10 @@ wmemchr, wmemcmp, wmemcpy, wmemmove, wmemcpy, wmemset, write, writev
 * CWE - https://cwe.mitre.org/data/definitions/476[476 NULL Pointer Dereference]
 * CERT - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[EXP01-J. Do not use a null in a case where an object is required]
 
+=== Related rules
+
+* S2259 detects dereferences of null pointer
+* S2637 detects passing of null pointer as argument for parameter that is annotated with `nonnull`
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3807/cfamily/rule.adoc
+++ b/rules/S3807/cfamily/rule.adoc
@@ -151,8 +151,8 @@ wmemchr, wmemcmp, wmemcpy, wmemmove, wmemcpy, wmemset, write, writev
 
 === Related rules
 
-* S2259 detects dereferences of null pointer
-* S2637 detects passing of null pointer as argument for parameter that is annotated with `nonnull`
+* S2259 detects dereferences of null pointers
+* S2637 detects uses of null pointers as arguments for parameters that are annotated with `nonnull`
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

