### PR TITLE
Modify S4787: Delete

### DIFF
--- a/rules/S4787/csharp/metadata.json
+++ b/rules/S4787/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "status": "closed"
 }

--- a/rules/S4787/vbnet/metadata.json
+++ b/rules/S4787/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-    "status": "deprecated"
+    "status": "closed"
 }

--- a/rules/S4787/vbnet/metadata.json
+++ b/rules/S4787/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "status": "deprecated"
 }


### PR DESCRIPTION
Deleting S4787 as it has been deprecated.
Deprecated since:

sonar-dotnet 8.9.0.19135, released on Jun 26, 2020
SQ 8.4.0.35506 on Jul 3, 2020.