### PR TITLE
Modify S1068: Migrate to LayC - unused private fields

### DIFF
--- a/rules/S1068/cfamily/rule.adoc
+++ b/rules/S1068/cfamily/rule.adoc
@@ -2,30 +2,17 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
-
 [source,cpp]
 ----
 class MyClass {
+  public:
+    int compute(int a) {
+      return a * 42;
+    }
+
+    int publicField = 0; // Compliant: might be used somewhere else
   private:
-    int foo = 42;  // Noncompliant, foo is unused
-
-  public:
-    int compute(int a) {
-      return a * 42;
-    }
-};
-----
-
-=== Compliant solution
-
-[source,cpp]
-----
-class MyClass {
-  public:
-    int compute(int a) {
-      return a * 42;
-    }
+    int foo = 42;  // Noncompliant: foo is unused and should be removed
 };
 ----
 

--- a/rules/S1068/description.adoc
+++ b/rules/S1068/description.adoc
@@ -1,1 +1,5 @@
-If a ``++private++`` field is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.
+If a `private` field is declared but not used locally, its limited visibility makes it dead code.
+
+This is either the sign that some logic is missing that should use this field or that the code should be cleaned.
+
+Cleaning out dead code decreases the size of the maintained codebase, making it easier to understand and preventing bugs from being introduced.

--- a/rules/S1068/description.adoc
+++ b/rules/S1068/description.adoc
@@ -1,5 +1,5 @@
 If a `private` field is declared but not used locally, its limited visibility makes it dead code.
 
-This is either the sign that some logic is missing that should use this field or that the code should be cleaned.
+This is either a sign that some logic is missing or that the code should be cleaned.
 
 Cleaning out dead code decreases the size of the maintained codebase, making it easier to understand and preventing bugs from being introduced.

--- a/rules/S1068/flex/rule.adoc
+++ b/rules/S1068/flex/rule.adoc
@@ -2,12 +2,10 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
-
 [source,flex]
 ----
 public class MyClass {
-  private var foo:int = 4;                       //foo is unused
+  private var foo:int = 4;  // Noncompliant: foo is unused and should be removed
 
   public function compute(a:int):int{
     return a * 4;
@@ -15,17 +13,6 @@ public class MyClass {
 }
 ----
 
-=== Compliant solution
-
-[source,flex]
-----
-public class MyClass {
-
-  public function compute(a:int):int{
-    return a * 4;
-  }
-}
-----
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1068/java/rule.adoc
+++ b/rules/S1068/java/rule.adoc
@@ -1,52 +1,39 @@
 == Why is this an issue?
 
-If a ``++private++`` field is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.
+include::../description.adoc[]
 
+[source,java]
+----
+public class MyClass {
+  private int foo = 42; // Noncompliant: foo is unused and should be removed
+
+  public int compute(int a) {
+    return a * 42;
+  }
+
+}
+----
 
 Note that this rule does not take reflection into account, which means that issues will be raised on ``++private++`` fields that are only accessed using the reflection API.
-
-=== Noncompliant code example
-
-[source,java]
-----
-public class MyClass {
-  private int foo = 42;
-
-  public int compute(int a) {
-    return a * 42;
-  }
-
-}
-----
-
-=== Compliant solution
-
-[source,java]
-----
-public class MyClass {
-  public int compute(int a) {
-    return a * 42;
-  }
-}
-----
 
 === Exceptions
 
 The rule admits 3 exceptions:
 
-* Serialization id fields
+* Serialization ID fields
 
-The Java serialization runtime associates with each serializable class a version number, called ``++serialVersionUID++``, which is used during deserialization to verify that the sender and receiver of a serialized object have loaded classes for that object that are compatible with respect to serialization.
+The Java serialization runtime associates with each serializable class a version number called `serialVersionUID`, which is used during deserialization to verify that the sender and receiver of a serialized object have loaded classes for that object that are compatible for serialization.
 
-A serializable class can declare its own ``++serialVersionUID++`` explicitly by declaring a field named ``++serialVersionUID++`` that must be static, final, and of type long. By definition those ``++serialVersionUID++`` fields should not be reported by this rule:
+A serializable class can declare its own `serialVersionUID` explicitly by declaring a field named `serialVersionUID` that must be static, final, and of type long. By definition, those `serialVersionUID` fields should not be reported by this rule:
 
 
 [source,java]
 ----
 public class MyClass implements java.io.Serializable {
-  private static final long serialVersionUID = 42L;
+  private static final long serialVersionUID = 42L;  // Compliant by exception
 }
 ----
+
 * Annotated fields
 
 The unused field in this class will not be reported by the rule as it is annotated.
@@ -54,7 +41,7 @@ The unused field in this class will not be reported by the rule as it is annotat
 ----
 public class MyClass {
   @SomeAnnotation
-  private int unused;
+  private int unused;  // Compliant by exception
 }
 ----
 
@@ -64,7 +51,7 @@ The unused field in this class will not be reported by the rule as it might be u
 [source,java]
 ----
 public class MyClass {
-  private int unused = 42;
+  private int unused = 42;  // Compliant by exception
   private native static void doSomethingNative();
 }
 ----

--- a/rules/S1068/php/rule.adoc
+++ b/rules/S1068/php/rule.adoc
@@ -2,24 +2,10 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
-
 [source,php]
 ----
 class MyClass {
-  private $foo = 4;                       //foo is unused
-
-  public function compute($a) {
-    return $a * 4;
-  }
-}
-----
-
-=== Compliant solution
-
-[source,php]
-----
-class MyClass {
+  private $foo = 4;            // Noncompliant: foo is unused and should be removed
 
   public function compute($a) {
     return $a * 4;

--- a/rules/S1068/rpg/rule.adoc
+++ b/rules/S1068/rpg/rule.adoc
@@ -1,23 +1,12 @@
 == Why is this an issue?
 
-If a variable is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.
-
-=== Noncompliant code example
+include::../description.adoc[]
 
 [source,rpg]
 ----
 D I               S              5P 0      INZ
 D* Noncompliant; X is not used in C-Specs
 D X               S              5P 0      INZ
-
-C                   EVAL      I = I + 1
-----
-
-=== Compliant solution
-
-[source,rpg]
-----
-D I               S              5P 0      INZ
 
 C                   EVAL      I = I + 1
 ----

--- a/rules/S1068/rule.adoc
+++ b/rules/S1068/rule.adoc
@@ -1,3 +1,0 @@
-== Why is this an issue?
-
-include::description.adoc[]

--- a/rules/S1068/vb6/rule.adoc
+++ b/rules/S1068/vb6/rule.adoc
@@ -1,22 +1,11 @@
 == Why is this an issue?
 
-If a private variable is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.
-
-=== Noncompliant code example
+include::../description.adoc[]
 
 [source,vb6]
 ----
-Private Foo as Integer
+Private Foo as Integer 'Noncompliant: Foo is unused and should be removed
 
-Function Compute(A As Integer)
-   Compute = A * 42
-End Function
-----
-
-=== Compliant solution
-
-[source,vb6]
-----
 Function Compute(A As Integer)
    Compute = A * 42
 End Function


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

