### PR TITLE
Modify rule S1048: remove extra space in code snippet

### DIFF
--- a/rules/S1048/cfamily/how_to_fix_it.adoc
+++ b/rules/S1048/cfamily/how_to_fix_it.adoc
@@ -153,7 +153,7 @@ public:
       logFailureToRemoveDirectory(e);
     }
   }
- };
+};
 ----
 
 === Pitfalls


### PR DESCRIPTION
Broken link is fixed in https://github.com/SonarSource/rspec/pull/3033.

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

