### PR TITLE
Modify rule S2259: Extend LaYC content for Python

### DIFF
--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -1,10 +1,50 @@
+
+Accessing attributes on `None` is almost always a logical error and will raise
+an `AttributeError`.
+To fix this issue, make sure not to access an attribute or method on a value
+that can be `None`.
+
 == Why is this an issue?
 
-Attributes of ``++None++`` values should never be accessed. Doing so will cause an ``++AttributeError++`` to be thrown. At best, such an exception will cause abrupt program termination. At worse, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures.
+`None` is a built-in object that represents the absence of a value.
+It is often used as a placeholder value for variables that only sometimes hold a
+value, or as a return value for method calls that have no result.
 
-=== Noncompliant code example
+Attributes and methods of symbols that sometimes can be `None` should only be
+accessed when it is certain that they hold a value and are not set to `None`.
+Otherwise, an `AttributeError` is raised and the program is interrupted.
 
-[source,python]
+Hence, this issue indicates a fatal logical error as it results from incorrect
+assumptions about the state of variables or the results of computations.
+
+`None` does support a fixed set of special attributes like `__class__` or
+`__bool__`, and this issue is not raised when accessing these attributes.
+
+=== What is the potential impact?
+
+include::../../shared_content/layc/exception-impact.adoc[]
+
+If the `None` value consequently the `AttributeError` can be induced by user
+input, this issue may even be exploited by attackers to disrupt your application
+or gain information from stack traces.
+
+== How to fix it
+
+If your code contains `if-else` statements or similar constructs where some
+branches potentially assign the `None` value to a variable, you need to ensure
+that this variable is handled safely afterwards.
+I.e. its attributes should not be accessed at all, or only after explicitly
+confirming that it is not `None`.
+
+For any function calls that can return `None` under certain conditions,
+carefully confirm that your code avoids these conditions.
+Again, it is likely safer to also explicitly check for a `None` return value.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,python,diff-id=1,diff-type=noncompliant]
 ----
 def myfunc(param):
     if param is None:
@@ -22,8 +62,17 @@ def myfunc(param):
         pass
     else:
         print(param.test())  # Noncompliant
-
 ----
+
+==== Compliant code example
+
+[source,python,diff-id=1,diff-type=compliant]
+----
+def myfunc(param):
+    TODO
+----
+
+=== How does this work?
 
 include::../see.adoc[]
 

--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -36,8 +36,8 @@ that this variable is handled safely afterwards.
 I.e. its attributes should not be accessed at all, or only after explicitly
 confirming that it is not `None`.
 
-For any function calls that can return `None` under certain conditions,
-carefully confirm that your code avoids these conditions.
+Conversely, for any function calls that can return `None` under certain
+conditions, carefully confirm that your code avoids these conditions.
 Again, it is likely safer to also explicitly check for a `None` return value.
 
 === Code examples
@@ -46,35 +46,57 @@ Again, it is likely safer to also explicitly check for a `None` return value.
 
 [source,python,diff-id=1,diff-type=noncompliant]
 ----
-def myfunc(param):
-    if param is None:
-        print(param.test())  # Noncompliant
-
-    if param == None:
-        print(param.test())  # Noncompliant
-
-    if param is not None:
-        pass
+def render(file_path):
+    if os.path.isfile(file_path):
+        data = interpret_csv(file_path)
     else:
-        print(param.test())  # Noncompliant
+        data = None
 
-    if param != None:
-        pass
-    else:
-        print(param.test())  # Noncompliant
-----
+    # ...
+
+    data.plot_graph() # Noncompliant
+---
 
 ==== Compliant code example
 
 [source,python,diff-id=1,diff-type=compliant]
 ----
-def myfunc(param):
-    TODO
-----
+def render(file_path):
+    if os.path.isfile(file_path):
+        data = interpret_csv(file_path)
+    else:
+        data = None
 
+    # ...
+
+    if data is not None:
+        data.plot_graph()
+    else:
+        print("No data available.")
+----
+        
 === How does this work?
 
-include::../see.adoc[]
+In the given example, the function `render` tries to load information into a
+variable `data`, depending on whether `file_path` is a path to a file.
+If this is not the case `data` is assigned to `None`.
+
+At the end of the function, a method `plot_graph()` is being accessed on `data`,
+which is certain to fail if `data` was assigned to `None`.
+This is prevented, by checking first whether `data` is not `None`, before
+making the call in the compliant version of the example.
+
+== Resources
+
+=== Documentation
+
+* The Python Data Model: https://docs.python.org/3/reference/datamodel.html#none[None]
+* https://docs.python.org/3/library/exceptions.html#AttributeError[Attribute Error]
+* https://docs.python.org/3/reference/expressions.html#attribute-references[Attribute References]
+
+=== Articles & blog posts
+
+* CVE  - https://cwe.mitre.org/data/definitions/476[CWE-476: - NULL Pointer Dereference]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -22,7 +22,7 @@ assumptions about the state of variables or the results of computations.
 
 === What is the potential impact?
 
-include::../../shared_content/layc/exception-impact.adoc[]
+include::../../../shared_content/layc/exception-impact.adoc[]
 
 If the `None` value consequently the `AttributeError` can be induced by user
 input, this issue may even be exploited by attackers to disrupt your application

--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -8,11 +8,11 @@ that can be `None`.
 
 `None` is a built-in object that represents the absence of a value.
 It is often used as a placeholder value for variables that only sometimes hold a
-value, or as a return value for method calls that have no result.
+value or as a return value for method calls that have no result.
 
 Attributes and methods of symbols that sometimes can be `None` should only be
 accessed in circumstances where it is certain that they are not set to `None`.
