### PR TITLE
Modify rule S6579: apply LaYC format

### DIFF
--- a/rules/S6579/docker/rule.adoc
+++ b/rules/S6579/docker/rule.adoc
@@ -4,7 +4,8 @@ It will be evaluated to an empty value.
 == Why is this an issue?
 
 The variables defined by `ARG` instruction have a scope from the definition to the end of the build stage where it was defined.
-The variables will be unresolved (it will be empty) which may lead to unintended behaviour.
+If it was defined in the beginning of the dockerfile (outside of any build stage), then its scope is restricted to only `FROM` instructions.
+Outside of their scope, variables will be resolved to empty string which may lead to unintended behaviour.
 
 == How to fix it
 
@@ -19,7 +20,7 @@ FROM busybox
 RUN ./run/setup $SETTINGS
 ----
 
-In this case the `$SETTINGS` variable will be not evaluated.
+In this case the `$SETTINGS` variable will be evaluated to empty string.
 
 ==== Compliant solution
 
@@ -41,7 +42,7 @@ FROM busybox
 RUN ./run/setup $SETTINGS
 ----
 
-In this case the `$SETTINGS` variable will be not evaluated, just the text `$SETTINGS` will be passed to `RUN` instruction.
+In this case the `$SETTINGS` variable will be evaluated to empty string.
 
 ==== Compliant solution
 
@@ -53,7 +54,7 @@ ARG SETTINGS
 RUN ./run/setup $SETTINGS
 ----
 
-In this case the flag `--default-settings` will be passed to `RUN` instruction.
+In this case the flag `--default-settings` will be passed to `RUN` instruction (unless another value is provided during build time).
 
 === How does this work?
 

--- a/rules/S6579/docker/rule.adoc
+++ b/rules/S6579/docker/rule.adoc
@@ -4,7 +4,7 @@ It will be evaluated to an empty value.
 == Why is this an issue?
 
 The variables defined by `ARG` instruction have a scope from the definition to the end of the build stage where it was defined.
-If it was defined in the beginning of the dockerfile (outside of any build stage), then its scope is restricted to only `FROM` instructions.
+If it was defined in the beginning of the Dockerfile (outside of any build stage), then its scope is restricted to only `FROM` instructions.
 Outside of their scope, variables will be resolved to empty string which may lead to unintended behaviour.
 
 == How to fix it


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

