### PR TITLE
Modify rule S6376: Change text to education framework format (APPSEC-1109)

### DIFF
--- a/rules/S6376/description.adoc
+++ b/rules/S6376/description.adoc
@@ -1,4 +1,0 @@
-An XML bomb / https://en.wikipedia.org/wiki/Billion_laughs_attack[billion laughs] attack is a malicious XML document containing the same large entity repeated over and over again. If no restrictions is in place, such a limit on the number of entity expansions, the XML processor can consume a lot memory and time during the parsing of such documents leading to Denial of Service.
-
-
-

--- a/rules/S6376/java/metadata.json
+++ b/rules/S6376/java/metadata.json
@@ -1,6 +1,1 @@
-{
-  "quickfix": "infeasible",
-  "tags": [
-    "symbolic-execution"
-  ]
-}
+{ }

--- a/rules/S6376/java/rule.adoc
+++ b/rules/S6376/java/rule.adoc
@@ -1,81 +1,99 @@
+XML parsers Denial of Service attacks are a type of vulnerability that can be exploited by malicious actors. These attacks target XML parsers, which are software components responsible for parsing and interpreting XML documents.
+
 == Why is this an issue?
 
-include::../description.adoc[]
+To exploit this vulnerability, an attacker typically crafts an XML document that triggers excessive memory consumption or CPU usage when processed by the XML parser. This can be achieved by exploiting vulnerabilities in the parser's implementation or by overwhelming the parser with large or nested XML structures.
 
-=== Noncompliant code example
+=== System Unavailability
 
-For https://docs.oracle.com/javase/9/docs/api/javax/xml/parsers/DocumentBuilderFactory.html[DocumentBuilder], https://docs.oracle.com/javase/9/docs/api/javax/xml/parsers/SAXParserFactory.html[SAXParser] and https://docs.oracle.com/javase/9/docs/api/javax/xml/validation/SchemaFactory.html[Schema] and https://docs.oracle.com/javase/9/docs/api/javax/xml/transform/TransformerFactory.html[Transformer] JAPX factories:
+When an attacker successfully exploits the vulnerability, it can lead to a Denial of Service (DoS) condition. This means that the affected system becomes unresponsive or crashes, rendering it unavailable to legitimate users. This can have severe consequences, especially for critical systems that rely on continuous availability, such as web servers, APIs, or network services.
 
-[source,java]
+=== Amplification Attacks
+
+In some cases, XML parsers Denial of Service attacks can be used as a part of larger-scale amplification attacks. By leveraging the vulnerability, attackers can generate a disproportionately large response from the targeted system, amplifying the impact of their attack. This can result in overwhelming network bandwidth, and causing widespread disruption.
+
+== How to fix it in Java SE
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false); // Noncompliant
-
-SAXParserFactory factory = SAXParserFactory.newInstance();
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false); // Noncompliant
-
-SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false); // Noncompliant
-
-TransformerFactory factory = javax.xml.transform.TransformerFactory.newInstance(); 
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false); // Noncompliant
 ----
 
-For https://dom4j.github.io/[Dom4j] library:
+==== Compliant solution
 
-[source,java]
+[source,java,diff-id=1,diff-type=compliant]
+----
+DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+----
+
+
+== How to fix it in Dom4j
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=2,diff-type=noncompliant]
 ----
 SAXReader xmlReader = new SAXReader();
 xmlReader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false); // Noncompliant
-
 ----
 
-For http://www.jdom.org/[Jdom2] library:
+==== Compliant solution
 
-[source,java]
+[source,java,diff-id=2,diff-type=compliant]
 ----
-SAXBuilder builder = new SAXBuilder(); 
+SAXReader xmlReader = new SAXReader();
+xmlReader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+----
+
+
+== How to fix it in Jdom2
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=2,diff-type=noncompliant]
+----
+SAXBuilder builder = new SAXBuilder();
 builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);  // Noncompliant
 ----
 
-=== Compliant solution
-For https://docs.oracle.com/javase/9/docs/api/javax/xml/parsers/DocumentBuilderFactory.html[DocumentBuilder], https://docs.oracle.com/javase/9/docs/api/javax/xml/parsers/SAXParserFactory.html[SAXParser] and https://docs.oracle.com/javase/9/docs/api/javax/xml/validation/SchemaFactory.html[Schema] and https://docs.oracle.com/javase/9/docs/api/javax/xml/transform/TransformerFactory.html[Transformer] JAPX factories:
+==== Compliant solution
 
-[source,java]
+[source,java,diff-id=2,diff-type=compliant]
 ----
-DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true); 
-
-SAXParserFactory factory = SAXParserFactory.newInstance();
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true); 
-
-SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true); 
-
-TransformerFactory factory = javax.xml.transform.TransformerFactory.newInstance(); 
-factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true); 
+SAXBuilder builder = new SAXBuilder();
+builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 ----
 
-For https://dom4j.github.io/[Dom4j] library:
-
-[source,java]
-----
-SAXReader xmlReader = new SAXReader();
-xmlReader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true); 
-
-----
-
-For http://www.jdom.org/[Jdom2] library:
-
-[source,java]
-----
-SAXBuilder builder = new SAXBuilder(); 
-builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);  
-----
 
 == Resources
 
-* https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-8CD65EF5-D113-4D5C-A564-B875C8625FAC[Oracle Java Documentation] - XML External Entity Injection Attack
+=== Documentation
+
+* https://docs.oracle.com/en/java/javase/21/docs/api/java.xml/javax/xml/parsers/DocumentBuilderFactory.html[DocumentBuilder]
+* https://docs.oracle.com/en/java/javase/21/docs/api/java.xml/javax/xml/parsers/SAXParserFactory.html[SAXParser]
+* https://docs.oracle.com/en/java/javase/21/docs/api/java.xml/javax/xml/validation/SchemaFactory.html[Schema]
+* https://docs.oracle.com/en/java/javase/21/docs/api/java.xml/javax/xml/transform/TransformerFactory.html[TransformerFactory]
+* https://dom4j.github.io/[Dom4j Library]
+* http://www.jdom.org/[Jdom2 Library]
+
+
+=== Articles & blog posts
+
+* https://docs.oracle.com/en/java/javase/21/security/java-api-xml-processing-jaxp-security-guide.html[Oracle Java Documentation] - Java API for XML Processing (JAXP) Security Guide
+
+=== Standards
+
+* https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguratio
 * https://owasp.org/www-project-top-ten/2017/A4_2017-XML_External_Entities_(XXE)[OWASP Top 10 2017 Category A4] - XML External Entities (XXE)
 * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java[OWASP XXE Prevention Cheat Sheet]
 * https://cwe.mitre.org/data/definitions/776[MITRE, CWE-776] - Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
@@ -89,7 +107,6 @@ ifdef::env-github,rspecator-view[]
 === Message
 
 Enable XML parsing limitations to prevent Denial of Service attacks.
-
 
 
 '''

--- a/rules/S6376/java/rule.adoc
+++ b/rules/S6376/java/rule.adoc
@@ -60,7 +60,7 @@ xmlReader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
 ==== Noncompliant code example
 
-[source,java,diff-id=2,diff-type=noncompliant]
+[source,java,diff-id=3,diff-type=noncompliant]
 ----
 SAXBuilder builder = new SAXBuilder();
 builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);  // Noncompliant
@@ -68,7 +68,7 @@ builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);  // Noncompli
 
 ==== Compliant solution
 
-[source,java,diff-id=2,diff-type=compliant]
+[source,java,diff-id=3,diff-type=compliant]
 ----
 SAXBuilder builder = new SAXBuilder();
 builder.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