-Otherwise, an `AttributeError` is raised and the program is interrupted.
+Otherwise, an `AttributeError` is raised, and the program is interrupted.
 Hence, this issue indicates a logical error as it results from incorrect
 assumptions about the state of variables or the results of computations.
 
@@ -30,14 +30,14 @@ stack traces.
 == How to fix it
 
 If your code contains `if-else` statements or similar constructs where some
-branches potentially assign the `None` value to a variable, you need to ensure
+branches potentially assign the `None` value to a variable, you must ensure
 that this variable is handled safely afterwards.
-I.e. its attributes should not be accessed at all, or only after explicitly
+I.e., its attributes should not be accessed at all or only after explicitly
 confirming that it is not `None`.
 
 Similarly, for any function calls that can return `None` under certain
 conditions, carefully confirm that your code avoids these conditions.
-Again, the safest approach is to explicitly check for a `None` return value.
+Again, the safest approach is to check for a `None` return value explicitly.
 
 === Code examples
 
@@ -56,7 +56,7 @@ def render(file_path):
     data.plot_graph() # Noncompliant
 ----
 
-==== Compliant code example
+==== Compliant solution
 
 [source,python,diff-id=1,diff-type=compliant]
 ----
@@ -81,15 +81,15 @@ variable `data`, depending on whether `file_path` is a path to a file.
 If this is not the case, `None` is assigned to `data`.
 
 At the end of the function, a method `plot_graph()` is called on `data`.
-The call is certain to fail if `data` was assigned to `None`.
-This is prevented, by checking first whether `data` is not `None` before
+The call is sure to fail if `data` was assigned to `None`.
+This is prevented by checking first whether `data` is not `None` before
 performing the call.
 
 == Resources
 
 === Documentation
 
-* The Python Data Model: https://docs.python.org/3/reference/datamodel.html#none[None]
+* The Python Data Model on https://docs.python.org/3/reference/datamodel.html#none[None]
 * https://docs.python.org/3/library/exceptions.html#AttributeError[Attribute Error]
 * https://docs.python.org/3/reference/expressions.html#attribute-references[Attribute References]
 

--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -16,9 +16,6 @@ Otherwise, an `AttributeError` is raised, and the program is interrupted.
 Hence, this issue indicates a logical error as it results from incorrect
 assumptions about the state of variables or the results of computations.
 
-`None` does support a fixed set of special attributes like `++__class__++` or
-`++__bool__++`, and this issue is not raised when accessing these attributes.
-
 === What is the potential impact?
 
 include::../../../shared_content/layc/exception-impact.adoc[]
@@ -26,6 +23,11 @@ include::../../../shared_content/layc/exception-impact.adoc[]
 If a `None` value can be induced by user input, this issue may even be
 exploited by attackers to disrupt your application or gain information from
 stack traces.
+
+=== Exceptions
+
+`None` does support a fixed set of special attributes like `++__class__++` or
+`++__bool__++`, and this issue is not raised when accessing these attributes.
 
 == How to fix it
 

--- a/rules/S2259/python/rule.adoc
+++ b/rules/S2259/python/rule.adoc
@@ -11,22 +11,21 @@ It is often used as a placeholder value for variables that only sometimes hold a
 value, or as a return value for method calls that have no result.
 
 Attributes and methods of symbols that sometimes can be `None` should only be
-accessed when it is certain that they hold a value and are not set to `None`.
+accessed in circumstances where it is certain that they are not set to `None`.
 Otherwise, an `AttributeError` is raised and the program is interrupted.
-
-Hence, this issue indicates a fatal logical error as it results from incorrect
+Hence, this issue indicates a logical error as it results from incorrect
 assumptions about the state of variables or the results of computations.
 
-`None` does support a fixed set of special attributes like `__class__` or
-`__bool__`, and this issue is not raised when accessing these attributes.
+`None` does support a fixed set of special attributes like `++__class__++` or
+`++__bool__++`, and this issue is not raised when accessing these attributes.
 
 === What is the potential impact?
 
 include::../../../shared_content/layc/exception-impact.adoc[]
 
-If the `None` value consequently the `AttributeError` can be induced by user
-input, this issue may even be exploited by attackers to disrupt your application
-or gain information from stack traces.
+If a `None` value can be induced by user input, this issue may even be
+exploited by attackers to disrupt your application or gain information from
+stack traces.
 
 == How to fix it
 
@@ -36,9 +35,9 @@ that this variable is handled safely afterwards.
 I.e. its attributes should not be accessed at all, or only after explicitly
 confirming that it is not `None`.
 
-Conversely, for any function calls that can return `None` under certain
+Similarly, for any function calls that can return `None` under certain
 conditions, carefully confirm that your code avoids these conditions.
-Again, it is likely safer to also explicitly check for a `None` return value.
+Again, the safest approach is to explicitly check for a `None` return value.
 
 === Code examples
 
@@ -55,7 +54,7 @@ def render(file_path):
     # ...
 
     data.plot_graph() # Noncompliant
----
+----
 
 ==== Compliant code example
 
@@ -79,12 +78,12 @@ def render(file_path):
 
 In the given example, the function `render` tries to load information into a
 variable `data`, depending on whether `file_path` is a path to a file.
-If this is not the case `data` is assigned to `None`.
+If this is not the case, `None` is assigned to `data`.
 
-At the end of the function, a method `plot_graph()` is being accessed on `data`,
-which is certain to fail if `data` was assigned to `None`.
-This is prevented, by checking first whether `data` is not `None`, before
-making the call in the compliant version of the example.
+At the end of the function, a method `plot_graph()` is called on `data`.
+The call is certain to fail if `data` was assigned to `None`.
+This is prevented, by checking first whether `data` is not `None` before
+performing the call.
 
 == Resources
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

