### PR TITLE
Deprecate rule S3884

### DIFF
--- a/rules/S3884/metadata.json
+++ b/rules/S3884/metadata.json
@@ -7,7 +7,7 @@
     },
     "attribute": "LOGICAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "20min"
@@ -44,7 +44,6 @@
     ]
   },
   "defaultQualityProfiles": [
-    "Sonar way"
   ],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

