### PR TITLE
Modify rule S5344: Add missing text to education framework format (APPSEC-1106)

### DIFF
--- a/rules/S5344/description.adoc
+++ b/rules/S5344/description.adoc
@@ -1,7 +1,0 @@
-A user password should never be stored in clear-text, instead a hash should be produced from it using a secure algorithm:
-
-* not vulnerable to ``++brute force attacks++``.
-* not vulnerable to ``++collision attacks++`` (see rule s4790).
-* and a salt should be added to the password to lower the risk of ``++rainbow table attacks++`` (see rule s2053).
-
-This rule raises an issue when a password is stored in clear-text or with a hash algorithm vulnerable to ``++bruce force attacks++``. These algorithms, like ``++md5++`` or ``++SHA-family++``  functions are fast to compute the hash and therefore brute force attacks are possible (it's easier to exhaust the entire space of all possible passwords) especially with hardware like GPU, FPGA or ASIC. Modern password hashing algorithms such as ``++bcrypt++``, ``++PBKDF2++`` or ``++argon2++`` are recommended.

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -23,11 +23,11 @@ Many industries and jurisdictions have specific regulations and standards to pro
 
 == How to fix it in Spring
 
-A user password should never be stored in clear text. Instead, a hash should be produced from it using a secure algorithm:
+A user password should never be stored in clear text. Instead, a hash should be produced from it using a secure algorithm. When dealing with password storage security, best practices recommend relying on a slow hashing algorithm, that will make brute force attacks more difficult. Using a hashing function with adaptable computation and memory complexity also is recommended to be able to increase the security level with time.
 
-* not vulnerable to brute force attacks.
-* not vulnerable to first preimage or second preimage attacks: If a hash is leaked, it should be difficut to find a password produding this same hash. It should also be difficult to find a password that has the same hash than another password.
-* and a salt should be added to the password to lower the risk of rainbow table attacks (see rule S2053).
+Adding a salt to the digest computation is also recommended to prevent pre-computed table attacks (see rule S2053).
+
+In general, relying on an algorithm with no known weaknesses is also a requirement. This prevents the use of the MD5 or SHA-1 algorithms.
 
 While considered strong for some use cases, some algorithms, like SHA-family functions, are too fast to compute and therefore susceptible to brute force attacks, especially with attack-dedicated hardware. Modern, slow, password hashing algorithms such as bcrypt, PBKDF2 or argon2 are recommended.
 

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -63,13 +63,7 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
 
 === How does this work?
 
-The ``BCryptPasswordEncoder`` is a password hashing function in Java that is designed to be secure and resistant to various types of attacks, including brute-force and rainbow table attacks. It is based on the Blowfish encryption algorithm and uses a technique called key stretching to make it computationally expensive to hash passwords. Here's how ``BCryptPasswordEncoder`` works:
-
-* Salt Generation: When a password is hashed using ``BCryptPasswordEncoder``, a random salt is generated. The salt is a random value that is added to the password before hashing, making it unique for each password. The salt is then stored along with the hashed password.
-
-* Password Hashing: The password, along with the salt, is then passed through the BCrypt hashing function. The function applies a series of iterations to the password and salt, creating a hash value that is unique to that combination.
-
-* Hash Comparison: When a user attempts to authenticate, the entered password is hashed using the same salt and number of iterations as the stored password. The generated hash is then compared with the stored hash. If they match, the password is considered valid.
+The ``BCryptPasswordEncoder`` is a password hashing function in Java that is designed to be secure and resistant to various types of attacks, including brute-force and rainbow table attacks. It is slow, adaptative, and automatically implements a salt.
 
 == Resources
 

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -1,10 +1,43 @@
+The improper storage of passwords poses a significant security risk to software applications. This vulnerability arises when passwords are stored in plain-text or with a fast hashing algorithm. To exploit this vulnerability, an attacker would typically require access to the stored passwords or the ability to intercept them during transmission. 
+
 == Why is this an issue?
 
-include::../description.adoc[]
+By obtaining these passwords, the attacker can gain unauthorized access to user accounts, potentially leading to various malicious activities.
 
-=== Noncompliant code example
+=== What is the potential impact?
 
-[source,java]
+Plain-text or weakly hashed password storage poses a significant security risk to software applications.
+
+==== Unauthorized Access
+
+When passwords are stored in plain-text or with weak hashing algorithms, an attacker who gains access to the password database can easily retrieve and use the passwords to gain unauthorized access to user accounts. This can lead to various malicious activities, such as unauthorized data access, identity theft, or even financial fraud.
+
+==== Credential Reuse
+
+Many users tend to reuse passwords across multiple platforms. If an attacker obtains plain-text passwords or weakly hashed passwords, they can potentially use these credentials to gain unauthorized access to other accounts held by the same user. This can have far-reaching consequences, as sensitive personal information or critical systems may be compromised.
+
+==== Regulatory Compliance
+
+Many industries and jurisdictions have specific regulations and standards in place to protect user data and ensure its confidentiality. Storing passwords in plain-text or with weak hashing algorithms can lead to non-compliance with these regulations, potentially resulting in legal consequences, financial penalties, and damage to the reputation of the software application and its developers.
+
+
+== How to fix it in Java EE
+
+A user password should never be stored in clear-text, instead a hash should be produced from it using a secure algorithm:
+
+* not vulnerable to brute force attacks.
+* not vulnerable to collision attacks (see rule S4790).
+* and a salt should be added to the password to lower the risk of rainbow table attacks (see rule S2053).
+
+Some algorithms, like MD5 or SHA-family functions are fast to compute hashes and therefore brute force attacks are possible especially with hardware like GPU, FPGA or ASIC. Modern password hashing algorithms such as bcrypt, PBKDF2 or argon2 are recommended.
+
+=== Code examples
+
+==== Noncompliant code example
+
+The following code is vulnerable because it uses a legacy digest-based password encoding that is not considered secure.
+
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 @Autowired
 public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSource) throws Exception {
@@ -12,22 +45,12 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
     .dataSource(dataSource)
     .usersByUsernameQuery("SELECT * FROM users WHERE username = ?")
     .passwordEncoder(new StandardPasswordEncoder()); // Noncompliant
-
-  // OR
-  auth.jdbcAuthentication()
-    .dataSource(dataSource)
-    .usersByUsernameQuery("SELECT * FROM users WHERE username = ?"); // Noncompliant; default uses plain-text
-
-  // OR 
-  auth.userDetailsService(...); // Noncompliant; default uses plain-text
-  // OR 
-  auth.userDetailsService(...).passwordEncoder(new StandardPasswordEncoder()); // Noncompliant
 }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,java]
