### PR TITLE
Modify rule S6183: Expand and adjust for LaYC

### DIFF
--- a/rules/S6183/cfamily/metadata.json
+++ b/rules/S6183/cfamily/metadata.json
@@ -30,8 +30,17 @@
   "ruleSpecification": "RSPEC-6183",
   "sqKey": "S6183",
   "scope": "All",
+  "securityStandards": {
+    "CERT": [
+      "INT02-C.",
+      "INT31-C."
+    ],
+    "CWE": [
+      195
+    ]
+  },
   "defaultQualityProfiles": [
 
   ],
-  "quickfix": "unknown"
+  "quickfix": "targeted"
 }

--- a/rules/S6183/cfamily/rule.adoc
+++ b/rules/S6183/cfamily/rule.adoc
@@ -1,48 +1,116 @@
+Functions from the ``++std::cmp_*++`` family should be used to compare signed and unsigned values.
+
 == Why is this an issue?
 
-Comparison between `signed` and `unsigned` integers is dangerous because it produces counterintuitive results outside of their common range of values.
+Comparisons between ``++signed++`` and ``++unsigned++`` integers are dangerous because they produce counterintuitive results outside of their common value range.
+
+When a signed integer is compared to an unsigned one, the former might be converted to unsigned.
+The conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result.
+The expression ``++2U < -1++`` evaluates to ``++true++``, for instance.
+
+{cpp}20 introduced remedy to this common pitfall: a family of ``++std::cmp_*++`` functions defined in the ``++<utility>++`` header:
+
+* ``++std::cmp_equal++``
+* ``++std::cmp_not_equal++``
+* ``++std::cmp_less++``
+* ``++std::cmp_greater++``
+* ``++std::cmp_less_equal++``
+* ``++std::cmp_greater_equal++``
+
+These functions correctly handle negative numbers and are safe against lossy integer conversion.
+For example, the comparison of ``++2U++`` and ``++-1++`` using ``++std::cmp_less(2U, -1)++`` evaluates to ``++false++`` and matches common intuition.
+
+=== Associated rule S6214
+
+This rule (S6183) starts by detecting comparisons between signed and unsigned integers.
+If the signed value can be proven negative, rule S6214 will raise an issue.
+Otherwise, this rule will raise an issue.
+Therefore, if rule S6183 is enabled, S6214 should be enabled, too.
 
 
-When a signed integer is compared to an unsigned one, the former might be converted to unsigned. The conversion preserves the two's-complement bit pattern of the signed value that often corresponds to a large unsigned result. For example, `2U < -1` is `true`.
+== What is the potential impact?
+
+Comparisons between ``++signed++`` and ``++unsigned++`` integer types produce counterintuitive results.
+
+Failing to understand integer conversion rules can lead to tricky bugs and to exploitable vulnerabilities.
+The major integer conversion risks include narrowing types, converting from unsigned to signed and from negative to unsigned.
 
 
-{cpp}20 introduced remedy to this common pitfall: a family of `std::cmp_*` functions defined in the `<utility>` header. These functions correctly handle negative numbers and lossy integer conversion. For example, `std::cmp_less(2U, -1)` is `false`.
+== How to fix it
 
-This rule starts by detecting comparisons between signed and unsigned integers. Then, if the signed value can be proven to be negative, the rule S6214 will raise an issue (it is a bug). Otherwise, this rule will raise an issue. Therefore, if this rule is enabled, S6214 should be enabled too.
+Use the appropriate function from the ``++std::cmp_*++`` family to conduct comparisons between signed _and_ unsigned integer types.
 
 
-=== Noncompliant code example
+=== Code examples
 
-[source,cpp]
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-bool less = 2U < -1; // Compliant, raises S6214
+#include <iostream>
 
-bool foo(unsigned x, signed y) {
+void foo() {
+  if (2U < -1) { // Compliant: raises on associated rule S6214
+    std::cout << "2 is less than -1\n";
+  } else {
+    std::cout << "2 is not less than -1\n";
+  }
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+#include <iostream>
+
+void foo() {
+  if (std::cmp_less(2U, -1)) { // Compliant: for this rule (S6183) and associated rule S6214
+    std::cout << "2 is less than -1\n";
+  } else {
+    std::cout << "2 is not less than -1\n";
+  }
+}
+----
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
+bool foo(unsigned x, int y) {
   return x < y; // Noncompliant: y might be negative
 }
+----
 
+==== Compliant solution
+
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+bool foo(unsigned x, int y) {
+  return std::cmp_less(x, y); // Compliant
+}
+----
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=3,diff-type=noncompliant]
+----
 bool fun(int x, std::vector<int> const& v) {
   return x < v.size(); // Noncompliant: x might be negative
 }
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,cpp]
+[source,cpp,diff-id=3,diff-type=compliant]
 ----
-bool less = std::cmp_less(2U, -1); // Compliant for this rule and S6214
-
-bool foo(unsigned x, signed y) {
-  return std::cmp_less(x, y); // Compliant
-}
-
 bool fun(int x, std::vector<int> const& v) {
   return std::cmp_less(x, v.size()); // Compliant
 }
 
 void compute(std::vector<int> const &v) {
-  if (0 < v.size() && v.size() < 100) { // Compliant, even though v.size() returns an unsigned integer
+  // Compliant: v.size() returns an unsigned integer, but only positive signed integer values are involved
+  if (0 < v.size() && v.size() < 100) {
   }
 }
 ----
@@ -50,8 +118,16 @@ void compute(std::vector<int> const &v) {
 
 == Resources
 
-* S845 - a more generic rule about mixing signed and unsigned values.
-* S6214 - a version of this rule that only triggers when it detects negative values are involved.
+=== Standards
+
+* CERT - https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules[INT02-C. Understand integer conversion rules]
+* CERT - https://wiki.sei.cmu.edu/confluence/display/c/INT31-C.+Ensure+that+integer+conversions+do+not+result+in+lost+or+misinterpreted+data[INT31-C. Ensure that integer conversions do not result in lost or misinterpreted data]
+* CWE - https://cwe.mitre.org/data/definitions/195.html[195 Signed to Unsigned Conversion Error]
+
+=== Related rules
+
+* S845 ensures that signed and unsigned types are not mixed in expressions
+* S6214 constitutes a version of this rule that only triggers when it detects the involvement of negative values
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

