### PR TITLE
Modify S7000&S2091: Fix resource links

### DIFF
--- a/rules/S2091/common/resources/articles.adoc
+++ b/rules/S2091/common/resources/articles.adoc
@@ -1,4 +1,4 @@
 === Articles & blog posts
 
 * https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html#xpath-injection[OWASP, XPath Injection Prevention Cheat Sheet]
-* https://www.ambionics.io/blog/hacking-watchguard-firewalls#vulnerability-2-time-based-xpath-injection[Ambionics, XPath Injection Section of "Hacking WatchGuard Firewalls']
+* https://web.archive.org/web/20230602194100/https://www.ambionics.io/blog/hacking-watchguard-firewalls[Ambionics, XPath Injection Section of "Hacking WatchGuard Firewalls']

--- a/rules/S6700/secrets/rule.adoc
+++ b/rules/S6700/secrets/rule.adoc
@@ -49,7 +49,7 @@ include::../../../shared_content/secrets/resources/standards.adoc[]
 
 === Documentation
 
-* RapidAPI Documentation - https://docs.rapidapi.com/docs/keys#creating-or-rotating-a-rapid-api-key[Creating or rotating a Rapid API key]
-* RapidAPI Documentation - https://docs.rapidapi.com/docs/audit-trails[Audit Trails]
+* RapidAPI Documentation - https://web.archive.org/web/20230627151620/https://docs.rapidapi.com/docs/keys#creating-or-rotating-a-rapid-api-key[Creating or rotating a Rapid API key]
+* RapidAPI Documentation - https://web.archive.org/web/20230521051107/https://docs.rapidapi.com/docs/audit-trails [Audit Trails]
 
 //=== Benchmarks

--- a/rules/S6700/secrets/rule.adoc
+++ b/rules/S6700/secrets/rule.adoc
@@ -49,7 +49,7 @@ include::../../../shared_content/secrets/resources/standards.adoc[]
 
 === Documentation
 
-* RapidAPI Documentation - https://web.archive.org/web/20230627151620/https://docs.rapidapi.com/docs/keys#creating-or-rotating-a-rapid-api-key[Creating or rotating a Rapid API key]
-* RapidAPI Documentation - https://web.archive.org/web/20230521051107/https://docs.rapidapi.com/docs/audit-trails[Audit Trails]
+* RapidAPI Documentation - https://docs.rapidapi.com/docs/keys-and-key-rotation#creating-or-rotating-a-rapid-api-key[Creating or rotating a Rapid API key]
+* RapidAPI Documentation - https://docs.rapidapi.com/docs/org-audit-trails-teams[Audit Trails]
 
 //=== Benchmarks

--- a/rules/S6700/secrets/rule.adoc
+++ b/rules/S6700/secrets/rule.adoc
@@ -50,6 +50,6 @@ include::../../../shared_content/secrets/resources/standards.adoc[]
 === Documentation
 
 * RapidAPI Documentation - https://web.archive.org/web/20230627151620/https://docs.rapidapi.com/docs/keys#creating-or-rotating-a-rapid-api-key[Creating or rotating a Rapid API key]
-* RapidAPI Documentation - https://web.archive.org/web/20230521051107/https://docs.rapidapi.com/docs/audit-trails [Audit Trails]
+* RapidAPI Documentation - https://web.archive.org/web/20230521051107/https://docs.rapidapi.com/docs/audit-trails[Audit Trails]
 
 //=== Benchmarks


### PR DESCRIPTION
The ambionics link started to work again and I still kept the fix because the wayback machine is still always more reliable 