### PR TITLE
Modify rule S6584: Add message and highlighting, remove `apk` in favor of `apt`

### DIFF
--- a/rules/S6584/docker/rule.adoc
+++ b/rules/S6584/docker/rule.adoc
@@ -9,11 +9,9 @@ Then, execution is aborted because there is no confirming manual input.
 As a result, instructions, such as installation or update of packages, cannot be performed in an automated way.
 This applies, among others, to the package manager used in Debian-based systems, Advanced Package Tool (APT).
 
-== How to fix it
+== How can I fix it?
 
-=== Code examples
-
-==== Noncompliant code example
+=== Noncompliant Code Example
 
 [source,docker,diff-id=1,diff-type=noncompliant]
 ----
@@ -22,7 +20,7 @@ RUN aptitude install ca-certificates
 RUN apt install ca-certificates
 ----
 
-==== Compliant solution
+=== Compliant Solution
 
 [source,docker,diff-id=1,diff-type=compliant]
 ----

--- a/rules/S6584/docker/rule.adoc
+++ b/rules/S6584/docker/rule.adoc
@@ -1,12 +1,13 @@
 Various package and software management applications require manual input for execution confirmation by default.
 This confirmation is usually required when installing, updating, or removing programs and packages.
-To execute the command without manual input, a general consent can be given.
+General consent can be given to execute the command without manual input.
 
 == Why is this an issue?
 
-If such a command is part of a script that is executed automatically, the execution is aborted because there is no confirming manual input.
-Instructions, such as installing programs or updating them, cannot be performed in an automated way.
-This applies, among others, to the advanced package tool, 'apt-get'.
+Suppose a package manager invocation is part of a script that is executed automatically, and non-interactive mode is not enabled.
+Then, execution is aborted because there is no confirming manual input.
+As a result, instructions, such as installation or update of packages, cannot be performed in an automated way.
+This applies, among others, to the package manager used in Debian-based systems, Advanced Package Tool (APT).
 
 == How to fix it
 
@@ -16,32 +17,48 @@ This applies, among others, to the advanced package tool, 'apt-get'.
 
 [source,docker,diff-id=1,diff-type=noncompliant]
 ----
-RUN apk add ca-certificates
 RUN apt-get install ca-certificates
 RUN aptitude install ca-certificates
+RUN apt install ca-certificates
 ----
 
 ==== Compliant solution
 
 [source,docker,diff-id=1,diff-type=compliant]
 ----
-RUN apk -y add ca-certificates
 RUN apt-get install -y ca-certificates
 RUN aptitude -y install ca-certificates
+RUN apt -y install ca-certificates
 ----
 
 === How does this work?
 
-If the `-y` flag set, no manual input is expected, and it is assumed that there is general consent.
-For `apk` and `apt-get` also the long versions `--yes` and `--assume-yes` exist.
-For `aptitude` also the long version `--assume-yes` exist.
+If the `-y` flag is set, no manual input is expected, and the package manager can run non-interactively.
+For `apt` and `apt-get`, the long versions `--yes` and `--assume-yes` also exist.
+For `aptitude`, the long version `--assume-yes` exists.
 
 == Resources
 === Documentation
 
+* https://linux.die.net/man/8/apt[apt - Linux man page]
 * https://linux.die.net/man/8/apt-get[apt-get - Linux man page]
-* https://docs.alpinelinux.org/user-handbook/0.1a/Working/apk.html[apk - Alpine Package Keeper]
 * https://wiki.debian.org/Aptitude[aptitude - Linux aptitude command]
 ]
 * https://docs.docker.com/engine/reference/builder/#run[RUN - Docker reference]
 * https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run[RUN - Best practices for writing Dockerfiles]
+
+ifdef::env-github,rspecator-view[]
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+Add a consent flag so that this command doesn't require user confirmation.
+
+=== Highlighting
+
+Highlight the command where a package manager is executed.
+
+'''
+endif::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

