### PR TITLE
Modify rule S1301: LaYC - switch replacable by if

### DIFF
--- a/rules/S1301/cfamily/metadata.json
+++ b/rules/S1301/cfamily/metadata.json
@@ -1,4 +1,5 @@
 {
+  "title": "\"switch\" statements shouldn't be used when \"if\" would be simpler",
   "tags": [
     "based-on-misra",
     "bad-practice"

--- a/rules/S1301/cfamily/rule.adoc
+++ b/rules/S1301/cfamily/rule.adoc
@@ -1,20 +1,60 @@
 == Why is this an issue?
 
-``++switch++`` statements are useful when there are many different cases depending on the value of the same expression. For just one or two cases however, the code will be more readable with ``++if++`` statements.
+`switch` statements are useful when there are many different cases depending on the value of the same expression. For just one or two cases, however, the code will be more readable with `if` statements.
 
 
-Moreover, ``++if++`` statements are obviously more suitable when the condition of the ``++switch++`` is boolean.
+In particular, `if` statements are more suitable when the condition of the `switch` is boolean.
 
 
-Here are the rules to count the cases:
+This rule detects statements that could be simplified with a simple `if / else`. That is when there is no more than one `case`, not counting those that fall through to a `default`.
 
-* ``++default++`` is counted as a case.
-* If there is no ``++default++`` clause, the ``++case++`` count is incremented by one (to account for the ``++else++`` branch of an equivalent ``++if++``).
-* All the cases falling through to ``++default++`` are not counted (they would all be the ``++else++`` branch of the equivalent ``++if++``).
+The following code:
 
-include::../noncompliant.adoc[]
+[source,cpp]
+----
+switch (variable) {
+  case 0:
+    doSomething();
+    break;
+  case 1:
+  case 2:
+  default:
+    doSomethingElse();
+    break;
+}
+----
 
-include::../compliant.adoc[]
+Would be more readable that way:
+
+[source,cpp]
+----
+if (variable == 0) {
+  doSomething();
+} else {
+  doSomethingElse();
+}
+----
+
+While the following codes don't trigger the rule, because using `if` would not improve their readability:
+
+[source,cpp]
+----
+switch (variable) {
+  case 0:
+  case 1: // Would need a less readable check in an `if`
+    doSomething();
+    break;
+}
+
+switch (variable) {
+  case 0:
+    doSomething();
+    break;
+  case 1: // Would require introducing `else if`
+    doSomethingElse();
+    break;
+}
+----
 
 == Resources
 

--- a/rules/S1301/compliant.adoc
+++ b/rules/S1301/compliant.adoc
@@ -1,6 +1,6 @@
 === Compliant solution
 
-[source,text]
+[source,java]
 ----
 if (variable == 0) {
   doSomething();

--- a/rules/S1301/description.adoc
+++ b/rules/S1301/description.adoc
@@ -1,3 +1,3 @@
-``++switch++`` statements are useful when there are many different cases depending on the value of the same expression.
+`switch` statements are useful when there are many different cases depending on the value of the same expression.
 
-For just one or two cases however, the code will be more readable with ``++if++`` statements.
+For just one or two cases, however, the code will be more readable with `if` statements.

--- a/rules/S1301/noncompliant.adoc
+++ b/rules/S1301/noncompliant.adoc
@@ -1,6 +1,6 @@
 === Noncompliant code example
 
-[source,text]
+[source,java]
 ----
 switch (variable) {
   case 0:


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

