### PR TITLE
Modify rule S1659: LaYC - one decl per line

### DIFF
--- a/rules/S1659/cfamily/metadata.json
+++ b/rules/S1659/cfamily/metadata.json
@@ -1,5 +1,4 @@
 {
-  "title": "Init-declarator-lists and member-declarator-lists should consist of single init-declarators and member-declarators respectively",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"

--- a/rules/S1659/cfamily/rule.adoc
+++ b/rules/S1659/cfamily/rule.adoc
@@ -1,11 +1,12 @@
 == Why is this an issue?
 
-Declaring multiple variables or members on the same line hinders readability.
-References, pointers and assignments quickly make the behavior confusing for maintainers.
+Declaring multiple variables or members on the same line hinders readability. Moreover, as soon as they contain references, pointers, or assignments, they become confusing for maintainers.
+
+This rule raises an issue when a declaration declares multiple variables or members.
 
 [source,cpp]
 ----
-int i1; int j1; // Compliant, but not preferred
+int i1, j1; // Noncompliant
 int i2, *j2; // Noncompliant
 int *i3,                  
     &j3 = i2; // Noncompliant

--- a/rules/S1659/cfamily/rule.adoc
+++ b/rules/S1659/cfamily/rule.adoc
@@ -1,8 +1,7 @@
 == Why is this an issue?
 
-Where multiple declarators appear in the same declaration the type of an identifier may not meet developer expectations.
-
-=== Noncompliant code example
+Declaring multiple variables or members on the same line hinders readability.
+References, pointers and assignments quickly make the behavior confusing for maintainers.
 
 [source,cpp]
 ----
@@ -12,7 +11,7 @@ int *i3,
     &j3 = i2; // Noncompliant
 ----
 
-=== Compliant solution
+Giving each declaration its own line makes the code more maintainable.
 
 [source,cpp]
 ----
@@ -26,9 +25,16 @@ int &j3 = i2;
 
 == Resources
 
-* MISRA {cpp}:2008, 8-0-1 - An init-declarator-list or a member-declarator-list shall consist of a single init-declarator or member-declarator respectively
+=== Standards
+
 * https://wiki.sei.cmu.edu/confluence/x/YTZGBQ[CERT, DCL52-J.] - Do not declare more than one variable per declaration
+
 * https://wiki.sei.cmu.edu/confluence/x/EtcxBQ[CERT, DCL04-C.] - Do not declare more than one variable per declaration
+
+=== External coding guidelines
+
+* MISRA {cpp}:2008, 8-0-1 - An init-declarator-list or a member-declarator-list shall consist of a single init-declarator or member-declarator respectively
+
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#es10-declare-one-name-only-per-declaration[{cpp} Core Guidelines - ES.10] - Declare one name (only) per declaration
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

