### PR TITLE
Modify S1774: Migrate to LayC - remove ternary expression

### DIFF
--- a/rules/S1774/cfamily/rule.adoc
+++ b/rules/S1774/cfamily/rule.adoc
@@ -2,17 +2,26 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+=== Exceptions
 
-[source,cpp]
+For {cpp}11 mode only, the issue is not raised for ternary operators used inside `constexpr` functions.
+In {cpp}11 such functions are limited to just a return statement, so the use of a ternary operator
+is required in them. This restriction is lifted in later standards, and thus issues are raised.
+
+== How to fix it
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 printf("%s", (i > 10 ? "yes" : "no"));
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 if (i > 10) {
   printf("yes");
@@ -20,14 +29,6 @@ if (i > 10) {
   printf("no");
 }
 ----
-
-
-=== Exceptions
-
-For {cpp}11 mode only, the issue is not raised for ternary operators used inside `constexpr` functions. 
-In {cpp}11 such functions are limited to just a return statement, so the use of a ternary operator
-is required in them. This restriction is lifted in later standards, and thus issues are raised.
-
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1774/cfamily/rule.adoc
+++ b/rules/S1774/cfamily/rule.adoc
@@ -8,8 +8,6 @@ For {cpp}11 mode only, the issue is not raised for ternary operators used inside
 In {cpp}11 such functions are limited to just a return statement, so the use of a ternary operator
 is required in them. This restriction is lifted in later standards, and thus issues are raised.
 
-== How to fix it
-
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1774/cfamily/rule.adoc
+++ b/rules/S1774/cfamily/rule.adoc
@@ -2,24 +2,18 @@
 
 include::../description.adoc[]
 
-=== Exceptions
-
-For {cpp}11 mode only, the issue is not raised for ternary operators used inside `constexpr` functions.
-In {cpp}11 such functions are limited to just a return statement, so the use of a ternary operator
-is required in them. This restriction is lifted in later standards, and thus issues are raised.
-
 === Code examples
 
 ==== Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp]
 ----
-printf("%s", (i > 10 ? "yes" : "no"));
+printf("%s", (i > 10 ? "yes" : "no"));  // Noncompliant
 ----
 
 ==== Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp]
 ----
 if (i > 10) {
   printf("yes");
@@ -27,6 +21,12 @@ if (i > 10) {
   printf("no");
 }
 ----
+
+=== Exceptions
+
+For {cpp}11 mode only, the issue is not raised for ternary operators used inside `constexpr` functions.
+In {cpp}11 such functions are limited to just a return statement, so the use of a ternary operator
+is required in them. This restriction is lifted in later standards, and thus issues are raised.
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1774/description.adoc
+++ b/rules/S1774/description.adoc
@@ -1,1 +1,3 @@
-While the ternary operator is pleasingly compact, its use can make code more difficult to read. It should therefore be avoided in favor of the more verbose ``++if++``/``++else++`` structure.
+Ternary expressions, while concise, can often lead to code that is difficult to read and understand, especially when they are nested or complex.
+Prioritizing readability fosters maintainability and reduces the likelihood of bugs.
+Therefore, they should be removed in favor of more explicit control structures, such as `if`/`else` statements, to improve the clarity and readability of the code.

--- a/rules/S1774/java/rule.adoc
+++ b/rules/S1774/java/rule.adoc
@@ -2,16 +2,20 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+== How to fix it
 
-[source,java]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
 System.out.println(i>10?"yes":"no");
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,java]
+[source,java,diff-id=1,diff-type=compliant]
 ----
 if (i > 10) {
   System.out.println("yes");

--- a/rules/S1774/java/rule.adoc
+++ b/rules/S1774/java/rule.adoc
@@ -2,8 +2,6 @@
 
 include::../description.adoc[]
 
-== How to fix it
-
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1774/java/rule.adoc
+++ b/rules/S1774/java/rule.adoc
@@ -6,14 +6,14 @@ include::../description.adoc[]
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java]
 ----
-System.out.println(i>10?"yes":"no");
+System.out.println(i>10?"yes":"no");  // Noncompliant
 ----
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java]
 ----
 if (i > 10) {
   System.out.println("yes");

--- a/rules/S1774/javascript/rule.adoc
+++ b/rules/S1774/javascript/rule.adoc
@@ -2,8 +2,6 @@
 
 include::../description.adoc[]
 
-== How to fix it
-
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1774/javascript/rule.adoc
+++ b/rules/S1774/javascript/rule.adoc
@@ -2,9 +2,13 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+== How to fix it
 
-[source,javascript]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 function foo(a) {
   var b = (a === 'A') ? 'is A' : 'is not A'; // Noncompliant
@@ -12,9 +16,9 @@ function foo(a) {
 }
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,javascript]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 function foo(a) {
   var b;


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

