### PR TITLE
Normalize links to C++ reference

### DIFF
--- a/docs/link_formatting.adoc
+++ b/docs/link_formatting.adoc
@@ -45,7 +45,7 @@ When web pages have massively long names like "Java™ Platform, Standard Editio
 * AWS blog - https://aws.amazon.com/blogs
 * Azure Documentation - https://learn.microsoft.com/en-us/azure/?product=popular
 * CERT  - https://wiki.sei.cmu.edu/confluence/display/seccode
-* CPP reference/C++ reference - https://en.cppreference.com/w/
+* {cpp} reference - https://en.cppreference.com/w/
 * C++ Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md
 * CVE - https://cve.mitre.org
 * CWE - https://cwe.mitre.org

--- a/rules/S1039/cfamily/rule.adoc
+++ b/rules/S1039/cfamily/rule.adoc
@@ -61,8 +61,9 @@ void g(int i) noexcept {
 == Resources
 
 === Documentation
-* C{plus}{plus} reference - https://en.cppreference.com/w/cpp/language/throw[`throw` expression]
-* C{plus}{plus} reference - https://en.cppreference.com/w/cpp/error/terminate[`std::terminate`]
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/throw[`throw` expression]
+* {cpp} reference - https://en.cppreference.com/w/cpp/error/terminate[`std::terminate`]
 
 === External coding guidelines
 

--- a/rules/S1232/cfamily/rule.adoc
+++ b/rules/S1232/cfamily/rule.adoc
@@ -140,7 +140,7 @@ std::string _pChar{100, '\0'};
 
 === Documentation
 
-* {cpp} Reference - https://en.cppreference.com/w/cpp/language/raii[RAII (Resource Acquisition Is Initialization)]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/raii[RAII (Resource Acquisition Is Initialization)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -18,7 +18,7 @@ This rule will only work if the format string is provided as a string literal.
 
 === Documentation
 
-* https://en.cppreference.com/w/cpp/utility/format/format[`std::format` starting from C++20]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/format/format[`std::format` starting from C++20]
 
 === Standards
 

--- a/rules/S3529/cfamily/rule.adoc
+++ b/rules/S3529/cfamily/rule.adoc
@@ -132,9 +132,9 @@ Class* p3 = objPtr.get();  // becomes dangling, when objPtr releases the pointer
 
 === Documentation
 
-- {cpp} reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
-- {cpp} reference - https://en.cppreference.com/w/cpp/memory/unique_ptr[std::unique_ptr]
-- {cpp} reference - https://en.cppreference.com/w/cpp/memory/shared_ptr[std::shared_ptr]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
+* {cpp} reference - https://en.cppreference.com/w/cpp/memory/unique_ptr[std::unique_ptr]
+* {cpp} reference - https://en.cppreference.com/w/cpp/memory/shared_ptr[std::shared_ptr]
 
 === Standards
 

--- a/rules/S3584/cfamily/rule.adoc
+++ b/rules/S3584/cfamily/rule.adoc
@@ -221,7 +221,7 @@ bool fire(Point pos, Direction dir, State const& s) {
 === Documentation
 
 * Wikipedia - https://en.wikipedia.org/wiki/Memory_leak[Memory leak]
-* C++ reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
 
 === Standards
 

--- a/rules/S5272/cfamily/rule.adoc
+++ b/rules/S5272/cfamily/rule.adoc
@@ -225,7 +225,7 @@ int bar() {
 
 === Documentation
 
-* {cpp} Reference - https://en.cppreference.com/w/cpp/language/move_constructor[Move constructors]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/move_constructor[Move constructors]
 
 === Conference presentations
 

--- a/rules/S5403/cfamily/rule.adoc
+++ b/rules/S5403/cfamily/rule.adoc
@@ -43,7 +43,7 @@ void swap(S& s1, S& s2) noexcept;
 
 == Resources
 
-* https://en.cppreference.com/w/cpp/language/noexcept_spec[Noexcept specifier]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/noexcept_spec[Noexcept specifier]
 * http://blogs.microsoft.co.il/sasha/2014/08/08/make-move-constructors-no-throw/[Make move constructor nothrow]
 
 

--- a/rules/S5417/cfamily/rule.adoc
+++ b/rules/S5417/cfamily/rule.adoc
@@ -84,9 +84,9 @@ struct C {
 
 == Resources
 
-* https://en.cppreference.com/w/cpp/utility/move[std::move]
-* https://en.cppreference.com/w/cpp/utility/forward[std::forward]
-* https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/move[std::move]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/forward[std::forward]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#f18-for-will-move-from-parameters-pass-by-x-and-stdmove-the-parameter[{cpp} Core Guidelines F.18] - For “will-move-from” parameters, pass by ``++X&&++`` and ``++std::move++`` the parameter
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#f19-for-forward-parameters-pass-by-tp-and-only-stdforward-the-parameter[{cpp} Core Guidelines F.19] - For “forward” parameters, pass by ``++TP&&++`` and only ``++std::forward++`` the parameter
 

--- a/rules/S5524/cfamily/rule.adoc
+++ b/rules/S5524/cfamily/rule.adoc
@@ -56,7 +56,7 @@ void f() { // Compliant: C++17 solution
 == Resources
 
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#cp21-use-stdlock-or-stdscoped_lock-to-acquire-multiple-mutexes[{cpp} Core Guidelines CP.21] - Use std::lock() or std::scoped_lock to acquire multiple mutexes
-* https://en.cppreference.com/w/cpp/thread/scoped_lock[cppreference.com - std::scoped_lock]
+* {cpp} reference - https://en.cppreference.com/w/cpp/thread/scoped_lock[cppreference.com - std::scoped_lock]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5553/cfamily/rule.adoc
+++ b/rules/S5553/cfamily/rule.adoc
@@ -333,13 +333,13 @@ std::cout <<c <<std::endl; // c refers to the memory formerly occupied by a temp
 
 === Documentation
 
-- C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
-- C++ reference - https://en.cppreference.com/w/cpp/language/range-for[Range-based for loop / Temporary range expression]
-- C++ reference - https://en.cppreference.com/w/cpp/header/string_view[string_view]
+* C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
+* C++ reference - https://en.cppreference.com/w/cpp/language/range-for[Range-based for loop / Temporary range expression]
+* C++ reference - https://en.cppreference.com/w/cpp/header/string_view[string_view]
 
 === Articles & blog posts
 
-- Abseil - https://abseil.io/tips/107[Tip of the Week #107: Reference Lifetime Extension]
+* Abseil - https://abseil.io/tips/107[Tip of the Week #107: Reference Lifetime Extension]
 
 ifdef::env-github,rspecator-view[]
 '''

--- a/rules/S5553/cfamily/rule.adoc
+++ b/rules/S5553/cfamily/rule.adoc
@@ -333,9 +333,9 @@ std::cout <<c <<std::endl; // c refers to the memory formerly occupied by a temp
 
 === Documentation
 
-* C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
-* C++ reference - https://en.cppreference.com/w/cpp/language/range-for[Range-based for loop / Temporary range expression]
-* C++ reference - https://en.cppreference.com/w/cpp/header/string_view[string_view]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/range-for[Range-based for loop / Temporary range expression]
+* {cpp} reference - https://en.cppreference.com/w/cpp/header/string_view[string_view]
 
 === Articles & blog posts
 

--- a/rules/S5558/cfamily/rule.adoc
+++ b/rules/S5558/cfamily/rule.adoc
@@ -43,7 +43,7 @@ public:
 
 == Resources
 
-* https://en.cppreference.com/w/cpp/language/aggregate_initialization
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/aggregate_initialization
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5570/cfamily/rule.adoc
+++ b/rules/S5570/cfamily/rule.adoc
@@ -29,7 +29,7 @@ This rule does not apply to overloaded operators because they respect the sequen
 == Resources
 
 * https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#es44-dont-depend-on-order-of-evaluation-of-function-arguments[{cpp} Core Guidelines ES.44] - Don't depend on order of evaluation of function arguments
-* https://en.cppreference.com/w/cpp/language/eval_order[cppreference.com - order of evaluation] 
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/eval_order[cppreference.com - order of evaluation]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5972/cfamily/rule.adoc
+++ b/rules/S5972/cfamily/rule.adoc
@@ -44,10 +44,10 @@ void f() {
 
 === Documentation
 
-* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string[Search functions for std::basic_string]
-* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string_view[Search functions for std::basic_string_view]
-* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string/npos[std::basic_string<CharT,Traits>::npos]
-* CPP reference - https://en.cppreference.com/w/cpp/string/basic_string_view/npos[std::basic_string_view<CharT,Traits>::npos]
+* {cpp} reference - https://en.cppreference.com/w/cpp/string/basic_string[Search functions for std::basic_string]
+* {cpp} reference - https://en.cppreference.com/w/cpp/string/basic_string_view[Search functions for std::basic_string_view]
+* {cpp} reference - https://en.cppreference.com/w/cpp/string/basic_string/npos[std::basic_string<CharT,Traits>::npos]
+* {cpp} reference - https://en.cppreference.com/w/cpp/string/basic_string_view/npos[std::basic_string_view<CharT,Traits>::npos]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6197/cfamily/rule.adoc
+++ b/rules/S6197/cfamily/rule.adoc
@@ -41,5 +41,5 @@ void f2(const std::vector<int>& v) {
 
 == Resources
 
-- {cpp} reference - https://en.cppreference.com/w/cpp/ranges[Ranges library]
+* {cpp} reference - https://en.cppreference.com/w/cpp/ranges[Ranges library]
 

--- a/rules/S6427/cfamily/rule.adoc
+++ b/rules/S6427/cfamily/rule.adoc
@@ -45,4 +45,4 @@ void g(std::optional<int> &val, bool b) {
 
 == Resources
 
-* CPP reference - https://en.cppreference.com/w/cpp/utility/optional[std::optional]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/optional[std::optional]

--- a/rules/S6458/cfamily/rule.adoc
+++ b/rules/S6458/cfamily/rule.adoc
@@ -277,8 +277,8 @@ constructor belongs to a class that has derived classes.
 
 === Documentation
 
-* CPP reference - https://en.cppreference.com/w/cpp/utility/forward[`std::forward`]
-* CPP reference - https://en.cppreference.com/w/cpp/language/overload_resolution#Ranking_of_implicit_conversion_sequences[Ranking of implicit conversion sequences during overload resolution]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/forward[`std::forward`]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/overload_resolution#Ranking_of_implicit_conversion_sequences[Ranking of implicit conversion sequences during overload resolution]
 
 === Articles & blog posts
 

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -85,7 +85,7 @@ auto func2(T&& arg)
 
 === Documentation
 
- * CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
- * CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
- * CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]
+* CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
+* CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
+* CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
+* CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]

--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -85,7 +85,7 @@ auto func2(T&& arg)
 
 === Documentation
 
-* CPP reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
-* CPP reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
-* CPP reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
-* CPP reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/reference#Forwarding_references[Forwarding references]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/constraints[Constraints and concepts]
+* {cpp} reference - https://en.cppreference.com/w/cpp/concepts/copy_constructible[`std::copy_constructible` concept]
+* {cpp} reference - https://en.cppreference.com/w/cpp/concepts/copyable[`std::copyable` concept]

--- a/rules/S6490/cfamily/rule.adoc
+++ b/rules/S6490/cfamily/rule.adoc
@@ -68,6 +68,5 @@ void example(std::string_view s, double d, int maxLen) {
 
 === Documentation
 
-* {cpp} reference -
-  https://en.cppreference.com/w/cpp/utility/format/format[`std::format`]
+* {cpp} reference - https://en.cppreference.com/w/cpp/utility/format/format[`std::format`]
 * {cpp} reference - https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification[standard format specification]

--- a/rules/S6655/cfamily/rule.adoc
+++ b/rules/S6655/cfamily/rule.adoc
@@ -202,13 +202,13 @@ Removing all nested scopes would lead to deadlock, where `l2` will try to lock
 
 === Documentation
 
-- C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
-- C++ reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
-- C++ reference - https://en.cppreference.com/w/cpp/thread/unique_lock[unique_lock]
+* C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
+* C++ reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
+* C++ reference - https://en.cppreference.com/w/cpp/thread/unique_lock[unique_lock]
 
 === Articles & blog posts
 
-- Abseil - https://abseil.io/tips/107[Tip of the Week #107: Reference Lifetime Extension]
+* Abseil - https://abseil.io/tips/107[Tip of the Week #107: Reference Lifetime Extension]
 
 === Related rules
 

--- a/rules/S6655/cfamily/rule.adoc
+++ b/rules/S6655/cfamily/rule.adoc
@@ -202,9 +202,9 @@ Removing all nested scopes would lead to deadlock, where `l2` will try to lock
 
 === Documentation
 
-* C++ reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
-* C++ reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
-* C++ reference - https://en.cppreference.com/w/cpp/thread/unique_lock[unique_lock]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/lifetime[Lifetime]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/raii[RAII]
+* {cpp} reference - https://en.cppreference.com/w/cpp/thread/unique_lock[unique_lock]
 
 === Articles & blog posts
 

--- a/rules/S836/cfamily/rule.adoc
+++ b/rules/S836/cfamily/rule.adoc
@@ -249,7 +249,7 @@ auto [px, py, pz] = [&] {
 
 === Documentation
 
-* C++ reference - https://en.cppreference.com/w/cpp/language/storage_duration[Storage class specifiers]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/storage_duration[Storage class specifiers]
 
 === External coding guidelines
 

--- a/rules/S878/cfamily/rule.adoc
+++ b/rules/S878/cfamily/rule.adoc
@@ -43,7 +43,7 @@ for (i = 0, j = 5; i < 6; i++, j++) { ... }
 
 === Documentation
 
-* {cpp} Reference - https://en.cppreference.com/w/cpp/language/operators#Array_subscript_operator[Array subscript operator]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/operators#Array_subscript_operator[Array subscript operator]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S961/cfamily/rule.adoc
+++ b/rules/S961/cfamily/rule.adoc
@@ -4,8 +4,8 @@ Before compilation, the preprocessor replaces macros with the code they expand t
 
 == Resources
 
-* CPP reference - https://en.cppreference.com/w/cpp/preprocessor/replace[Replacing text macros]
-* CPP reference - https://en.cppreference.com/w/cpp/language/translation_phases#Phase_3[Phases of translation: Phase 3]
+* {cpp} reference - https://en.cppreference.com/w/cpp/preprocessor/replace[Replacing text macros]
+* {cpp} reference - https://en.cppreference.com/w/cpp/language/translation_phases#Phase_3[Phases of translation: Phase 3]
 * MISRA C:2004, 19.8 - A function-like macro shall not be invoked without all of its arguments.
 * https://cwe.mitre.org/data/definitions/628[CWE] - CWE-628: Function Call with Incorrectly Specified Arguments
 


### PR DESCRIPTION
This is done gradually over a few commits, each increasing the length of the common prefix. This should be squashed.