### PR TITLE
Modify rule S5523: Correct spec and update metadata

### DIFF
--- a/rules/S5523/cfamily/metadata.json
+++ b/rules/S5523/cfamily/metadata.json
@@ -3,9 +3,9 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
-    "attribute": "CLEAR"
+    "attribute": "CONVENTIONAL"
   },
   "status": "ready",
   "remediation": {
@@ -24,7 +24,7 @@
 
     ]
   },
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-5523",
   "sqKey": "S5523",
   "scope": "All",

--- a/rules/S5523/cfamily/rule.adoc
+++ b/rules/S5523/cfamily/rule.adoc
@@ -14,7 +14,7 @@ Such direct initialization increases the readability of the code:
 Please note that the intent of the rule is not to initialize any variable with some semi-random value, but with the value that is meaningful for this variable.
 
 
-This rule raises an issue when a variable of a non-array type with no constructor is declared without initial value.
+This rule raises an issue when a local variable of a built-in or pointer type is declared without an initial value.
 
 
 The related rule S836 detects situations when a variable is actually read before being initialized, while this rule promotes the good practice of systematically initializing the variable.


### PR DESCRIPTION
- Metadata is updated so that it is consistent with the metadata of the new MISRA rule M23_321. See SonarSource/sonar-cpp#3006.
- Correct the spec since the implementation has been updated later so that it raises only on built-in and pointer types. See SonarSource/sonar-cpp#684.

I considered updating the rule to LaYC format, but I wanted to keep this PR simple for now because the rule is not in "Sonar Way"...

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

