### PR TITLE
Modify rule S2612, S4423 (Go): fix diff-view errors

### DIFF
--- a/rules/S2612/go/rule.adoc
+++ b/rules/S2612/go/rule.adoc
@@ -40,7 +40,7 @@ func main() {
 
 For https://pkg.go.dev/os#Chmod[Chmod() in the `os` package]:
 
-[source,go,diff-id=1,diff-type=noncompliant]
+[source,go,diff-id=1,diff-type=compliant]
 ----
 import (
     "os"
@@ -56,7 +56,7 @@ func main() {
 
 For https://pkg.go.dev/syscall#Umask[`Umask()` in the `syscall` package]:
 
-[source,go,diff-id=2,diff-type=noncompliant]
+[source,go,diff-id=2,diff-type=compliant]
 ----
 import (
     "golang.org/x/sys/unix"

--- a/rules/S4423/go/how-to-fix-it/stdlib.adoc
+++ b/rules/S4423/go/how-to-fix-it/stdlib.adoc
@@ -30,7 +30,7 @@ func main() {
 
 For HTTP servers:
 
-[source,go,diff-id=1,diff-type=noncompliant]
+[source,go,diff-id=2,diff-type=noncompliant]
 ----
 import (
     "net/http"


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

