### PR TITLE
Modify rule: Delete S2228

### DIFF
--- a/rules/S2228/csharp/metadata.json
+++ b/rules/S2228/csharp/metadata.json
@@ -1,3 +1,4 @@
 {
-  
+    "status": "closed"
 }
+  


### PR DESCRIPTION
Deleting S2228 as it has been deprecated.

Deprecated since:
sonar-dotnet [8.15.0.24505](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.15.0.24505).
SQ [8.6.0.39681](https://github.com/SonarSource/sonar-enterprise/releases/tag/8.6.0.39681)