### PR TITLE
APPSEC-1082: S6381 Adjust code examples so that they can be scanned by Sonarqube

### DIFF
--- a/rules/S6381/azureresourcemanager/rule.adoc
+++ b/rules/S6381/azureresourcemanager/rule.adoc
@@ -13,6 +13,7 @@ include::../recommended.adoc[]
   "contentVersion": "1.0.0.0",
   "resources": [
     {
+      "name": "example",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
       "properties": {
@@ -49,6 +50,7 @@ resource symbolicname 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   "contentVersion": "1.0.0.0",
   "resources": [
     {
+      "name": "example",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
       "properties": {


### PR DESCRIPTION
This PR adjusts the JSON code examples and adds a name field that is needed for the files to be recognized by sonar-iac-plugin.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

