### PR TITLE
Modify rule S3471: LaYC - virtual / override

### DIFF
--- a/rules/S3471/cfamily/rule.adoc
+++ b/rules/S3471/cfamily/rule.adoc
@@ -2,13 +2,6 @@
 
 In a base class, ``++virtual++`` indicates that a function can be overridden. In a derived class, it indicates an override. But given the specifier's dual meaning, it would be both clearer and more sound to use derived class-specific specifiers instead: ``++override++`` or ``++final++``.
 
-
-* ``++final++`` indicates a function ``++override++`` that cannot itself be overridden. The compiler will issue a warning if the signature does not match the signature of a base-class ``++virtual++`` function.
-* ``++override++`` indicates that a function is intended to override a base-class function. The compiler will issue a warning if this is not the case. It is redundant in combination with ``++final++``.
-
-
-=== Noncompliant code example
-
 [source,cpp]
 ----
 class Counter {
@@ -22,14 +15,14 @@ public:
 
 class FastCounter: public Counter {
 public:
-  virtual void count() {  // Noncompliant
+  virtual void count() {  // Noncompliant: ambiguous
     c += 2;
   }
 };
 ----
 
+* ``++override++`` indicates that a function is intended to override a base-class function. The compiler will issue a warning if this is not the case.
 
-=== Compliant solution
 
 [source,cpp]
 ----
@@ -49,7 +42,8 @@ public:
   }
 };
 ----
-or
+
+* ``++final++`` indicates a function ``++override++`` that cannot itself be overridden. The compiler will issue a warning if the signature does not match the signature of a base-class ``++virtual++`` function. `override` is redundant when `final` is specified.
 
 [source,cpp]
 ----

--- a/rules/S3471/cfamily/rule.adoc
+++ b/rules/S3471/cfamily/rule.adoc
@@ -52,7 +52,7 @@ public:
 
 === Related rules
 
-* S1016
+* S1016 - Virtual functions should be declared with the "virtual" keyword
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3471/cfamily/rule.adoc
+++ b/rules/S3471/cfamily/rule.adoc
@@ -26,15 +26,6 @@ public:
 
 [source,cpp]
 ----
-class Counter {
-protected:
-  int c = 0;
-public:
-  virtual void count() {
-    c++;
-  }
-};
-
 class FastCounter: public Counter {
 public:
   void count() override {
@@ -47,15 +38,6 @@ public:
 
 [source,cpp]
 ----
-class Counter {
-protected:
-  int c = 0;
-public:
-  virtual void count() {
-    c++;
-  }
-};
-
 class FastCounter: public Counter {
 public:
   void count() final {
@@ -66,7 +48,7 @@ public:
 
 == Resources
 
-* https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final[{cpp} Core Guidelines C.128] - Virtual functions should specify exactly one of virtual, override, or final
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final[C.128 - Virtual functions should specify exactly one of virtual, override, or final]
 
 === Related rules
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

