### PR TITLE
Modify S1121: Migrate to LayC - Assignments should not be made from within sub-expressions

### DIFF
--- a/rules/S1121/cfamily/metadata.json
+++ b/rules/S1121/cfamily/metadata.json
@@ -1,4 +1,5 @@
 {
+  "title": "Assignments should not be made from within conditions",
   "tags": [
     "cwe",
     "based-on-misra",

--- a/rules/S1121/cfamily/rule.adoc
+++ b/rules/S1121/cfamily/rule.adoc
@@ -3,43 +3,22 @@
 Assigning a value inside a condition (of an `if` statement, a `for` statement, a `while`, or a `switch`) can be confusing. It assigns the value and checks it at the same time, but it is easily confused with a simple equality check with `==` and the original intention can be unclear.
 
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
-void action(int parm) {
-  if (parm = getValue()) { // Noncompliant: assigning and checking. Is it on purpose?
+  if (x = getValue()) { // Noncompliant: assigning and checking. Is it on purpose?
     doSomething();
   }
-  // ...
-}
 ----
 
+It is better to assign before the statement and use the condition for the check only:
 
-{cpp}17 introduced `if` and `switch` statements with initializers, which allows to clearly separate the assignment from the check while keeping the code compact:
-
-
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
-void action(int parm) {
-  if (parm = getValue(); parm) { // Compliant: Assignment and check are separate
+  x = getValue();
+  if (x) {
     doSomething();
   }
-  // ...
-}
 ----
-
-For older versions of the standard, it is better to assign before the statement:
-
-[source,cpp]
-----
-void action(int parm) {
-  parm = getValue();
-  if (parm) { // Compliant
-    doSomething();
-  }
-  // ...
-}
-----
-
 
 === Exceptions
 
@@ -57,8 +36,6 @@ while ((run = keepRunning())) {
 === Documentation
 
 * CWE - https://cwe.mitre.org/data/definitions/481[481: Assigning instead of Comparing]
-
-* {cpp} Reference - https://en.cppreference.com/w/cpp/language/if#If_statements_with_initializer[If statements with initializer]
 
 === Standards
 

--- a/rules/S1121/cfamily/rule.adoc
+++ b/rules/S1121/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Assigning a value inside a condition (of an `if` statement, a `for` statement, a `while` or a `switch`) can be confusing. It assigns the value and checks it at the same time, but it is easily confused with a simple equality check with `==` and the original intention can be unclear.
+Assigning a value inside a condition (of an `if` statement, a `for` statement, a `while`, or a `switch`) can be confusing. It assigns the value and checks it at the same time, but it is easily confused with a simple equality check with `==` and the original intention can be unclear.
 
 
 [source,cpp]
@@ -14,7 +14,7 @@ void action(int parm) {
 ----
 
 
-{cpp}17 introduced `if` and `switch` statements with initializers, which allows to clearly separate the assignment and the check while keeping a compact code:
+{cpp}17 introduced `if` and `switch` statements with initializers, which allows to clearly separate the assignment from the check while keeping the code compact:
 
 
 [source,cpp]
@@ -27,7 +27,7 @@ void action(int parm) {
 }
 ----
 
-For older versions of the standard, it's better to assign before the statement:
+For older versions of the standard, it is better to assign before the statement:
 
 [source,cpp]
 ----
@@ -62,10 +62,9 @@ while ((run = keepRunning())) {
 
 === Standards
 
-* CERT https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[EXP45-C.: Do not perform assignments in selection statements]
-* CERT https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[EXP51-J.: Do not perform assignments in conditional expressions]
+* CERT - https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[EXP45-C. Do not perform assignments in selection statements]
 
-=== External guidelines
+=== External coding guidelines
 
 * MISRA C:2004, 13.1 - Assignment operators shall not be used in expressions that yield a Boolean value
 * MISRA {cpp}:2008, 6-2-1 - Assignment operators shall not be used in sub-expressions

--- a/rules/S1121/cfamily/rule.adoc
+++ b/rules/S1121/cfamily/rule.adoc
@@ -2,17 +2,41 @@
 
 include::../description.adoc[]
 
-include::../noncompliant.adoc[]
-
-include::../compliant.adoc[]
-
 === Exceptions
 
-Assignments explicitly enclosed in parentheses are ignored.
+This rule ignores assignments explicitly enclosed in parentheses.
 
+[source,cpp]
 ----
 while ((run = keepRunning())) {
   //...
+}
+----
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+int arr[] = {0, 1, 2, 3, 4};
+if (int a; a = arr[1]) {
+  // do something with "a"
+}
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+int arr[] = {0, 1, 2, 3, 4};
+int a = arr[1];
+if (a) {
+  // do something with "a"
 }
 ----
 

--- a/rules/S1121/cfamily/rule.adoc
+++ b/rules/S1121/cfamily/rule.adoc
@@ -1,6 +1,45 @@
 == Why is this an issue?
 
-include::../description.adoc[]
+Assigning a value inside a condition (of an `if` statement, a `for` statement, a `while` or a `switch`) can be confusing. It assigns the value and checks it at the same time, but it is easily confused with a simple equality check with `==` and the original intention can be unclear.
+
+
+[source,cpp]
+----
+void action(int parm) {
+  if (parm = getValue()) { // Noncompliant: assigning and checking. Is it on purpose?
+    doSomething();
+  }
+  // ...
+}
+----
+
+
+{cpp}17 introduced `if` and `switch` statements with initializers, which allows to clearly separate the assignment and the check while keeping a compact code:
+
+
+[source,cpp]
+----
+void action(int parm) {
+  if (parm = getValue(); parm) { // Compliant: Assignment and check are separate
+    doSomething();
+  }
+  // ...
+}
+----
+
+For older versions of the standard, it's better to assign before the statement:
+
+[source,cpp]
+----
+void action(int parm) {
+  parm = getValue();
+  if (parm) { // Compliant
+    doSomething();
+  }
+  // ...
+}
+----
+
 
 === Exceptions
 
@@ -13,41 +52,24 @@ while ((run = keepRunning())) {
 }
 ----
 
-== How to fix it
-
-include::../how-to-fix-it.adoc[]
-
-=== Code examples
-
-==== Noncompliant code example
-
-[source,cpp,diff-id=1,diff-type=noncompliant]
-----
-int arr[] = {0, 1, 2, 3, 4};
-if (int a; a = arr[1]) {
-  // do something with "a"
-}
-----
-
-==== Compliant solution
-
-[source,cpp,diff-id=1,diff-type=compliant]
-----
-int arr[] = {0, 1, 2, 3, 4};
-int a = arr[1];
-if (a) {
-  // do something with "a"
-}
-----
-
 == Resources
+
+=== Documentation
+
+* CWE - https://cwe.mitre.org/data/definitions/481[481: Assigning instead of Comparing]
+
+* {cpp} Reference - https://en.cppreference.com/w/cpp/language/if#If_statements_with_initializer[If statements with initializer]
+
+=== Standards
+
+* CERT https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[EXP45-C.: Do not perform assignments in selection statements]
+* CERT https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[EXP51-J.: Do not perform assignments in conditional expressions]
+
+=== External guidelines
 
 * MISRA C:2004, 13.1 - Assignment operators shall not be used in expressions that yield a Boolean value
 * MISRA {cpp}:2008, 6-2-1 - Assignment operators shall not be used in sub-expressions
 * MISRA C:2012, 13.4 - The result of an assignment operator should not be used
-* https://cwe.mitre.org/data/definitions/481[MITRE, CWE-481] - Assigning instead of Comparing
-* https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[CERT, EXP45-C.] - Do not perform assignments in selection statements
-* https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[CERT, EXP51-J.] - Do not perform assignments in conditional expressions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1121/compliant.adoc
+++ b/rules/S1121/compliant.adoc
@@ -1,8 +1,0 @@
-=== Compliant solution
-
-[source,text]
-----
-str = cont.substring(pos1, pos2);
-if (str.isEmpty()) {
-  //...
-----

--- a/rules/S1121/csharp/rule.adoc
+++ b/rules/S1121/csharp/rule.adoc
@@ -6,6 +6,16 @@ include::../description.adoc[]
 
 Assignments inside lambda and delegate expressions are allowed.
 
+[source,csharp]
+----
+var result = Foo(() =>
+{
+   int x = 100; // dead store, but ignored
+   x = 200;
+   return x;
+}
+----
+
 The rule also ignores the following patterns:
 
 * Chained assignments

--- a/rules/S1121/csharp/rule.adoc
+++ b/rules/S1121/csharp/rule.adoc
@@ -4,16 +4,18 @@ include::../description.adoc[]
 
 === Exceptions
 
-The rule ignores the following patterns:
+Assignments inside lambda and delegate expressions are allowed.
+
+The rule also ignores the following patterns:
 
 * Chained assignments
-* Assignments enclosed in relational expressions
-* Assignment in a right-hand side of coalescing operator
 
 [source,csharp]
 ----
 var a = b = c = 10;
 ----
+
+* Assignments that are part of a condition of an `if` statement or a loop
 
 [source,csharp]
 ----
@@ -23,16 +25,12 @@ while ((val = GetNewValue()) > 0)
 }
 ----
 
+* Assignment in the right-hand side of a coalescing operator
+
 [source,csharp]
 ----
 private MyClass instance;
-public MyClass Instance
-{
-  get
-  {
-    return instance ?? (instance = new MyClass());
-  }
-}
+public MyClass Instance => instance ?? (instance = new MyClass());
 ----
 
 == How to fix it

--- a/rules/S1121/csharp/rule.adoc
+++ b/rules/S1121/csharp/rule.adoc
@@ -2,33 +2,13 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
-
-[source,csharp]
-----
-if (string.IsNullOrEmpty(result = str.Substring(index, length))) // Noncompliant
-{
-  //...
-}
-----
-
-=== Compliant solution
-
-[source,csharp]
-----
-var result = str.Substring(index, length);
-if (string.IsNullOrEmpty(result))
-{
-  //...
-}
-----
-
 === Exceptions
 
-Assignments inside lambda and delegate expressions are allowed. 
+The rule ignores the following patterns:
 
-
-Furthermore, the following patterns are also accepted:
+* Chained assignments
+* Assignments enclosed in relational expressions
+* Assignment in a right-hand side of coalescing operator
 
 [source,csharp]
 ----
@@ -52,6 +32,33 @@ public MyClass Instance
   {
     return instance ?? (instance = new MyClass());
   }
+}
+----
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
+----
+if (string.IsNullOrEmpty(result = str.Substring(index, length))) // Noncompliant
+{
+  // do something with "result"
+}
+----
+
+==== Compliant solution
+
+[source,csharp,diff-id=1,diff-type=compliant]
+----
+var result = str.Substring(index, length);
+if (string.IsNullOrEmpty(result))
+{
+  // do something with "result"
 }
 ----
 

--- a/rules/S1121/description.adoc
+++ b/rules/S1121/description.adoc
@@ -1,1 +1,4 @@
-Assignments within sub-expressions are hard to spot and therefore make the code less readable. Ideally, sub-expressions should not have side-effects.
+A common code smell that can hinder the clarity of source code is making assignments within sub-expressions.
+This practice involves assigning a value to a variable inside a larger expression, such as within a loop or a conditional statement.
+
+This practice essentially gives a side-effect to a larger expression, thus making it less readable. This often leads to confusion and potential errors.

--- a/rules/S1121/how-to-fix-it.adoc
+++ b/rules/S1121/how-to-fix-it.adoc
@@ -1,0 +1,5 @@
+Making assignments within sub-expressions can hinder the clarity of source code.
+
+This practice essentially gives a side-effect to a larger expression, thus making it less readable. This often leads to confusion and potential errors.
+
+Extracting assignments into separate statements is encouraged to keep the code clear and straightforward.

--- a/rules/S1121/java/rule.adoc
+++ b/rules/S1121/java/rule.adoc
@@ -59,7 +59,6 @@ if (!str.isEmpty()) {
 
 include::../see.adoc[]
 
-* https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[CERT, EXP45-C.] - Do not perform assignments in selection statements
 * https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[CERT, EXP51-J.] - Do not perform assignments in conditional expressions
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1121/java/rule.adoc
+++ b/rules/S1121/java/rule.adoc
@@ -2,27 +2,59 @@
 
 include::../description.adoc[]
 
-include::../noncompliant.adoc[]
-
-include::../compliant.adoc[]
-
 === Exceptions
 
-Assignments in ``++while++`` statement conditions, and assignments enclosed in relational expressions are ignored.
+This rule ignores assignments in conditions of ``++while++`` statements and assignments enclosed in relational expressions.
 
+[source,java]
 ----
-BufferedReader br = new BufferedReader(/* ... */);
-String line;
-while ((line = br.readLine()) != null) {...}
-if ((i = j) >= 1) {...}
+void processInput(BufferedReader br) {
+  String line;
+  while ((line = br.readLine()) != null) {
+    processLine(line);
+  }
+}
+
+Object foo;
+if ((foo = bar()) != null) {
+  // do something with "foo"
+}
 ----
 
-Chained assignments, including compound assignments, are ignored.
+This rule also ignores chained assignments, including compound assignments.
 
+[source,java]
 ----
-int i = j = 0;
+int j, i = j = 0;
 int k = (j += 1);
+byte[] result, bresult;
 result = (bresult = new byte[len]);
+----
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=1,diff-type=noncompliant]
+----
+String str;
+if (!(str = cont.substring(pos1, pos2)).isEmpty()) {  // Noncompliant
+  // do something with "str"
+}
+----
+
+==== Compliant solution
+
+[source,java,diff-id=1,diff-type=compliant]
+----
+String str = cont.substring(pos1, pos2);
+if (!str.isEmpty()) {
+  // do something with "str"
+}
 ----
 
 == Resources

--- a/rules/S1121/java/rule.adoc
+++ b/rules/S1121/java/rule.adoc
@@ -4,7 +4,7 @@ include::../description.adoc[]
 
 === Exceptions
 
-This rule ignores assignments in conditions of ``++while++`` statements and assignments enclosed in relational expressions.
+This rule ignores assignments in conditions of `while` statements and assignments enclosed in relational expressions.
 
 [source,java]
 ----
@@ -57,9 +57,8 @@ if (!str.isEmpty()) {
 }
 ----
 
-== Resources
+include::../see.adoc[]
 
-* https://cwe.mitre.org/data/definitions/481[MITRE, CWE-481] - Assigning instead of Comparing
 * https://wiki.sei.cmu.edu/confluence/x/ZNYxBQ[CERT, EXP45-C.] - Do not perform assignments in selection statements
 * https://wiki.sei.cmu.edu/confluence/x/ITZGBQ[CERT, EXP51-J.] - Do not perform assignments in conditional expressions
 

--- a/rules/S1121/javascript/rule.adoc
+++ b/rules/S1121/javascript/rule.adoc
@@ -2,31 +2,11 @@
 
 include::../description.adoc[]
 
-Moreover, using chained assignment in declarations is also dangerous because one may accidentally create global variables, e.g. in ``++let x = y = 1;++``, if ``++y++`` is not declared, it will be hoisted as global.
-
-=== Noncompliant code example
-
-[source,javascript]
-----
-if (val = value() && check()) { // Noncompliant
-  // ...
-}
-----
-
-=== Compliant solution
-
-[source,javascript]
-----
-val = value();
-if (val && check()) {
-  // ...
-}
-----
+Moreover, using chained assignments in declarations is also dangerous because one may accidentally create global variables. Consider the following code snippet: ``++let x = y = 1;++``. If ``++y++`` is not declared, it will be hoisted as global.
 
 === Exceptions
 
 The rule does not raise issues for the following patterns:
-
 
 * chained assignments: ``++a = b = c = 0;++``
 * relational assignments: ``++(a = 0) != b++``
@@ -34,6 +14,31 @@ The rule does not raise issues for the following patterns:
 * assignments in lambda body: ``++() => a = 0++``
 * conditional assignment idiom: ``++a || (a = 0)++``
 * assignments in (do-)while conditions: ``++while (a = 0);++``
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,javascript,diff-id=1,diff-type=noncompliant]
+----
+if (val = value() && check()) { // Noncompliant
+  // ...
+}
+----
+
+==== Compliant solution
+
+[source,javascript,diff-id=1,diff-type=compliant]
+----
+val = value();
+if (val && check()) {
+  // ...
+}
+----
 
 include::../see.adoc[]
 

--- a/rules/S1121/noncompliant.adoc
+++ b/rules/S1121/noncompliant.adoc
@@ -1,7 +1,0 @@
-=== Noncompliant code example
-
-[source,text]
-----
-if ((str = cont.substring(pos1, pos2)).isEmpty()) {  // Noncompliant
-  //...
-----

--- a/rules/S1121/php/rule.adoc
+++ b/rules/S1121/php/rule.adoc
@@ -2,17 +2,34 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+=== Exceptions
+
+This rule ignores assignments in conditions of ``++while++`` statements and assignments enclosed in relational expressions.
 
 [source,php]
+----
+while (($line = next_line()) != NULL) {...}
+
+while ($line = next_line()) {...}
+----
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,php,diff-id=1,diff-type=noncompliant]
 ----
 if (($val = value()) && check()) { // Noncompliant
 }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,php]
+[source,php,diff-id=1,diff-type=compliant]
 ----
 $val = value();
 if ($val && check()) {
@@ -20,21 +37,10 @@ if ($val && check()) {
 ----
 or 
 
-[source,php]
+[source,php,diff-id=1,diff-type=compliant]
 ----
-if ($val == value() && check()) { // Perhaps in fact the equality operator was expected
+if ($val == value() && check()) { // Original intention might have been to use equality operator and not assignment
 }
-----
-
-=== Exceptions
-
-Assignments in ``++while++`` statement conditions, and assignments enclosed in relational expressions are allowed.
-
-[source,php]
-----
-while (($line = next_line()) != NULL) {...}
-
-while ($line = next_line()) {...}
 ----
 
 include::../see.adoc[]

--- a/rules/S1121/php/rule.adoc
+++ b/rules/S1121/php/rule.adoc
@@ -4,7 +4,7 @@ include::../description.adoc[]
 
 === Exceptions
 
-This rule ignores assignments in conditions of ``++while++`` statements and assignments enclosed in relational expressions.
+This rule ignores assignments in conditions of `while` statements and assignments enclosed in relational expressions.
 
 [source,php]
 ----

--- a/rules/S1121/rule.adoc
+++ b/rules/S1121/rule.adoc
@@ -1,9 +1,0 @@
-== Why is this an issue?
-
-include::description.adoc[]
-
-include::noncompliant.adoc[]
-
-include::compliant.adoc[]
-
-include::see.adoc[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

