### PR TITLE
Modify rule S6411: fix link

### DIFF
--- a/rules/S6411/java/rule.adoc
+++ b/rules/S6411/java/rule.adoc
@@ -52,7 +52,7 @@ class Program {
 
 == Resources
 
-- https://www.kb.cert.org/vuls/id/903934
+- https://kb.cert.org/vuls/id/903934
 - https://dzone.com/articles/java-8-hashmaps-keys-and-the-comparable-interface
 - https://github.com/openjdk/jdk/blob/4927ee426aedbeea0f4119bac0a342c6d3576762/src/hotspot/share/runtime/synchronizer.cpp#L760-L798
 - https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Comparable.html


### PR DESCRIPTION
Fix this issue from the CI:

```txt
Retrying 1 failed probes
https://www.kb.cert.org/vuls/id/903934 in 1 files (previously failed)
ERROR: Connection error HTTPSConnectionPool(host='www.kb.cert.org', port=443): Max retries exceeded with url: /vuls/id/903934 (Caused by SSLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'www.kb.cert.org'. (_ssl.c:1129)")))
There were errors
https://www.kb.cert.org/vuls/id/903934 in:
/tmp/cirrus-ci-build/rspec-tools/../out/S6411/java/rule.html
1/3037 links are dead, see above ^^ the list and the related files
```

Seems like the `www.` part of the link is not valid anymore.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

