### PR TITLE
Modify rule S6597: "WORKDIR" instruction should be used instead of "cd" commands

### DIFF
--- a/rules/S6597/docker/metadata.json
+++ b/rules/S6597/docker/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "WORKDIR instruction should be used instead of cd command",
+  "title": "\"WORKDIR\" instruction should be used instead of \"cd\" commands",
   "type": "CODE_SMELL",
   "code": {
     "impacts": {

--- a/rules/S6597/docker/rule.adoc
+++ b/rules/S6597/docker/rule.adoc
@@ -18,6 +18,17 @@ RUN cd /tmp && \
 
 In this example, the first `cd /tmp` command can be replaced by `WORKDIR cd /tmp` put above `RUN`.
 The last `cd /app/bin` command can be replaced too.
+The result will be following:
+
+[source,docker]
+----
+WORKDIR /tmp
+RUN git clone myrepository.com/MyOrganization/project && \
+  cd project && \
+  make
+WORKDIR /app/bin
+----
+
 Those actions will reduce the length of the `RUN` instruction, which makes it easier to read and understand.
 Sometimes, it is hard to avoid the usage of `cd` command, especially in the middle of a long script.
 Removing them from the beginning and end of a multi-line is an easy improvement.
@@ -33,7 +44,7 @@ Following this recommendation provides a clear structure for Dockerfiles, making
 == How to fix it
 
 Where possible, ensure that all usages of `cd` commands are replaced by a `WORKDIR` instruction.
-`cd` commands at the beginning or end of multiline commands are a reliable sign, that they can be replaced.
+The `cd` commands at the beginning or end of multiline commands are a reliable sign, that they can be replaced.
 Also, using absolute paths can be considered for commands that accept them.
 
 === Code examples

--- a/rules/S6597/docker/rule.adoc
+++ b/rules/S6597/docker/rule.adoc
@@ -1,12 +1,38 @@
-The `cd` command should not be used to change the working directory.
-Instead `WORKDIR` should be used.
-
 == Why is this an issue?
 
-The `cd` commands in `RUN` (and other) instructions make them longer, harder to read, troubleshoot, and maintain.
-It is better to use the `WORKDIR` instruction to set a working directory for the next Docker instructions.
+In single Dockerfile instructions like `RUN`, `CMD`, and `ENTRYPOINT` multiple commands can be run, including changing directory `cd` command.
+Using `WORKDIR` instead reduces the complexity of the above instructions and makes them easy to read, understand, troubleshoot, and maintain.
+
+=== What is the potential impact?
+
+The Dockerfile instructions like `RUN` allow users to execute longer scripts. See the following example:
+
+[source,docker]
+----
+RUN cd /tmp && \
+  git clone myrepository.com/MyOrganization/project && \
+  cd project && \
+  make && \
+  cd /app/bin
+----
+
+In this example, the first `cd /tmp` command can be replaced by `WORKDIR cd /tmp` put above `RUN`.
+The last `cd /app/bin` command can be replaced too.
+Those actions will reduce the length of the `RUN` instruction, which makes it easier to read and understand.
+Sometimes, it is hard to avoid the usage of `cd` command, especially in the middle of a long script, but removing them from the beginning and end is straightforward.
+Additionally, most commands work well with absolute paths, so changing directories can be avoided very often.
+
+The `WORKDIR` instruction can be used multiple times in Dockerfile.
+It changes the current directory for next instructions (until the following change).
+This approach simplifies understanding of what is a current directory.
+
+The same principles apply to `CMD` and `ENTRYPOINT` instructions.
+Following this recommendation provides a clear structure for Dockerfiles, making it easier to maintain.
 
 == How to fix it
+
+Ensure that all usages of `cd` command are replaced by `WORKDIR` instruction, where possible.
+Also, using absolute paths can be considered for commands that accept them.
 
 === Code examples
 
@@ -25,14 +51,8 @@ WORKDIR app/bin
 RUN ./start.sh
 ----
 
-=== How does this work?
-
-The `WORKDIR` instruction can be used multiple times in Dockerfile.
-It sets the working directory for any `RUN`, `CMD`, `ENTRYPOINT`, `COPY`, and `ADD` instructions that follow.
-It increases clarity and reliability.
-
-
 == Resources
+
 === Documentation
 
 * https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#workdir[WORKDIR - Best practices for writing Dockerfiles]

--- a/rules/S6597/docker/rule.adoc
+++ b/rules/S6597/docker/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-In single Dockerfile instructions like `RUN`, `CMD`, and `ENTRYPOINT` multiple commands can be run, including changing directory `cd` command.
+In single Dockerfile instructions like `RUN`, `CMD`, and `ENTRYPOINT` multiple commands can be run, including the `cd` command for changing directories.
 Using `WORKDIR` instead reduces the complexity of the above instructions and makes them easy to read, understand, troubleshoot, and maintain.
 
 === What is the potential impact?
@@ -19,11 +19,12 @@ RUN cd /tmp && \
 In this example, the first `cd /tmp` command can be replaced by `WORKDIR cd /tmp` put above `RUN`.
 The last `cd /app/bin` command can be replaced too.
 Those actions will reduce the length of the `RUN` instruction, which makes it easier to read and understand.
-Sometimes, it is hard to avoid the usage of `cd` command, especially in the middle of a long script, but removing them from the beginning and end is straightforward.
-Additionally, most commands work well with absolute paths, so changing directories can be avoided very often.
+Sometimes, it is hard to avoid the usage of `cd` command, especially in the middle of a long script.
+Removing them from the beginning and end of a multi-line is an easy improvement.
+Additionally, a lot of commands work well with absolute paths, so changing directories can be avoided in most cases.
 
-The `WORKDIR` instruction can be used multiple times in Dockerfile.
-It changes the current directory for next instructions (until the following change).
+The `WORKDIR` instruction can be used multiple times in a Dockerfile.
+It changes the current directory for the next instructions and until there is a following change.
 This approach simplifies understanding of what is a current directory.
 
 The same principles apply to `CMD` and `ENTRYPOINT` instructions.
@@ -31,7 +32,8 @@ Following this recommendation provides a clear structure for Dockerfiles, making
 
 == How to fix it
 
-Ensure that all usages of `cd` command are replaced by `WORKDIR` instruction, where possible.
+Where possible, ensure that all usages of `cd` commands are replaced by a `WORKDIR` instruction.
+`cd` commands at the beginning or end of multiline commands are a reliable sign, that they can be replaced.
 Also, using absolute paths can be considered for commands that accept them.
 
 === Code examples


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

