### PR TITLE
Modify S5738: Migrate to LayC - `@Deprecated` code marked for removal should never be used

### DIFF
--- a/rules/S5738/java/rule.adoc
+++ b/rules/S5738/java/rule.adoc
@@ -1,19 +1,22 @@
 == Why is this an issue?
 
-Java 9 introduced a flag for the ``++@Deprecated++`` annotation, which allows to explicitly say if the deprecated code is planned to be removed at some point or not. This is done using ``++forRemoval=true++`` as annotation parameter. The javadoc of the annotation explicitly mention the following: 
-
-
-____
-If true, it means that this API element is earmarked for removal in a future release.
-
-If false, the API element is deprecated, but there is currently no intention to remove it in a future release.
+With the introduction of Java 9, the standard annotation class `java.lang.Deprecated` has been updated with new parameters. Notably, a boolean parameter `forRemoval` has been added to clearly signify whether the deprecated code is intended to be removed in the future. This is indicated with `forRemoval=true`. The javadoc of the annotation explicitly mentions the following: 
 
 ____
+This annotation type has a boolean-valued element `forRemoval`. A value of `true` indicates intent to remove the annotated program element in a future version. A value of `false` indicates that use of the annotated program element is discouraged, but at the time the program element was annotated, there was no specific intent to remove it.
+____
 
-While usually deprecated classes, interfaces, and their deprecated members should be avoided rather than used, inherited or extended, those already marked for removal are much more sensitive to causing trouble in your code soon. Consequently, any usage of such deprecated code should be avoided or removed.
+While it is generally recommended for developers to steer clear of using deprecated classes, interfaces, and their deprecated members, those already marked for removal will surely block you from upgrading your dependency. Usage of deprecated code should be avoided or eliminated as soon as possible to prevent accumulation and allow a smooth upgrade of dependencies.
 
+The deprecated code is usually no longer maintained, can contain some bugs or vulnerabilities, and usually indicates that there is a better way to do the same thing. Removing it can even lead to significant improvement of your software.
 
-=== Noncompliant code example
+== How to fix it
+
+Usage of deprecated classes, interfaces, and their methods explicitly marked for removal is discouraged. A developer should either migrate to alternative methods or refactor the code to avoid the deprecated ones.
+
+=== Code examples
+
+==== Noncompliant code example
 
 [source,java]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

