### PR TITLE
Modify S1117: Migrate To LayC - shadow variables

### DIFF
--- a/rules/S1117/cfamily/metadata.json
+++ b/rules/S1117/cfamily/metadata.json
@@ -1,4 +1,5 @@
 {
+  "title": "Variables should not be shadowed",
   "tags": [
     "based-on-misra",
     "cert",

--- a/rules/S1117/cfamily/metadata.json
+++ b/rules/S1117/cfamily/metadata.json
@@ -11,7 +11,6 @@
   ],
   "securityStandards": {
     "CERT": [
-      "DCL51-J.",
       "DCL01-C."
     ]
   }

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -98,10 +98,10 @@ if (ExpectedData e = readData()) {
 
 This rule also raises issues on some variables, although they do not shadow another variable according to a strict interpretation of the {cpp} language. There are mainly two reasons for this.
 
- . The primary one is that the readability and maintainability of the code are impaired.
+ . Primarily, the readability and maintainability of the code are impaired.
    Readers need an advanced understanding of the {cpp} language to understand the subtle differences.
 
- . The second motivation is that a small change can lead to actual shadowing.
+ . Secondly, a small change can lead to actual shadowing.
    This can lead to subtle bugs when updating the code.
 
 Here is an example with nested classes:
@@ -115,19 +115,14 @@ public:
 };
 
 class A::B {
-  void f(int x) { // Noncompliant
-    // The parameter "x" shadows the field "A::x".
-  }
-
-  void illFormed() {
-    x = 42; // Error: use of non-static data member 'x' of 'A' from nested type 'B'
+  void f(int x) { // Noncompliant: The parameter "x" shadows the field "A::x".
+    // ...
   }
 };
 ----
 
-In the above example, `A::x` cannot be used from `A::B` member functions because it is not a static field.
-Changing the declaration of `A::x` from `int x;` to `static int x;` would make the code compile.
-This can lead to surprising effects when moving code around, for example.
+In the above example, `A::x` cannot be used from `A::B` member functions because it is not a `static` field.
+This can lead to surprising effects when moving code around, particularly if the declaration of `A::x` was changed from `int x;` to `static int x;`.
 
 You should always avoid shadowing to avoid any confusion and increase the maintainability of your code.
 

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -3,6 +3,8 @@ include::../why-general.adoc[]
 
 The examples below show typical situations in which shadowing can occur.
 
+ * Parameter shadowing
++
 [source,cpp]
 ----
 void f(int x, bool b) {
@@ -13,7 +15,12 @@ void f(int x, bool b) {
     // ...
   }
 }
+----
 
+* Member variable shadowing
++
+[source,cpp]
+----
 class Foo {
 private:
   int myField;
@@ -24,7 +31,12 @@ public:
     // ...
   }
 };
+----
 
+* Global variable shadowing
++
+[source,cpp]
+----
 namespace ns {
   int state;
 

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -1,8 +1,7 @@
 include::../why-general.adoc[]
 
-=== Noncompliant code example
 
-The example below shows the typical situations in which shadowing can occur.
+The examples below show typical situations in which shadowing can occur.
 
 [source,cpp]
 ----

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 === Noncompliant code example

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -80,20 +80,17 @@ This can be even more confusing and result in unintended behavior, as illustrate
 
 [source,cpp]
 ----
-if (std::expected<std::string, std::error_code> e = readData())
-{
-  std::cout << *e << std::endl;
-}
-else if (std::expected<std::string, std::error_code> e = readFallbackSource())
-{
-  std::cout << "Initial source failed with: "
-    << e.error().message() << std::endl; // Ups, I mean previous e here
-  std::cout << *e << std::endl;
-}
-else
-{
-  std::cout << "Initial source failed with: "
-    << e.error().message() << std::endl; // Ups, I mean first e here
+using ExpectedData = std::expected<std::string, std::error_code>;
+
+if (ExpectedData e = readData()) {
+  printMessage(e.value());
+} else if (ExpectedData e = readFallbackSource()) { // Noncompliant
+  printMessage(e.value());
+} else {
+  logError(
+    "Initial source failed with: ",
+    e.error() // Contrary to the intention, the second "e" is used.
+  );
 }
 ----
 

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -1,19 +1,4 @@
-== Why is this an issue?
-
-Variable shadowing happens when a variable declared in a specific scope has the same name as a variable in an outer scope.
-This can lead to three main problems:
-
-* Confusion:
-  The same name can refer to different variables in different parts of the scope, making the code hard to read and understand.
-
-* Unintended Behavior:
-  You might accidentally use the wrong variable, leading to hard-to-detect bugs.
-
-* Maintenance Issues:
-  If the inner variable is removed or renamed, the code's behavior might change unexpectedly because the outer variable is now being used.
-
-To avoid these problems, rename the shadowing, shadowed, or both variables to accurately represent their purpose with unique and meaningful names.
-It improves clarity and allows reasoning locally about the code without considering other software parts.
+include::../why-general.adoc[]
 
 === Noncompliant code example
 

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -1,93 +1,158 @@
-include::../why.adoc[]
+== Why is this an issue?
+
+Variable shadowing happens when a variable declared in a specific scope has the same name as a variable in an outer scope.
+This can lead to three main problems:
+
+* Confusion:
+  The same name can refer to different variables in different parts of the scope, making the code hard to read and understand.
+
+* Unintended Behavior:
+  You might accidentally use the wrong variable, leading to hard-to-detect bugs.
+
+* Maintenance Issues:
+  If the inner variable is removed or renamed, the code's behavior might change unexpectedly because the outer variable is now being used.
+
+To avoid these problems, rename the shadowing, shadowed, or both variables to accurately represent their purpose with unique and meaningful names.
+It improves clarity and allows reasoning locally about the code without considering other software parts.
 
 === Noncompliant code example
 
-[source,cpp]
-----
-class Foo
-{
-public:
-  void doSomething();
-
-private: 
-  int myField;
-};
-
-void Foo::doSomething()
-{
-    int myField = 0; // Noncompliant
-    // ...
-}
-----
+The example below shows the typical situations in which shadowing can occur.
 
 [source,cpp]
 ----
 void f(int x, bool b) {
-  int y = 4; 
+  int y = 4;
   if (b) {
-    int x = 7; // Noncompliant
-    int y = 9; // Noncompliant
+    int x = 7; // Noncompliant: the parameter "x" is shadowed.
+    int y = 9; // Noncompliant: the local variable "y" is shadowed.
     // ...
   }
 }
-----
 
-=== Compliant solution
-
-[source,cpp]
-----
-class Foo
-{
-public:
-  void doSomething();
-
-private: 
+class Foo {
+private:
   int myField;
+
+public:
+  void doSomething() {
+    int myField = 0; // Noncompliant: Foo::myField is shadowed.
+    // ...
+  }
 };
 
-void Foo::doSomething()
-{
-    int myInternalField = 0; // Compliant
-    // ...
-}
-----
+namespace ns {
+  int state;
 
-
-[source,cpp]
-----
-void f(int x, bool b) {
-  int y = 4; 
-  if (b) {
-    int z = 7; // Better yet: Use meaningful names
-    int w = 9;
-    // ...
+  void bar() {
+    int state = 0; // Noncompliant: the namespace variable is shadowed.
   }
 }
 ----
 
 === Exceptions
 
-It is common in a constructor to have constructor arguments shadowing the fields that they will initialize. This pattern avoids the need to select new names for the constructor arguments, and will not be reported by this rule:
+It is common practice to have constructor arguments shadowing the fields they initialize in the _member initializer list_.
+This pattern avoids the need to select new names for the constructor arguments and will not be reported by this rule.
 
 [source,cpp]
 ----
-class Point{
+class Point {
 public:
-  Point(int x, int y) : x(x), y(y) {} // Compliant by exception
+  Point(int x, int y)
+    : x(x) // Compliant by exception: the parameter "x" is used
+           // in the member initializer list.
+  {
+    y = y; // Noncompliant: the parameter is assigned to itself
+           // and the member "y" is not initialized.
+  }
+
 private:
   int x;
   int y;
 };
 ----
 
+=== Pitfalls
+
+==== Shadowing in `if`, `else if`, and `else`
+
+Variables can be introduced in the condition of an `if` statement.
+Their scope includes the optional `else` statement, which may be surprising.
+Consequently, such variables can be shadowed in an `else if` statement.
+This can be even more confusing and result in unintended behavior, as illustrated in this example:
+
+[source,cpp]
+----
+if (std::expected<std::string, std::error_code> e = readData())
+{
+  std::cout << *e << std::endl;
+}
+else if (std::expected<std::string, std::error_code> e = readFallbackSource())
+{
+  std::cout << "Initial source failed with: "
+    << e.error().message() << std::endl; // Ups, I mean previous e here
+  std::cout << *e << std::endl;
+}
+else
+{
+  std::cout << "Initial source failed with: "
+    << e.error().message() << std::endl; // Ups, I mean first e here
+}
+----
+
+==== Shadowing of inaccessible declarations
+
+This rule also raises issues on some variables, although they do not shadow another variable according to a strict interpretation of the {cpp} language. There are mainly two reasons for this.
+
+ . The primary one is that the readability and maintainability of the code are impaired.
+   Readers need an advanced understanding of the {cpp} language to understand the subtle differences.
+
+ . The second motivation is that a small change can lead to actual shadowing.
+   This can lead to subtle bugs when updating the code.
+
+Here is an example with nested classes:
+
+[source,cpp]
+----
+class A {
+public:
+  int x;
+  class B;
+};
+
+class A::B {
+  void f(int x) { // Noncompliant
+    // The parameter "x" shadows the field "A::x".
+  }
+
+  void illFormed() {
+    x = 42; // Error: use of non-static data member 'x' of 'A' from nested type 'B'
+  }
+};
+----
+
+In the above example, `A::x` cannot be used from `A::B` member functions because it is not a static field.
+Changing the declaration of `A::x` from `int x;` to `static int x;` would make the code compile.
+This can lead to surprising effects when moving code around, for example.
+
+You should always avoid shadowing to avoid any confusion and increase the maintainability of your code.
+
 == Resources
 
-=== Documentation
+=== External coding guidelines
 
 * MISRA C:2004, 5.2 - Identifiers in an inner scope shall not use the same name as an identifier in an outer scope, and therefore hide that identifier
 * MISRA {cpp}:2008, 2-10-2 - Identifiers declared in an inner scope shall not hide an identifier declared in an outer scope
 * MISRA C:2012, 5.3 - An identifier declared in an inner scope shall not hide an identifier declared in an outer scope
+
+=== Standards
+
 * https://wiki.sei.cmu.edu/confluence/display/c/DCL01-C.+Do+not+reuse+variable+names+in+subscopes[CERT, DCL01-C.] - Do not reuse variable names in subscopes
 * https://wiki.sei.cmu.edu/confluence/display/java/DCL51-J.+Do+not+shadow+or+obscure+identifiers+in+subscopes[CERT, DCL51-J.] - Do not shadow or obscure identifiers in subscopes
+
+=== Related rules
+
+* S2387 - Child class fields should not shadow parent class fields
 
 include::../rspecator.adoc[]

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -148,8 +148,7 @@ You should always avoid shadowing to avoid any confusion and increase the mainta
 
 === Standards
 
-* https://wiki.sei.cmu.edu/confluence/display/c/DCL01-C.+Do+not+reuse+variable+names+in+subscopes[CERT, DCL01-C.] - Do not reuse variable names in subscopes
-* https://wiki.sei.cmu.edu/confluence/display/java/DCL51-J.+Do+not+shadow+or+obscure+identifiers+in+subscopes[CERT, DCL51-J.] - Do not shadow or obscure identifiers in subscopes
+* CERT - https://wiki.sei.cmu.edu/confluence/display/c/DCL01-C.+Do+not+reuse+variable+names+in+subscopes[DCL01-C. Do not reuse variable names in subscopes]
 
 === Related rules
 

--- a/rules/S1117/cfamily/rule.adoc
+++ b/rules/S1117/cfamily/rule.adoc
@@ -69,7 +69,7 @@ private:
 };
 ----
 
-=== Pitfalls
+=== Caveats
 
 ==== Shadowing in `if`, `else if`, and `else`
 

--- a/rules/S1117/csharp/rule.adoc
+++ b/rules/S1117/csharp/rule.adoc
@@ -1,17 +1,15 @@
-:message: Rename "${elementName}" which hides the (field|property) with the same name.
-
 == Why is this an issue?
 
 Overriding or shadowing a field or a property declared in an outer scope can strongly impact the readability, and therefore the maintainability, of a piece of code. Developers may mistakenly assume they are modifying or accessing the class field/property when, in fact, they are working with the local variable.
 
 [source,csharp]
 ----
-class Foo 
+class Foo
 {
   public int myField;
   public int MyProperty { get; set; }
 
-  public void DoSomething() 
+  public void DoSomething()
   {
     int myField = 0;    // Noncompliant
     int MyProperty = 0; // Noncompliant

--- a/rules/S1117/csharp/rule.adoc
+++ b/rules/S1117/csharp/rule.adoc
@@ -1,6 +1,15 @@
 == Why is this an issue?
 
-Overriding or shadowing a field or a property declared in an outer scope can strongly impact the readability, and therefore the maintainability, of a piece of code. Developers may mistakenly assume they are modifying or accessing the class field/property when, in fact, they are working with the local variable.
+Shadowing occurs when a local variable has the same name as a variable, field, or property in an outer scope.
+
+include::../problems.adoc[]
+
+To avoid these problems, rename the shadowing, shadowed, or both variables/fields/properties to accurately represent their purpose with unique and meaningful names.
+It improves clarity and allows reasoning locally about the code without considering other software parts.
+
+This rule focuses on variables shadowing fields or properties.
+
+=== Noncompliant code example
 
 [source,csharp]
 ----
@@ -21,7 +30,12 @@ class Foo
 
 === Documentation
 
-* https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/fields[Fields]
-* https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties[Properties]
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/fields[Fields]
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties[Properties]
+
+=== Related rules
+
+* S2387 - Child class fields should not shadow parent class fields
+* S3218 - Inner class members should not shadow outer class "static" or type members
 
 include::../rspecator.adoc[]

--- a/rules/S1117/flex/rule.adoc
+++ b/rules/S1117/flex/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 [source,flex]

--- a/rules/S1117/flex/rule.adoc
+++ b/rules/S1117/flex/rule.adoc
@@ -1,4 +1,6 @@
-include::../why.adoc[]
+include::../why-fields.adoc[]
+
+=== Noncompliant code example
 
 [source,flex]
 ----
@@ -6,8 +8,8 @@ class Foo {
   public var myField:int;
 
   public function doSomething():String {
-    var myField:int = 0; /* Noncompliant */
-    ...
+    var myField:int = 0; // Noncompliant
+    //...
   }
 }
 ----

--- a/rules/S1117/java/metadata.json
+++ b/rules/S1117/java/metadata.json
@@ -7,8 +7,7 @@
   ],
   "securityStandards": {
     "CERT": [
-      "DCL51-J.",
-      "DCL01-C."
+      "DCL51-J."
     ]
   }
 }

--- a/rules/S1117/java/rule.adoc
+++ b/rules/S1117/java/rule.adoc
@@ -1,4 +1,6 @@
-include::../why.adoc[]
+include::../why-fields.adoc[]
+
+=== Noncompliant code example
 
 [source,java]
 ----
@@ -7,7 +9,7 @@ class Foo {
 
   public void doSomething() {
     int myField = 0; // Noncompliant
-    ...
+    // ...
   }
 }
 ----
@@ -17,5 +19,11 @@ class Foo {
 === Documentation
 
 * CERT - https://wiki.sei.cmu.edu/confluence/display/java/DCL51-J.+Do+not+shadow+or+obscure+identifiers+in+subscopes[DCL51-J. Do not shadow or obscure identifiers in subscopes]
+
+=== Related rules
+
+* S2176 - Class names should not shadow interfaces or superclasses
+* S2387 - Child class fields should not shadow parent class fields
+* S4977 - Type parameters should not shadow other type parameters
 
 include::../rspecator.adoc[]

--- a/rules/S1117/java/rule.adoc
+++ b/rules/S1117/java/rule.adoc
@@ -16,7 +16,6 @@ class Foo {
 
 === Documentation
 
-* https://wiki.sei.cmu.edu/confluence/display/c/DCL01-C.+Do+not+reuse+variable+names+in+subscopes[CERT, DCL01-C.] - Do not reuse variable names in subscopes
-* https://wiki.sei.cmu.edu/confluence/display/java/DCL51-J.+Do+not+shadow+or+obscure+identifiers+in+subscopes[CERT, DCL51-J.] - Do not shadow or obscure identifiers in subscopes
+* CERT - https://wiki.sei.cmu.edu/confluence/display/java/DCL51-J.+Do+not+shadow+or+obscure+identifiers+in+subscopes[DCL51-J. Do not shadow or obscure identifiers in subscopes]
 
 include::../rspecator.adoc[]

--- a/rules/S1117/java/rule.adoc
+++ b/rules/S1117/java/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 [source,java]

--- a/rules/S1117/javascript/metadata.json
+++ b/rules/S1117/javascript/metadata.json
@@ -1,4 +1,5 @@
 {
+  "title": "Variables should not be shadowed",
   "defaultQualityProfiles": [
   ],
   "scope": "Main"

--- a/rules/S1117/javascript/rule.adoc
+++ b/rules/S1117/javascript/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 include::../rspecator.adoc[]

--- a/rules/S1117/javascript/rule.adoc
+++ b/rules/S1117/javascript/rule.adoc
@@ -1,3 +1,38 @@
-include::../why.adoc[]
+include::../why-general.adoc[]
+
+Note that variables can also shadow functions.
+
+=== Noncompliant code example
+
+The example below shows the typical situations in which shadowing can occur.
+
+[source,javascript]
+----
+function example(items) {
+  var counter = 0;
+
+  let nested = function(items) { // Noncompliant: the parameter "items" is shadowed.
+    var counter = counter + 1; // Noncompliant: the outer "counter" is shadowed.
+  }
+
+  nested(items);
+
+  return counter; // returns 0
+}
+
+function search(items, match) { // Noncompliant: the function "match" (below) is shadowed.
+  // ...
+}
+
+function match(value, key) {
+  // ...
+}
+----
+
+== Resources
+
+=== Related rules
+
+* S2814 - Variables and functions should not be redeclared
 
 include::../rspecator.adoc[]

--- a/rules/S1117/javascript/rule.adoc
+++ b/rules/S1117/javascript/rule.adoc
@@ -1,6 +1,6 @@
 include::../why-general.adoc[]
 
-Note that variables can also shadow functions.
+Note that functions in JavaScript are first-class citizens. This means that they possess the same attributes as variables, including the ability to shadow other variables and, conversely, be shadowed by them. 
 
 === Noncompliant code example
 
@@ -8,14 +8,14 @@ The example below shows the typical situations in which shadowing can occur.
 
 [source,javascript]
 ----
-function example(items) {
+function outer(items) {
   var counter = 0;
 
-  let nested = function(items) { // Noncompliant: the parameter "items" is shadowed.
+  function inner(items) { // Noncompliant: the parameter "items" is shadowed.
     var counter = counter + 1; // Noncompliant: the outer "counter" is shadowed.
   }
 
-  nested(items);
+  inner(items);
 
   return counter; // returns 0
 }

--- a/rules/S1117/metadata.json
+++ b/rules/S1117/metadata.json
@@ -1,5 +1,4 @@
 {
-  "title": "Variables should not be shadowed",
   "type": "CODE_SMELL",
   "code": {
     "impacts": {

--- a/rules/S1117/php/rule.adoc
+++ b/rules/S1117/php/rule.adoc
@@ -1,4 +1,6 @@
-include::../why.adoc[]
+include::../why-fields.adoc[]
+
+=== Noncompliant code example
 
 [source,php]
 ----

--- a/rules/S1117/php/rule.adoc
+++ b/rules/S1117/php/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 [source,php]

--- a/rules/S1117/plsql/metadata.json
+++ b/rules/S1117/plsql/metadata.json
@@ -1,3 +1,3 @@
 {
-  
+  "title": "Variables should not be shadowed"
 }

--- a/rules/S1117/plsql/rule.adoc
+++ b/rules/S1117/plsql/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which (hides|has the same name as) the field declared at line {}.
-
 include::../why.adoc[]
 
 [source,sql,diff-id=1,diff-type=noncompliant]

--- a/rules/S1117/plsql/rule.adoc
+++ b/rules/S1117/plsql/rule.adoc
@@ -1,4 +1,8 @@
-include::../why.adoc[]
+include::../why-general.adoc[]
+
+=== Noncompliant code example
+
+The example below shows the typical situation in which shadowing can occur.
 
 [source,sql,diff-id=1,diff-type=noncompliant]
 ----
@@ -17,6 +21,8 @@ BEGIN
 END;
 /
 ----
+
+=== Compliant solution
 
 [source,sql,diff-id=1,diff-type=compliant]
 ----

--- a/rules/S1117/problems.adoc
+++ b/rules/S1117/problems.adoc
@@ -1,0 +1,11 @@
+This can lead to three main problems:
+
+* Confusion:
+  The same name can refer to different variables in different parts of the scope, making the code hard to read and understand.
+
+* Unintended Behavior:
+  You might accidentally use the wrong variable, leading to hard-to-detect bugs.
+
+* Maintenance Issues:
+  If the inner variable is removed or renamed, the code's behavior might change unexpectedly because the outer variable is now being used.
+

--- a/rules/S1117/rspecator.adoc
+++ b/rules/S1117/rspecator.adoc
@@ -1,20 +1,5 @@
 ifdef::env-github,rspecator-view[]
 
-'''
-== Implementation Specification
-(visible only on this page)
-
-=== Message
-
-{message}
-
-=== Highlighting
-
-* Primary: shadowing variable
-* Secondary: shadowed variable
-** message: 'Shadowed variable/field.'
-
-'''
 == Comments And Links
 (visible only on this page)
 

--- a/rules/S1117/swift/rule.adoc
+++ b/rules/S1117/swift/rule.adoc
@@ -1,6 +1,15 @@
 == Why is this an issue?
 
-Shadowing fields or `enum case`s with a local variable is a bad practice that reduces code readability: It makes it confusing to know whether the field or the variable is being used.
+Shadowing occurs when a local variable has the same name as a variable, field, or `enum case` in an outer scope.
+
+include::../problems.adoc[]
+
+To avoid these problems, rename the shadowing, shadowed, or both variables/fields/``enum case``s to accurately represent their purpose with unique and meaningful names.
+It improves clarity and allows reasoning locally about the code without considering other software parts.
+
+This rule focuses on variables shadowing fields or ``enum case``s.
+
+=== Noncompliant code example
 
 [source,swift]
 ----
@@ -9,7 +18,7 @@ public class Foo {
 
   public func doSomething() {
     var myField = 0 /// Noncompliant
-    ...
+    // ...
   }
 }
 ----

--- a/rules/S1117/swift/rule.adoc
+++ b/rules/S1117/swift/rule.adoc
@@ -4,7 +4,7 @@ Shadowing occurs when a local variable has the same name as a variable, field, o
 
 include::../problems.adoc[]
 
-To avoid these problems, rename the shadowing, shadowed, or both variables/fields/``enum case``s to accurately represent their purpose with unique and meaningful names.
+To avoid these problems, rename the shadowing, shadowed, or both identifiers to accurately represent their purpose with unique and meaningful names.
 It improves clarity and allows reasoning locally about the code without considering other software parts.
 
 This rule focuses on variables shadowing fields or ``enum case``s.

--- a/rules/S1117/swift/rule.adoc
+++ b/rules/S1117/swift/rule.adoc
@@ -1,5 +1,3 @@
-:message: Rename "${elementName}" which has the same name as the (field|case) declared at line {}.
-
 == Why is this an issue?
 
 Shadowing fields or `enum case`s with a local variable is a bad practice that reduces code readability: It makes it confusing to know whether the field or the variable is being used.

--- a/rules/S1117/why-fields.adoc
+++ b/rules/S1117/why-fields.adoc
@@ -1,0 +1,10 @@
+== Why is this an issue?
+
+Shadowing occurs when a local variable has the same name as a variable or a field in an outer scope.
+
+include::./problems.adoc[]
+
+To avoid these problems, rename the shadowing, shadowed, or both variables/fields to accurately represent their purpose with unique and meaningful names.
+It improves clarity and allows reasoning locally about the code without considering other software parts.
+
+This rule focuses on variables in methods that shadow a field.

--- a/rules/S1117/why-fields.adoc
+++ b/rules/S1117/why-fields.adoc
@@ -5,6 +5,5 @@ Shadowing occurs when a local variable has the same name as a variable or a fiel
 include::./problems.adoc[]
 
 To avoid these problems, rename the shadowing, shadowed, or both variables/fields to accurately represent their purpose with unique and meaningful names.
-It improves clarity and allows reasoning locally about the code without considering other software parts.
 
 This rule focuses on variables in methods that shadow a field.

--- a/rules/S1117/why-fields.adoc
+++ b/rules/S1117/why-fields.adoc
@@ -4,6 +4,6 @@ Shadowing occurs when a local variable has the same name as a variable or a fiel
 
 include::./problems.adoc[]
 
-To avoid these problems, rename the shadowing, shadowed, or both variables/fields to accurately represent their purpose with unique and meaningful names.
+To avoid these problems, rename the shadowing, shadowed, or both identifiers to accurately represent their purpose with unique and meaningful names.
 
 This rule focuses on variables in methods that shadow a field.

--- a/rules/S1117/why-general.adoc
+++ b/rules/S1117/why-general.adoc
@@ -6,4 +6,3 @@ Variable shadowing happens when a variable declared in a specific scope has the 
 include::problems.adoc[]
 
 To avoid these problems, rename the shadowing, shadowed, or both variables to accurately represent their purpose with unique and meaningful names.
-It improves clarity and allows reasoning locally about the code without considering other software parts.

--- a/rules/S1117/why-general.adoc
+++ b/rules/S1117/why-general.adoc
@@ -1,0 +1,9 @@
+
+== Why is this an issue?
+
+Variable shadowing happens when a variable declared in a specific scope has the same name as a variable in an outer scope.
+
+include::problems.adoc[]
+
+To avoid these problems, rename the shadowing, shadowed, or both variables to accurately represent their purpose with unique and meaningful names.
+It improves clarity and allows reasoning locally about the code without considering other software parts.

--- a/rules/S1117/why.adoc
+++ b/rules/S1117/why.adoc
@@ -1,3 +1,0 @@
-== Why is this an issue?
-
-Overriding or shadowing a variable declared in an outer scope can strongly impact the readability, and therefore the maintainability, of a piece of code. Further, it could lead maintainers to introduce bugs because they think they’re using one variable but are really using another.


### PR DESCRIPTION
The languages for this rule fall into two categories:

 * CFamily, JS, and PLSQL: "Variables should not be shadowed" (general case of shadowing)
 * C#, Flex, Java, PHP, Swift: "Local variables should not shadow field/property/enum case/..." (narrow case of shadowing)

For CFamily, these tickets are also handled: CPP-2785 CPP-3589

## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

