### PR TITLE
APPSEC-1077: S6329 Improve examples fso that they can be scanned with sonar-iac

### DIFF
--- a/rules/S6329/azureresourcemanager/rule.adoc
+++ b/rules/S6329/azureresourcemanager/rule.adoc
@@ -10,7 +10,7 @@ Using `publicNetworkAccess` to control access to resources:
 
 [source,bicep,diff-id=1,diff-type=noncompliant]
 ----
-resource exampleSite "Microsoft.Web/sites@2020-12-01" {
+resource exampleSite 'Microsoft.Web/sites@2020-12-01' = {
   name: 'example-site'
   properties: {
     publicNetworkAccess: 'Enabled'
@@ -21,7 +21,7 @@ resource exampleSite "Microsoft.Web/sites@2020-12-01" {
 [source,json,diff-id=2,diff-type=noncompliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -41,7 +41,7 @@ resource exampleSite "Microsoft.Web/sites@2020-12-01" {
 [source,json,diff-id=3,diff-type=noncompliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -67,7 +67,7 @@ Using IP address ranges to control access to resources:
 
 [source,bicep,diff-id=4,diff-type=noncompliant]
 ----
-resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
+resource exampleFirewall 'Microsoft.Sql/servers/firewallRules@2014-04-01' = {
   name: 'example-firewall'
   properties: {
     startIpAddress: '0.0.0.0'
@@ -79,7 +79,7 @@ resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
 [source,json,diff-id=5,diff-type=noncompliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -98,7 +98,7 @@ resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
 [source,json,diff-id=6,diff-type=noncompliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -127,7 +127,7 @@ Using `publicNetworkAccess` to control access to resources:
 
 [source,bicep,diff-id=1,diff-type=compliant]
 ----
-resource exampleSite "Microsoft.Web/sites@2020-12-01" {
+resource exampleSite 'Microsoft.Web/sites@2020-12-01' = {
   name: 'example-site'
   properties: {
     publicNetworkAccess: 'Disabled'
@@ -138,7 +138,7 @@ resource exampleSite "Microsoft.Web/sites@2020-12-01" {
 [source,json,diff-id=2,diff-type=compliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -158,7 +158,7 @@ resource exampleSite "Microsoft.Web/sites@2020-12-01" {
 [source,json,diff-id=3,diff-type=compliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -184,7 +184,7 @@ Using IP address ranges to control access to resources:
 
 [source,bicep,diff-id=4,diff-type=compliant]
 ----
-resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
+resource exampleFirewall 'Microsoft.Sql/servers/firewallRules@2014-04-01' = {
   name: 'example-firewall'
   properties: {
     startIpAddress: '192.168.0.0'
@@ -196,7 +196,7 @@ resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
 [source,json,diff-id=5,diff-type=compliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {
@@ -215,7 +215,7 @@ resource exampleFirewall "Microsoft.Sql/servers/firewallRules@2014-04-01" {
 [source,json,diff-id=6,diff-type=compliant]
 ----
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "resources": [
     {


### PR DESCRIPTION
This PR fixes the code examples for ARM for rule S6329 so that they can be scanned with Sonarqube.
The schema URL for the JSON examples has to be https and for the bicep examples, the correct quotes need to be used.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

