### PR TITLE
Modify rule S5827: LaYC - auto on redundant type

### DIFF
--- a/rules/S5827/cfamily/rule.adoc
+++ b/rules/S5827/cfamily/rule.adoc
@@ -2,62 +2,54 @@
 
 When used as a type specifier in a declaration, `auto` allows the compiler to deduce the type of a variable based on the type of the initialization expression.
 
+When the spelling of the initialization expression already contains the type of the declared variable, it leaves no ambiguity and `auto` should be used as it makes the code easier to read and reduces duplication. This includes:
 
-When the spelling of the initialization expression already contains the type of the declared variable, it leaves no ambiguity and `auto` should be used as it makes the code easier to read and reduces duplication. This includes initializations using `new`, template factory functions for smart pointers and cast expressions.
-
-The rule S6234 detects more controversial situations when `auto` can improve readability.
-
-
-=== Noncompliant code example
+* Initializations using `new`
 
 [source,cpp]
 ----
-#include <memory>
-#include <vector>
-
-class C {};
-class LongAndBoringClassName : public C {};
-
 void f() {
-  LongAndBoringClassName *newClass1 = new LongAndBoringClassName(); // Noncompliant
-  LongAndBoringClassName *newClass2 = new LongAndBoringClassName(); // Noncompliant
+  LongAndBoringClassName *avoid = new LongAndBoringClassName(); // Noncompliant
 
-  std::unique_ptr<LongAndBoringClassName> newClass3 = std::make_unique<LongAndBoringClassName>(); // Noncompliant
-  std::shared_ptr<LongAndBoringClassName> newClass4 = std::make_shared<LongAndBoringClassName>(); // Noncompliant
-
-  C* c = new LongAndBoringClassName(); // Compliant
-  LongAndBoringClassName *newClass5 = static_cast<LongAndBoringClassName*>(c); // Noncompliant
+  auto prefer = new LongAndBoringClassName(); // Compliant
 }
 ----
 
-
-=== Compliant solution
+* Template factory functions for smart pointers
 
 [source,cpp]
 ----
-#include <memory>
-#include <vector>
-
-class C {};
-class LongAndBoringClassName : public C {};
-
 void f() {
-  auto newClass1 = new LongAndBoringClassName(); // Compliant
-  auto *newClass2 = new LongAndBoringClassName(); // Compliant
-
-  auto newClass3 = std::make_unique<LongAndBoringClassName>(); // Compliant
-  auto newClass4 = std::make_shared<LongAndBoringClassName>(); // Compliant
-
-  C* c = new LongAndBoringClassName(); // Compliant
-  auto newClass5 = static_cast<LongAndBoringClassName*>(c); // Compliant
+  std::unique_ptr<LongAndBoringClassName> avoid = std::make_unique<LongAndBoringClassName>(); // Noncompliant
+  auto prefer = std::make_unique<LongAndBoringClassName>(); // Compliant
 }
 ----
+
+* Cast expressions
+
+[source,cpp]
+----
+void f() {
+  C *c = new LongAndBoringClassName(); // Compliant
+
+  LongAndBoringClassName *avoid = static_cast<LongAndBoringClassName*>(c); // Noncompliant
+
+  auto prefer = static_cast<LongAndBoringClassName*>(c); // Compliant
+}
+----
+
+The rule S6234 detects other situations where `auto` can improve readability.
 
 
 == Resources
 
+=== External coding guidelines
+
 * https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es11-use-auto-to-avoid-redundant-repetition-of-type-names[{cpp} Core Guidelines ES.11] - Use auto to avoid redundant repetition of type names
 
+=== Related rules
+
+* S6234 - "auto" should be used to store a result of functions that conventionally return an iterator or a range
 
 ifdef::env-github,rspecator-view[]
 '''


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

