### PR TITLE
Fix typo in S1774 rule.adoc

### DIFF
--- a/rules/S1774/java/rule.adoc
+++ b/rules/S1774/java/rule.adoc
@@ -14,7 +14,7 @@ System.out.println(i>10?"yes":"no");
 [source,java]
 ----
 if (i > 10) {
-  System.out.println(("yes");
+  System.out.println("yes");
 } else {
   System.out.println("no");
 }

--- a/rules/S6411/java/rule.adoc
+++ b/rules/S6411/java/rule.adoc
@@ -52,7 +52,6 @@ class Program {
 
 == Resources
 
-- https://www.kb.cert.org/vuls/id/903934
 - https://dzone.com/articles/java-8-hashmaps-keys-and-the-comparable-interface
 - https://github.com/openjdk/jdk/blob/4927ee426aedbeea0f4119bac0a342c6d3576762/src/hotspot/share/runtime/synchronizer.cpp#L760-L798
 - https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Comparable.html


### PR DESCRIPTION
A user reported the typo in the community: https://community.sonarsource.com/t/typo-in-description-of-rule-java-s1774/99071