### PR TITLE
Modify rule S3457: LaYC on printf errors

### DIFF
--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -1,16 +1,16 @@
 == Why is this an issue?
 
-Because `printf` format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule statically validates the correlation of `printf` format strings and their arguments.
+Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule statically validates the correlation of `printf` format strings and their arguments.
 
 [source,cpp]
 ----
-printf("%d", 1, 2); // Noncompliant; the second argument "2" is unused
-printf("%0-f", 1.2); // Noncompliant; flag "0" is ignored because of "-"
+printf("%d", 1, 2); // Noncompliant: the second argument "2" is unused
+printf("%0-f", 1.2); // Noncompliant: flag "0" is ignored because of "-"
 ----
 
-Starting with C++20, std::format should be preferred, as it is more readable and validated at compile-time, making it more secure. S6494 covers that.
+Starting with C++20, `std::format` should be preferred, as it is more readable and validated at compile-time, making it more secure. S6494 covers that.
 
-The related rule S2275 is about errors that will create undefined behavior, while this rule is about errors that produce an unexpected string.
+This rule is about errors that produce an unexpected string. For errors that will create undefined behavior, see the related rule S2275.
 
 === Exceptions
 

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -1,11 +1,6 @@
 == Why is this an issue?
 
-Because ``++printf++`` format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created. This rule statically validates the correlation of ``++printf++`` format strings to their arguments.
-
-
-The related rule S2275 is about errors that will create undefined behavior, while this rule is about errors that produce an unexpected string.
-
-=== Noncompliant code example
+Because `printf` format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule statically validates the correlation of `printf` format strings and their arguments.
 
 [source,cpp]
 ----
@@ -13,13 +8,9 @@ printf("%d", 1, 2); // Noncompliant; the second argument "2" is unused
 printf("%0-f", 1.2); // Noncompliant; flag "0" is ignored because of "-"
 ----
 
-=== Compliant solution
+Starting with C++20, std::format should be preferred, as it is more readable and validated at compile-time, making it more secure. S6494 covers that.
 
-[source,cpp]
-----
-printf("%d %d", 1, 2); // Compliant
-printf("%-f", 1.2); // Compliant
-----
+The related rule S2275 is about errors that will create undefined behavior, while this rule is about errors that produce an unexpected string.
 
 === Exceptions
 
@@ -27,7 +18,15 @@ This rule will only work if the format string is provided as a string literal.
 
 == Resources
 
+=== Standards
+
 * https://wiki.sei.cmu.edu/confluence/x/J9YxBQ[CERT, FIO47-C.] - Use valid format strings
+
+=== Related rules
+
+* S6494 - C++ formatting functions should be used instead of C printf-like functions
+
+* S2275 - Printf-style format strings should not lead to unexpected behavior at runtime
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -12,11 +12,13 @@ Starting with C++20, `std::format` should be preferred, as it is more readable a
 
 This rule is about errors that produce an unexpected string. For errors that will create undefined behavior, see the related rule S2275.
 
-=== Exceptions
-
 This rule will only work if the format string is provided as a string literal.
 
 == Resources
+
+=== Documentation
+
+* https://en.cppreference.com/w/cpp/utility/format/format[`std::format` starting from C++20]
 
 === Standards
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

