### PR TITLE
Modify rule S6504: Clarify guidelines for Docker

### DIFF
--- a/rules/S6504/docker/rule.adoc
+++ b/rules/S6504/docker/rule.adoc
@@ -24,7 +24,8 @@ There is a risk if you answered yes to the question.
 
 == Recommended Secure Coding Practices
 
-* Use `--chmod` to change executable permissions at build-time.
+* Use `--chown` to change the owner to a root user.
+* Use `--chmod` to change the permissions so that only root users can write to files.
 * Be mindful of the container immutability principle.
 
 
@@ -45,7 +46,8 @@ COPY --chown=exampleuser:exampleuser src.py dst.py
 ----
 FROM example
 
-COPY src.py dst.py
+RUN useradd exampleuser
+COPY --chown=root:exampleuser --chmod=644 src.py dst.py
 ----
 
 == See


### PR DESCRIPTION
During internal testing, it was found that the guidance for S6504 for Docker wasn't as clear as it should be.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

