### PR TITLE
Modify S4829: Delete

### DIFF
--- a/rules/S4829/csharp/metadata.json
+++ b/rules/S4829/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+  "status": "closed"
 }

--- a/rules/S4829/vbnet/metadata.json
+++ b/rules/S4829/vbnet/metadata.json
@@ -1,3 +1,4 @@
 {
-  
+    "status": "closed"
 }
+  


### PR DESCRIPTION
Deleting S4829 as it has been deprecated.
Deprecated since:

sonar-dotnet 8.9.0.19135, released on Jun 26, 2020
SQ 8.4.0.35506 on Jul 3, 2020.