+[source,java,diff-id=1,diff-type=compliant]
 ----
 @Autowired
 public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSource) throws Exception {
@@ -35,13 +58,35 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
     .dataSource(dataSource)
     .usersByUsernameQuery("Select * from users where username=?")
     .passwordEncoder(new BCryptPasswordEncoder());
-
-  // or 
-  auth.userDetailsService(null).passwordEncoder(new BCryptPasswordEncoder());
 }
 ----
 
-include::../see.adoc[]
+=== How does this work?
+
+The ``BCryptPasswordEncoder`` is a password hashing function in Java that is designed to be secure and resistant to various types of attacks, including brute-force and rainbow table attacks. It is based on the Blowfish encryption algorithm and uses a technique called key stretching to make it computationally expensive to hash passwords. Here's how ``BCryptPasswordEncoder`` works:
+
+* Salt Generation: When a password is hashed using ``BCryptPasswordEncoder``, a random salt is generated. The salt is a random value that is added to the password before hashing, making it unique for each password. The salt is then stored along with the hashed password.
+
+* Password Hashing: The password, along with the salt, is then passed through the BCrypt hashing function. The function applies a series of iterations to the password and salt, creating a hash value that is unique to that combination.
+
+* Hash Comparison: When a user attempts to authenticate, the entered password is hashed using the same salt and number of iterations as the stored password. The generated hash is then compared with the stored hash. If they match, the password is considered valid.
+
+== Resources
+
+=== Documentation
+
+* Spring Framework Security Documentation - https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html[Class BCryptPasswordEncoder]
+
+=== Standards
+
+* https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
+* https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
+* https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html[OWASP CheatSheet] - Password Storage Cheat Sheet
+* https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
+* https://cwe.mitre.org/data/definitions/256[MITRE, CWE-256] - Plaintext Storage of a Password
+* https://cwe.mitre.org/data/definitions/916[MITRE, CWE-916] - Use of Password Hash With Insufficient Computational Effort
+* https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses
+
 
 ifdef::env-github,rspecator-view[]
 
