### PR TITLE
APPSEC-1053 Validate S6648 ARM default value for secret

### DIFF
--- a/rules/S6648/azureresourcemanager/how-to-fix-it/bicep.adoc
+++ b/rules/S6648/azureresourcemanager/how-to-fix-it/bicep.adoc
@@ -15,5 +15,5 @@ param secureStringWithDefaultValue string = 'S3CR3T' // Noncompliant
 [source,bicep,diff-id=11,diff-type=compliant]
 ----
 @secure()
-param secureStringWithDefaultValue string
+param secureString string
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

