### PR TITLE
Modify S905: Migrate to LaYC - Non-empty statements should change control flow or have at least one side-effect

### DIFF
--- a/rules/S905/cfamily/rule.adoc
+++ b/rules/S905/cfamily/rule.adoc
@@ -6,9 +6,7 @@ include::../description.adoc[]
 
 === Exceptions
 
-The rule does not raise an issue:
-
-* Statements containing only a semicolon (``++;++``)
+The rule does not raise an issue on statements containing only a semicolon (``++;++``).
 
 == How to fix it
 

--- a/rules/S905/cfamily/rule.adoc
+++ b/rules/S905/cfamily/rule.adoc
@@ -4,6 +4,12 @@ include::../summary.adoc[]
 
 include::../description.adoc[]
 
+=== Exceptions
+
+The rule does not raise an issue:
+
+* Statements containing only a semicolon (``++;++``)
+
 == How to fix it
 
 include::../how-to-fix.adoc[]
@@ -71,11 +77,14 @@ int sub(int a, int b) {
 
 == Resources
 
-=== Documentation
+=== Standards
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+* CWE - https://cwe.mitre.org/data/definitions/482[482 Comparing instead of Assigning]
+* CERT - https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[MSC12-C. Detect and remove code that has no effect or is never executed]
+
+=== External coding guidelines
+
 * MISRA C:2004, 14.2 - All non-null statements shall either have at least one side-effect however executed or cause control flow to change.
-* https://wiki.sei.cmu.edu/confluence/x/5dUxBQ[CERT, MSC12-C.] - Detect and remove code that has no effect or is never executed
 
 === Related rules
 

--- a/rules/S905/description.adoc
+++ b/rules/S905/description.adoc
@@ -7,9 +7,3 @@ contributes to the overall functionality of the program. When they have no side 
    caused by mistyping, copy-and-paste errors, etc. 
 
 2. The statements are residual after a refactoring.
-
-=== Exceptions
-
-The rule does not raise an issue:
-
-* Statements containing only a semicolon (``++;++``)

--- a/rules/S905/javascript/rule.adoc
+++ b/rules/S905/javascript/rule.adoc
@@ -6,9 +6,7 @@ include::../description.adoc[]
 
 === Exceptions
 
-The rule does not raise an issue:
-
-* Statements containing only a semicolon (``++;++``)
+The rule does not raise an issue on statements containing only a semicolon (``++;++``).
 
 == How to fix it
 

--- a/rules/S905/javascript/rule.adoc
+++ b/rules/S905/javascript/rule.adoc
@@ -1,14 +1,57 @@
+include::../summary.adoc[]
+
 == Why is this an issue?
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+=== Exceptions
 
-[source,javascript]
+The rule does not raise an issue:
+
+* Statements containing only a semicolon (``++;++``)
+
+== How to fix it
+
+include::../how-to-fix.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
-a == 1; // Noncompliant; was assignment intended?
+function getResult() {
+    let result = 42;
+    if (shouldBeZero()) {
+        result == 0; // Noncompliant: no side effect, was an assignment intended?
+    }
+    return result;
+}
+----
+
+[source,javascript,diff-id=2,diff-type=noncompliant]
+----
 var msg = "Hello, "
   "World!"; // Noncompliant; have we forgotten '+' operator on previous line?
+----
+
+==== Compliant solution
+
+[source,javascript,diff-id=1,diff-type=compliant]
+----
+function getResult() {
+    let result = 42;
+    if (shouldBeZero()) {
+        result = 0; // Compliant
+    }
+    return result;
+}
+----
+
+[source,javascript,diff-id=2,diff-type=compliant]
+----
+var msg = "Hello, " +
+  "World!"; // Compliant
 ----
 
 include::../see.adoc[]

--- a/rules/S905/php/rule.adoc
+++ b/rules/S905/php/rule.adoc
@@ -6,9 +6,7 @@ include::../description.adoc[]
 
 === Exceptions
 
-The rule does not raise an issue:
-
-* Statements containing only a semicolon (``++;++``)
+The rule does not raise an issue on statements containing only a semicolon (``++;++``).
 
 == How to fix it
 

--- a/rules/S905/php/rule.adoc
+++ b/rules/S905/php/rule.adoc
@@ -1,14 +1,47 @@
+include::../summary.adoc[]
+
 == Why is this an issue?
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+=== Exceptions
+
+The rule does not raise an issue:
+
+* Statements containing only a semicolon (``++;++``)
+
+== How to fix it
+
+include::../how-to-fix.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
 
 [source,php]
 ----
-$a == 1; // Noncompliant; was assignment intended? 
-$a < $b; // Noncompliant; have we forgotten to assign the result to a variable? 
+function getResult() {
+    $result = 42;
+    if (shouldBeZero()) {
+        $result == 0; // Noncompliant: no side effect, was an assignment intended?
+    }
+    return $result;
+}
 ----
+
+==== Compliant solution
+
+[source,php]
+----
+function getResult() {
+    $result = 42;
+    if (shouldBeZero()) {
+        $result = 0; // Compliant
+    }
+    return $result;
+}
+----
+
 
 include::../see.adoc[]
 

--- a/rules/S905/python/rule.adoc
+++ b/rules/S905/python/rule.adoc
@@ -1,32 +1,30 @@
+include::../summary.adoc[]
+
 == Why is this an issue?
 
-Any statement, other than a ``++pass++``, ``++...++`` (ellipsis) or an empty statement (i.e. a single semicolon \"``++;++``"), which has no side effect and does not result in a change of control flow will normally indicate a programming error, and therefore should be refactored.
-
-=== Noncompliant code example
-
-[source,python]
-----
-a == 1 # Noncompliant; was assignment intended?
-a < b # Noncompliant; have we forgotten to assign the result to a variable?
-----
+include::../description.adoc[]
 
 === Exceptions
 
+*Intentionally empty statement*
+
+Statements such as ``++pass++`` or ``++...++`` (ellipsis) are clearly meant to have no effect and may be used to indicate an implementation is missing. No issue will be raised in this case.
+
 *Strings*
 
-Some projects use string literals as comments. By default, this rule will not raise an issue on these strings. Reporting on string literals can be enabled by setting the rule parameter "reportOnStrings" to "true".
-
+Some projects use string literals as comments. By default, this rule will not raise an issue on these strings. Reporting on string literals can be enabled by setting the rule parameter `reportOnStrings` to `true`.
 
 [source,python]
 ----
-class MyClass:
-    myattr = 42
-    """This is an attribute"""  # Noncompliant by default. Set "reportOnStrings" to "false"
+def foo():
+    bar()
+    """Some comment"""  # Compliant by default. Noncompliant with "reportOnStrings" set to "true"
+    qix()
 ----
 
 *Operators*
 
-By default, this rule considers that no arithmetic operator has a side effect. Some rare projects redefine operators and add a side effect. You can list such operators in the rule parameter "ignoredOperators".
+By default, this rule considers that no arithmetic operator has a side effect. Some projects may redefine operators and add a side effect. You can list such operators in the rule parameter `ignoredOperators`.
 
 
 [source,python]
@@ -37,6 +35,34 @@ def process(p, beam):
     Thus for Apache Beam projects "ignoredOperators"should be set to "|,>>"
     """
     p | "create" >> beam.Create()  # Noncompliant by default
+----
+
+== How to fix it
+
+include::../how-to-fix.adoc[]
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,python]
+----
+def get_result():
+    result = 42
+    if should_be_zero():
+        result == 0 # Noncompliant: no side effect, was an assignment intended?
+    return result
+----
+
+==== Compliant solution
+
+[source,python]
+----
+def get_result():
+    result = 42
+    if should_be_zero():
+        result = 0 # Compliant
+    return result
 ----
 
 include::../see.adoc[]

--- a/rules/S905/see.adoc
+++ b/rules/S905/see.adoc
@@ -1,3 +1,5 @@
 == Resources
 
-* https://cwe.mitre.org/data/definitions/482[MITRE, CWE-482] - Comparing instead of Assigning
+=== Standards
+
+* CWE - https://cwe.mitre.org/data/definitions/482[482 Comparing instead of Assigning]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

