### PR TITLE
Modify rule S5276: LaYC - narrowing conversions

### DIFF
--- a/rules/S5276/cfamily/rule.adoc
+++ b/rules/S5276/cfamily/rule.adoc
@@ -1,19 +1,30 @@
 == Why is this an issue?
 
-Implicit casts discard information when the resulting type has a lower precision than the original type.
+A narrowing conversion is an implicit conversion to a destination type that cannot represent all values from the source type.
 
+It can be a floating-point type converted to an integer type, or a type with a larger range of values converted to a type with a smaller range.
 
-=== Noncompliant code example
+Narrowing conversions can lead to a loss of information and because they are implicit, they are not always obvious.
 
 [source,cpp]
 ----
-int a = 2.1f; // Noncompliant
+int a = 2.1f; // Noncompliant: loss of floating-point precision
 
 long double f();
 double d = 0;
-d += f(); // Noncompliant
+d += f(); // Noncompliant: smaller range of values
 ----
 
+Narrowing conversions should be fixed by either using a destination type that can represent all the source values or by using an explicit conversion:
+
+[source,cpp]
+----
+double a = 2.1f; // Compliant: double can represent all floats
+
+long double f();
+double d = 0;
+d += static_cast<double>(f()); // Compliant: clear
+----
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5276/cfamily/rule.adoc
+++ b/rules/S5276/cfamily/rule.adoc
@@ -23,7 +23,7 @@ double a = 2.1f; // Compliant: double can represent all floats
 
 long double f();
 double d = 0;
-d += static_cast<double>(f()); // Compliant: clear
+d += static_cast<double>(f()); // Compliant: the intent is clear
 ----
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5276/cfamily/rule.adoc
+++ b/rules/S5276/cfamily/rule.adoc
@@ -6,7 +6,7 @@ It can be a floating-point type converted to an integer type, or a type with a l
 
 Narrowing conversions can lead to a loss of information and because they are implicit, they are not always obvious.
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 int a = 2.1f; // Noncompliant: loss of floating-point precision
 
@@ -17,7 +17,7 @@ d += f(); // Noncompliant: smaller range of values
 
 Narrowing conversions should be fixed by either using a destination type that can represent all the source values or by using an explicit conversion:
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 double a = 2.1f; // Compliant: double can represent all floats
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

