### PR TITLE
Modify rule: Delete S4564

### DIFF
--- a/rules/S4564/csharp/metadata.json
+++ b/rules/S4564/csharp/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "ASP.NET HTTP request validation feature should not be disabled",
   "type": "VULNERABILITY",
-  "status": "deprecated",
+  "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"


### PR DESCRIPTION
Delete S4564 as it has been deprecated.

Deprecated since:
sonar-dotnet [8.17.0.26580](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.17.0.26580).
SQ [8.7.0.41497](https://github.com/SonarSource/sonar-enterprise/releases/tag/8.7.0.41497)

