### PR TITLE
Modify rule: Delete S4834

### DIFF
--- a/rules/S4834/csharp/metadata.json
+++ b/rules/S4834/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "status": "closed"
 }

--- a/rules/S4834/vbnet/metadata.json
+++ b/rules/S4834/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+    "status": "closed"
 }


### PR DESCRIPTION
Delete S4834 as it has been deprecated.

Deprecated since:
sonar-dotnet [8.18.0.27296](https://github.com/SonarSource/sonar-dotnet/releases/tag/8.18.0.27296).
SonarQube [8.7.0.41497](https://github.com/SonarSource/sonar-enterprise/releases/tag/8.7.0.41497)

