### PR TITLE
Modify S1135: Fix typo

### DIFF
--- a/rules/S1135/description.adoc
+++ b/rules/S1135/description.adoc
@@ -1,4 +1,4 @@
-Developers often use `TOOO` tags to mark areas in the code where additional work or improvements are needed but are not implemented immediately.
+Developers often use `TODO` tags to mark areas in the code where additional work or improvements are needed but are not implemented immediately.
 However, these `TODO` tags sometimes get overlooked or forgotten, leading to incomplete or unfinished code.
 This code smell class aims to identify and address such unattended `TODO` tags to ensure a clean and maintainable codebase.
 This description will explore why this is a problem and how it can be fixed to improve the overall code quality.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

