### PR TITLE
Modify rule S6661(Python): Fixing typo in title

### DIFF
--- a/rules/S6661/python/metadata.json
+++ b/rules/S6661/python/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Assignments of lambdas to variables should be replaced by function definitions.",
+  "title": "Assignments of lambdas to variables should be replaced by function definitions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