@@ -49,7 +94,9 @@ ifdef::env-github,rspecator-view[]
 == Implementation Specification
 (visible only on this page)
 
-include::../message.adoc[]
+=== Message
+
+Use a secure password hashing algorithm.
 
 '''
 == Comments And Links

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -21,7 +21,7 @@ Many users tend to reuse passwords across multiple platforms. If an attacker obt
 Many industries and jurisdictions have specific regulations and standards to protect user data and ensure its confidentiality. Storing passwords in plain-text or with weak hashing algorithms can lead to non-compliance with these regulations, potentially resulting in legal consequences, financial penalties, and damage to the reputation of the software application and its developers.
 
 
-== How to fix it in Java EE
+== How to fix it in Spring
 
 A user password should never be stored in clear text. Instead, a hash should be produced from it using a secure algorithm:
 

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -26,7 +26,7 @@ Many industries and jurisdictions have specific regulations and standards to pro
 A user password should never be stored in clear text. Instead, a hash should be produced from it using a secure algorithm:
 
 * not vulnerable to brute force attacks.
-* not vulnerable to collision attacks (see rule S4790).
+* not vulnerable to first preimage or second preimage attacks: If a hash is leaked, it should be difficut to find a password produding this same hash. It should also be difficult to find a password that has the same hash than another password.
 * and a salt should be added to the password to lower the risk of rainbow table attacks (see rule S2053).
 
 While considered strong for some use cases, some algorithms, like SHA-family functions, are too fast to compute and therefore susceptible to brute force attacks, especially with attack-dedicated hardware. Modern, slow, password hashing algorithms such as bcrypt, PBKDF2 or argon2 are recommended.

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -1,8 +1,8 @@
-The improper storage of passwords poses a significant security risk to software applications. This vulnerability arises when passwords are stored in plain-text or with a fast hashing algorithm. To exploit this vulnerability, an attacker would typically require access to the stored passwords or the ability to intercept them during transmission. 
+The improper storage of passwords poses a significant security risk to software applications. This vulnerability arises when passwords are stored in plain-text or with a fast hashing algorithm. To exploit this vulnerability, an attacker typically requires access to the stored passwords. 
 
 == Why is this an issue?
 
-By obtaining these passwords, the attacker can gain unauthorized access to user accounts, potentially leading to various malicious activities.
+Attackers who would get access to the stored passwords could reuse them without further attacks or with little additional effort. Obtaining the clear-text passwords, they could then gain unauthorized access to user accounts, potentially leading to various malicious activities.
 
 === What is the potential impact?
 
@@ -14,22 +14,22 @@ When passwords are stored in plain-text or with weak hashing algorithms, an atta
 
 ==== Credential Reuse
 
-Many users tend to reuse passwords across multiple platforms. If an attacker obtains plain-text passwords or weakly hashed passwords, they can potentially use these credentials to gain unauthorized access to other accounts held by the same user. This can have far-reaching consequences, as sensitive personal information or critical systems may be compromised.
+Many users tend to reuse passwords across multiple platforms. If an attacker obtains plain-text or weakly hashed passwords, they can potentially use these credentials to gain unauthorized access to other accounts held by the same user. This can have far-reaching consequences, as sensitive personal information or critical systems may be compromised.
 
 ==== Regulatory Compliance
 
-Many industries and jurisdictions have specific regulations and standards in place to protect user data and ensure its confidentiality. Storing passwords in plain-text or with weak hashing algorithms can lead to non-compliance with these regulations, potentially resulting in legal consequences, financial penalties, and damage to the reputation of the software application and its developers.
+Many industries and jurisdictions have specific regulations and standards to protect user data and ensure its confidentiality. Storing passwords in plain-text or with weak hashing algorithms can lead to non-compliance with these regulations, potentially resulting in legal consequences, financial penalties, and damage to the reputation of the software application and its developers.
 
 
 == How to fix it in Java EE
 
-A user password should never be stored in clear-text, instead a hash should be produced from it using a secure algorithm:
+A user password should never be stored in clear text. Instead, a hash should be produced from it using a secure algorithm:
 
 * not vulnerable to brute force attacks.
 * not vulnerable to collision attacks (see rule S4790).
 * and a salt should be added to the password to lower the risk of rainbow table attacks (see rule S2053).
 
-Some algorithms, like MD5 or SHA-family functions are fast to compute hashes and therefore brute force attacks are possible especially with hardware like GPU, FPGA or ASIC. Modern password hashing algorithms such as bcrypt, PBKDF2 or argon2 are recommended.
+While considered strong for some use cases, some algorithms, like SHA-family functions, are too fast to compute and therefore susceptible to brute force attacks, especially with attack-dedicated hardware. Modern, slow, password hashing algorithms such as bcrypt, PBKDF2 or argon2 are recommended.
 
 === Code examples
 

--- a/rules/S5344/java/rule.adoc
+++ b/rules/S5344/java/rule.adoc
@@ -76,12 +76,12 @@ The ``BCryptPasswordEncoder`` is a password hashing function in Java that is des
 === Documentation
 
 * Spring Framework Security Documentation - https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html[Class BCryptPasswordEncoder]
+* https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html[OWASP CheatSheet] - Password Storage Cheat Sheet
 
 === Standards
 
 * https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
 * https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html[OWASP CheatSheet] - Password Storage Cheat Sheet
 * https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
 * https://cwe.mitre.org/data/definitions/256[MITRE, CWE-256] - Plaintext Storage of a Password
 * https://cwe.mitre.org/data/definitions/916[MITRE, CWE-916] - Use of Password Hash With Insufficient Computational Effort

--- a/rules/S5344/message.adoc
+++ b/rules/S5344/message.adoc
@@ -1,4 +1,0 @@
-=== Message
-
-Use a secure password hashing algorithm.
-

--- a/rules/S5344/rule.adoc
+++ b/rules/S5344/rule.adoc
@@ -1,6 +1,0 @@
-== Why is this an issue?
-
-include::description.adoc[]
-
-include::see.adoc[]
-

--- a/rules/S5344/see.adoc
+++ b/rules/S5344/see.adoc
@@ -1,9 +1,0 @@
-== Resources
-
-* https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Top 10 2021 Category A2] - Cryptographic Failures
-* https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP Top 10 2021 Category A4] - Insecure Design
-* https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html[OWASP CheatSheet] - Password Storage Cheat Sheet
-* https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure[OWASP Top 10 2017 Category A3] - Sensitive Data Exposure
-* https://cwe.mitre.org/data/definitions/256[MITRE, CWE-256] - Plaintext Storage of a Password
-* https://cwe.mitre.org/data/definitions/916[MITRE, CWE-916] - Use of Password Hash With Insufficient Computational Effort
-* https://www.sans.org/top25-software-errors/#cat3[SANS Top 25] - Porous Defenses


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

