### PR TITLE
APPSEC-1080: S6364 Adjust the retention period of the compliant examples

### DIFF
--- a/rules/S6364/azureresourcemanager/rule.adoc
+++ b/rules/S6364/azureresourcemanager/rule.adoc
@@ -48,6 +48,7 @@ For https://learn.microsoft.com/en-us/azure/templates/microsoft.documentdb/datab
   "contentVersion": "1.0.0.0",
   "resources": [
     {
+      "name": "example",
       "type": "Microsoft.DocumentDB/databaseAccounts",
       "apiVersion": "2023-04-15",
       "properties": {
@@ -122,7 +123,7 @@ For https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites/config
           "frequencyInterval": 1,
           "frequencyUnit": "Day",
           "keepAtLeastOneBackup": true,
-          "retentionPeriodInDays": 15
+          "retentionPeriodInDays": 30
         }
       },
       "dependsOn": [
@@ -142,6 +143,7 @@ For https://learn.microsoft.com/en-us/azure/templates/microsoft.documentdb/datab
   "contentVersion": "1.0.0.0",
   "resources": [
     {
+      "name": "example",
       "type": "Microsoft.DocumentDB/databaseAccounts",
       "apiVersion": "2023-04-15",
       "properties": {
@@ -149,7 +151,7 @@ For https://learn.microsoft.com/en-us/azure/templates/microsoft.documentdb/datab
           "type": "Periodic",
           "periodicModeProperties": {
             "backupIntervalInMinutes": 1440,
-            "backupRetentionIntervalInHours": 360
+            "backupRetentionIntervalInHours": 720
           }
         }
       }
@@ -180,7 +182,7 @@ For https://learn.microsoft.com/en-us/azure/templates/microsoft.recoveryservices
             "retentionPolicy": {
               "retentionPolicyType": "SimpleRetentionPolicy",
               "retentionDuration": {
-                "count": 8,
+                "count": 30,
                 "durationType": "Days"
               }
             }


### PR DESCRIPTION
This PR adjusts the retention period from the compliant examples so that they do not raise security hotspots when scanned with the Sonarway profile.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

