### PR TITLE
Modify rule S6326: Add support for quick fixes

### DIFF
--- a/rules/S6326/javascript/metadata.json
+++ b/rules/S6326/javascript/metadata.json
@@ -1,2 +1,3 @@
 {
+    "quickfix": "covered"
 }


### PR DESCRIPTION
Forgot to update the RSPEC while introducing quick fix support for S6326 in https://github.com/SonarSource/SonarJS/pull/4096