### PR TITLE
Modify rule S3776: Add cog complexity blog post link

### DIFF
--- a/rules/S3776/resources.adoc
+++ b/rules/S3776/resources.adoc
@@ -3,3 +3,7 @@
 === Documentation
 
 * https://www.sonarsource.com/docs/CognitiveComplexity.pdf[Cognitive Complexity]
+
+=== Articles & blog posts
+
+* https://www.sonarsource.com/blog/5-clean-code-tips-for-reducing-cognitive-complexity/[5 Clean Code Tips for Reducing Cognitive Complexity]


### PR DESCRIPTION
Added the cognitive complexity blog post link so that it shows up in the 'more info' tab for all languages.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

