### PR TITLE
CPP-4618 Consistent CCT attributes for rules similar to MISRA 2023

### DIFF
--- a/rules/S3743/cfamily/metadata.json
+++ b/rules/S3743/cfamily/metadata.json
@@ -5,7 +5,7 @@
     "impacts": {
       "MAINTAINABILITY": "HIGH"
     },
-    "attribute": "CONVENTIONAL"
+    "attribute": "LOGICAL"
   },
   "status": "ready",
   "remediation": {

--- a/rules/S836/cfamily/metadata.json
+++ b/rules/S836/cfamily/metadata.json
@@ -1,4 +1,10 @@
 {
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "LOGICAL"
+  },
   "tags": [
     "cwe",
     "symbolic-execution",

--- a/rules/S836/metadata.json
+++ b/rules/S836/metadata.json
@@ -1,12 +1,6 @@
 {
   "title": "Variables should be initialized before use",
   "type": "BUG",
-  "code": {
-    "impacts": {
-      "RELIABILITY": "MEDIUM"
-    },
-    "attribute": "CLEAR"
-  },
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/rules/S836/php/metadata.json
+++ b/rules/S836/php/metadata.json
@@ -1,4 +1,10 @@
 {
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  },
   "defaultQualityProfiles": [
     "Sonar way"
   ]

--- a/rules/S854/cfamily/metadata.json
+++ b/rules/S854/cfamily/metadata.json
@@ -5,7 +5,7 @@
     "impacts": {
       "MAINTAINABILITY": "HIGH"
     },
-    "attribute": "IDENTIFIABLE"
+    "attribute": "CLEAR"
   },
   "status": "ready",
   "remediation": {

--- a/rules/S859/cfamily/metadata.json
+++ b/rules/S859/cfamily/metadata.json
@@ -5,7 +5,7 @@
     "impacts": {
       "MAINTAINABILITY": "HIGH"
     },
-    "attribute": "CLEAR"
+    "attribute": "MODULAR"
   },
   "status": "ready",
   "remediation": {

--- a/rules/S877/cfamily/metadata.json
+++ b/rules/S877/cfamily/metadata.json
@@ -5,7 +5,7 @@
     "impacts": {
       "MAINTAINABILITY": "MEDIUM"
     },
-    "attribute": "LOGICAL"
+    "attribute": "CONVENTIONAL"
   },
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
Change the CCT attribute for some sonar rules such that they are consistent with the attribute chosen for similar MISRA 2023 rules. See the comments on the linked issue CPP-4618 for more details.
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

