### PR TITLE
Add CI task to validate file extension

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,7 +131,7 @@ validate_file_extensions_task:
     dockerfile: ci/Dockerfile
     cpu: 1
     memory: 2G
-  asciidoc_tests_script:
+  file_extension_tests_script:
     - ./ci/validate_file_extensions.sh
 
 all_required_checks_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,7 +132,7 @@ validate_file_extensions_task:
     cpu: 1
     memory: 2G
   file_extension_tests_script:
-    - ./ci/validate_file_extensions.sh
+    - bash ./ci/validate_file_extensions.sh
 
 all_required_checks_task:
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,6 +125,15 @@ validate_links_task:
     cache_upload_script:
       - bash ci/cirrus-cache.sh upload ${LINK_CACHE_NAME} ${LINK_CACHE_PATH}
 
+validate_file_extensions_task:
+  eks_container:
+    <<: *CONTAINER_DEFINITION
+    dockerfile: ci/Dockerfile
+    cpu: 1
+    memory: 2G
+  asciidoc_tests_script:
+    - ./ci/validate_file_extensions.sh
+
 all_required_checks_task:
   depends_on:
     - tooling_tests
@@ -132,6 +141,7 @@ all_required_checks_task:
     - validate_metadata
     - validate_asciidoc
     - validate_ci_tests
+    - validate_file_extensions
   eks_container:
     <<: *CONTAINER_DEFINITION
     dockerfile: ci/Dockerfile

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 
 TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
-CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
+CSVB_FILES=($(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb"))
 
 echo ${#CSVB_FILES[@]}
 

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -euxo pipefail
+set -exo pipefail
 
 TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
-
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
 if [ "${#CSVB_FILES[@]}" -gt 0 ]; then

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Validates that there are no files with .cs and .vb extensions present inside rules folder.
+# Validates that there are no files with .cs, .vb, .razor or .cshtml extensions present inside rules folder.
 #
 # As part of the new DotNet squad rule specification sprint guidelines, test case files similar to the ones 
 # used for unit tests in sonar-dotnet should be temporarely added under the rule folder on RSPEC repository. 
-# Those files can be of any number for both C# (*.cs) and VB.NET (.*vb).
+# Those files can be of any number for both C# (*.cs, *.razor, *.cshtml) and VB.NET (.*vb).
 # The test case files will be copied to the sonar-dotnet repository during the initial phases of implementation 
 # and will serve as an initial test bed.
 # Before merging the PR on the RSPEC side, it is important to ensure that these test case files are deleted.

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -6,7 +6,7 @@ RULES_DIR="${TOPLEVEL}/rules"
 
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
-if [[ ${#CSVB_FILES[@]} -gt 0 ]]; then
+if [[ "${#CSVB_FILES[@]}" -gt 0 ]]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
     echo $CSVB_FILES
     exit 1

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#
+# Validates that there are no files with .cs and .vb extensions present inside rules folder.
+#
+# As part of the new DotNet squad rule specification sprint guidelines, test case files similar to the ones 
+# used for unit tests in sonar-dotnet should be temporarely added under the rule folder on RSPEC repository. 
+# Those files can be of any number for both C# (*.cs) and VB.NET (.*vb).
+# The test case files will be copied to the sonar-dotnet repository during the initial phases of implementation 
+# and will serve as an initial test bed.
+# Before merging the PR on the RSPEC side, it is important to ensure that these test case files are deleted.
+# The script make sure to fail the CI if any of those previously mentioned files are present inside the rules folder.
 set -euxo pipefail
 
 TOPLEVEL="$(realpath .)"

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -7,7 +7,7 @@ CSVB_FILES=($(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb"))
 
 if [ ${#CSVB_FILES[@]} -gt 0 ]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
-    echo $CSVB_FILES
+    printf '%s\n' "${CSVB_FILES[@]}"
     exit 1
 else 
     echo "SUCCESS: no '.cs' or '.vb' files detected."

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -6,7 +6,7 @@ RULES_DIR="${TOPLEVEL}/rules"
 
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
-if [[ "${#CSVB_FILES[@]}" -gt 0 ]]; then
+if [ "${#CSVB_FILES[@]}" -gt 0 ]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
     echo $CSVB_FILES
     exit 1

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -5,6 +5,8 @@ TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
+echo ${#CSVB_FILES[@]}
+
 if [ ${#CSVB_FILES[@]} -gt 0 ]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
     echo $CSVB_FILES

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+TOPLEVEL="$(realpath "${TOPLEVEL}")"
+RULES_DIR="${TOPLEVEL}/rules"
+
+CS_FILES=$(find "${RULES_DIR}" -type f -name "*.cs")
+VB_FILES=$(find "${RULES_DIR}" -type f -name "*.vb")
+
+if [[ ${#CS_FILES[@]} -gt 0 ]] || [[ ${#VB_FILES[@]} -gt 0 ]]; then
+    echo "ERROR: '.cs' and/or '.vb' files are detected."
+    echo $CS_FILES
+    echo $VB_FILES
+    exit 1
+fi
+echo "SUCCESS: no '.cs' or '.vb' files detected."
+exit 0

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -13,10 +13,10 @@ set -euxo pipefail
 
 TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
-CSVB_FILES=($(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb"))
+CSVB_FILES=($(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb" -o -name "*.razor" -o -name "*.cshtml"))
 
 if [ ${#CSVB_FILES[@]} -gt 0 ]; then
-    echo "ERROR: '.cs' and/or '.vb' files are detected."
+    echo "ERROR: '.cs','.vb','.razor' or '.cshtml' files are detected."
     printf '%s\n' "${CSVB_FILES[@]}"
     exit 1
 else 

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-set -exo pipefail
+set -euxo pipefail
 
 TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
 CSVB_FILES=($(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb"))
-
-echo ${#CSVB_FILES[@]}
 
 if [ ${#CSVB_FILES[@]} -gt 0 ]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -5,7 +5,7 @@ TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
-if [ "${#CSVB_FILES[@]}" -gt 0 ]; then
+if [ ${#CSVB_FILES[@]} -gt 0 ]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
     echo $CSVB_FILES
     exit 1

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -5,14 +5,13 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 TOPLEVEL="$(realpath "${TOPLEVEL}")"
 RULES_DIR="${TOPLEVEL}/rules"
 
-CS_FILES=$(find "${RULES_DIR}" -type f -name "*.cs")
-VB_FILES=$(find "${RULES_DIR}" -type f -name "*.vb")
+CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")
 
-if [[ ${#CS_FILES[@]} -gt 0 ]] || [[ ${#VB_FILES[@]} -gt 0 ]]; then
+if [[ ${#CSVB_FILES[@]} -gt 0 ]]; then
     echo "ERROR: '.cs' and/or '.vb' files are detected."
-    echo $CS_FILES
-    echo $VB_FILES
+    echo $CSVB_FILES
     exit 1
+else 
+    echo "SUCCESS: no '.cs' or '.vb' files detected."
+    exit 0
 fi
-echo "SUCCESS: no '.cs' or '.vb' files detected."
-exit 0

--- a/ci/validate_file_extensions.sh
+++ b/ci/validate_file_extensions.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-TOPLEVEL="$(realpath "${TOPLEVEL}")"
+TOPLEVEL="$(realpath .)"
 RULES_DIR="${TOPLEVEL}/rules"
 
 CSVB_FILES=$(find "${RULES_DIR}" -type f -name "*.cs" -o -name "*.vb")


### PR DESCRIPTION
The dotnet squad would like to improve the rule specification sprint process requiring some UTs to be temporarily added under the rule folder on RSPEC repository. These test case files (`.cs` and `.vb`) will be copied to the sonar-dotnet repository during the initial phases of implementation and will serve as an initial test bed. 
However, before merging the PR on the RSPEC side we need to make sure that these test case files are deleted and they don't end up on master. 

The goal of this PR would be to add a check on the pipeline that will fail if `.cs` or `.vb` files are detected (it's acceptable if it's red until the implementation is done).