### PR TITLE
Modify rule S6584: Environment variables should not be unset on a different layer than they were set

### DIFF
--- a/rules/S6581/docker/metadata.json
+++ b/rules/S6581/docker/metadata.json
@@ -18,6 +18,8 @@
   "ruleSpecification": "RSPEC-6581",
   "sqKey": "S6581",
   "scope": "All",
-  "defaultQualityProfiles": ["Sonar way"],
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ],
   "quickfix": "unknown"
 }

--- a/rules/S6581/docker/rule.adoc
+++ b/rules/S6581/docker/rule.adoc
@@ -37,6 +37,7 @@ However, the value can still be extracted from the image.
 The best solution is to use `ARG` instead.
 
 == Resources
+
 === Documentation
 
 * https://docs.docker.com/engine/reference/builder/#env[ENV - Dockerfile reference]
@@ -44,7 +45,9 @@ The best solution is to use `ARG` instead.
 
 ifdef::env-github,rspecator-view[]
 '''
+
 == Implementation Specification
+
 (visible only on this page)
 
 === Message


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

