### PR TITLE
Modify rule S1854: Update 'quickfix' field

### DIFF
--- a/rules/S1854/cfamily/metadata.json
+++ b/rules/S1854/cfamily/metadata.json
@@ -16,5 +16,6 @@
     "CWE": [
       563
     ]  
-  }
+  },
+  "quickfix": "targeted"
 }

--- a/rules/S1854/csharp/metadata.json
+++ b/rules/S1854/csharp/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+  "quickfix": "targeted"
 }

--- a/rules/S1854/metadata.json
+++ b/rules/S1854/metadata.json
@@ -36,5 +36,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "targeted"
+  "quickfix": "unknown"
 }


### PR DESCRIPTION
Partially reverts `quickfix` changes done in https://github.com/SonarSource/rspec/pull/3150:
- C# and CFamily keep `targeted`
- all other languages go back to `unknown`

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

