### PR TITLE
Modify S3457: Migrate to LayC - `printf`-style format string are misused

### DIFF
--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -1,10 +1,10 @@
 == Why is this an issue?
 
-`printf` format strings contain placeholders, represented by special characters such as "%s". These placeholders are replaced by values when the string is printed or logged.
+https://en.cppreference.com/w/c/io/fprintf[`printf`] format strings contain placeholders, represented by special characters such as "%s". These placeholders are replaced by values when the string is printed or logged.
 
-Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule statically validates the correlation of `printf` format strings and their arguments.
+Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule checks whether the format string specifiers of `printf` can be correctly matched with one of the additional arguments.
 
-Starting with C++20, `std::format` should be preferred, as it is more readable and validated at compile-time, making it more secure. The rule S6494 covers that.
+Starting with C++20, https://en.cppreference.com/w/cpp/utility/format/format[`std::format`] should be preferred, as it is more readable and validated at compile-time, making it more secure. Rule S6494 covers that.
 
 This rule is about errors that produce an unexpected string. For errors that will create undefined behavior, see the related rule S2275.
 

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -23,6 +23,7 @@ printf("Numbers: %d", 1, 2); // Noncompliant: the second argument "2" is unused
 ----
 printf("Formatted number: %0-f", 1.2); // Noncompliant: flag "0" is ignored because of "-"
 ----
+
 This rule will only work if the format string is provided as a string literal.
 
 == How to fix it

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-https://en.cppreference.com/w/c/io/fprintf[`printf`] format strings contain placeholders, represented by special characters such as "%s". These placeholders are replaced by values when the string is printed or logged.
+https://en.cppreference.com/w/c/io/fprintf[`printf`] format strings contain placeholders, represented by special characters such as "%s". These placeholders are replaced at runtime with values.
 
 Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule checks whether the format string specifiers of `printf` can be correctly matched with one of the additional arguments.
 
@@ -8,6 +8,21 @@ Starting with C++20, https://en.cppreference.com/w/cpp/utility/format/format[`st
 
 This rule is about errors that produce an unexpected string. For errors that will create undefined behavior, see the related rule S2275.
 
+Detected problems are:
+
+* Unused arguments
++
+[source,cpp]
+----
+printf("Numbers: %d", 1, 2); // Noncompliant: the second argument "2" is unused
+----
+
+* Ignored flags
++
+[source,cpp]
+----
+printf("Formatted number: %0-f", 1.2); // Noncompliant: flag "0" is ignored because of "-"
+----
 This rule will only work if the format string is provided as a string literal.
 
 == How to fix it
@@ -28,10 +43,20 @@ printf("Formatted number: %0-f", 1.2); // Noncompliant: flag "0" is ignored beca
 
 ==== Compliant solution
 
+With `std::format` and https://en.cppreference.com/w/cpp/io/print[`std::print`]
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+std::print("Numbers: {} {}", 1, 2);
+std::print("Formatted number: {:f}", 1.2);
+----
+
+With `printf`:
+
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
 printf("Numbers: %d %d", 1, 2);
-printf("Formatted number: %-0f", 1.2);
+printf("Formatted number: %-f", 1.2);
 ----
 
 == Resources
@@ -39,6 +64,7 @@ printf("Formatted number: %-0f", 1.2);
 === Documentation
 
 * {cpp} reference - https://en.cppreference.com/w/cpp/utility/format/format[`std::format` starting from C++20]
+* {cpp} reference - https://en.cppreference.com/w/cpp/io/print[`std::print` starting from C++23]
 
 === Standards
 

--- a/rules/S3457/cfamily/rule.adoc
+++ b/rules/S3457/cfamily/rule.adoc
@@ -1,18 +1,38 @@
 == Why is this an issue?
 
+`printf` format strings contain placeholders, represented by special characters such as "%s". These placeholders are replaced by values when the string is printed or logged.
+
 Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that result in the wrong string being created. This rule statically validates the correlation of `printf` format strings and their arguments.
 
-[source,cpp]
-----
-printf("%d", 1, 2); // Noncompliant: the second argument "2" is unused
-printf("%0-f", 1.2); // Noncompliant: flag "0" is ignored because of "-"
-----
-
-Starting with C++20, `std::format` should be preferred, as it is more readable and validated at compile-time, making it more secure. S6494 covers that.
+Starting with C++20, `std::format` should be preferred, as it is more readable and validated at compile-time, making it more secure. The rule S6494 covers that.
 
 This rule is about errors that produce an unexpected string. For errors that will create undefined behavior, see the related rule S2275.
 
 This rule will only work if the format string is provided as a string literal.
+
+== How to fix it
+
+A `printf` format string contains placeholders, replaced by values when the string is printed or logged. Mismatch in the format specifiers and the arguments provided can lead to incorrect strings being created.
+
+To avoid issues, a developer should ensure that the provided arguments match format specifiers. If possible, `std::format` from C++20 should be preferred.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+printf("Numbers: %d", 1, 2); // Noncompliant: the second argument "2" is unused
+printf("Formatted number: %0-f", 1.2); // Noncompliant: flag "0" is ignored because of "-"
+----
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+printf("Numbers: %d %d", 1, 2);
+printf("Formatted number: %-0f", 1.2);
+----
 
 == Resources
 
@@ -35,8 +55,6 @@ ifdef::env-github,rspecator-view[]
 '''
 == Implementation Specification
 (visible only on this page)
-
-include::../message.adoc[]
 
 '''
 == Comments And Links

--- a/rules/S3457/csharp/rule.adoc
+++ b/rules/S3457/csharp/rule.adoc
@@ -4,7 +4,20 @@ A [composite format string](https://learn.microsoft.com/en-us/dotnet/standard/ba
 
 Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors.
 
-This rule validates the correspondence between arguments and composite formats when calling the methods of `String.Format`, `StringBuilder.AppendFormat`, `Console.Write`, `Console.WriteLine`, `TextWriter.Write`, `TextWriter.WriteLine`, `Debug.WriteLine(String, Object[])`, `Trace.TraceError(String, Object[])`, `Trace.TraceInformation(String, Object[])`, `Trace.TraceWarning(String, Object[])` and `TraceSource.TraceInformation(String, Object[])`.
+This rule validates the correspondence between arguments and composite formats when calling the
+following methods:
+
+* https://learn.microsoft.com/en-us/dotnet/api/system.string.format?view=net-7.0[`String.Format`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendformat?view=net-7.0[`StringBuilder.AppendFormat`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.console.write?view=net-7.0[`Console.Write`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.console.writeline?view=net-7.0[`Console.WriteLine`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.write?view=net-7.0[`TextWriter.Write`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.io.textwriter.writeline?view=net-7.0[`TextWriter.WriteLine`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debug.writeline?view=net-7.0[`Debug.WriteLine(String, Object[])`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.trace.traceerror?view=net-7.0[`Trace.TraceError(String, Object[])`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.trace.traceinformation?view=net-7.0[`Trace.TraceInformation(String, Object[])`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.trace.tracewarning?view=net-7.0[`Trace.TraceWarning(String, Object[])`]
+* https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.tracesource.traceinformation?view=net-7.0[`TraceSource.TraceInformation(String, Object[])`]
 
 === Exceptions
 

--- a/rules/S3457/csharp/rule.adoc
+++ b/rules/S3457/csharp/rule.adoc
@@ -1,36 +1,22 @@
 == Why is this an issue?
 
-Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors. This rule statically validates the good behavior of composite formats when calling the methods of ``++String.Format++``, ``++StringBuilder.AppendFormat++``, ``++Console.Write++``, ``++Console.WriteLine++``, ``++TextWriter.Write++``, ``++TextWriter.WriteLine++``, ``++Debug.WriteLine(String, Object[])++``, ``++Trace.TraceError(String, Object[])++``, ``++Trace.TraceInformation(String, Object[])++``, ``++Trace.TraceWarning(String, Object[])++`` and ``++TraceSource.TraceInformation(String, Object[])++``. 
+A composite format string is a string that contains placeholders, represented by indices inside curly braces "{0}", "{1}", etc. These placeholders are replaced by values when the string is printed or logged.
 
-=== Noncompliant code example
+Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors.
 
-[source,csharp]
-----
-s = string.Format("{0}", arg0, arg1); // Noncompliant, arg1 is declared but not used.
-s = string.Format("{0} {2}", arg0, arg1, arg2); // Noncompliant, the format item with index 1 is missing so arg1 will not be used.
-s = string.Format("foo"); // Noncompliant, there is no need to use string.Format here.
-----
-
-=== Compliant solution
-
-[source,csharp]
-----
-s = string.Format("{0}", arg0);
-s = string.Format("{0} {1}", arg0, arg2);
-s = "foo";
-----
+This rule statically validates the correspondence between arguments and composite formats when calling the methods of `String.Format`, `StringBuilder.AppendFormat`, `Console.Write`, `Console.WriteLine`, `TextWriter.Write`, `TextWriter.WriteLine`, `Debug.WriteLine(String, Object[])`, `Trace.TraceError(String, Object[])`, `Trace.TraceInformation(String, Object[])`, `Trace.TraceWarning(String, Object[])` and `TraceSource.TraceInformation(String, Object[])`.
 
 === Exceptions
 
-* No issue is raised if the format string is not a ``++const++``.
+* No issue is raised if the format string is not a `const`.
 
 [source,csharp]
 ----
 var pattern = "{0} {1} {2}";
-var res = string.Format(pattern, 1, 2); // Compliant, not const string are not recognized
+var res = string.Format(pattern, 1, 2);
 ----
 
-* No issue is raised if the argument is not an inline creation array.
+* No issue is raised if the argument is not an inline created array.
 
 [source,csharp]
 ----
@@ -38,16 +24,39 @@ var array = new int[] {};
 var res = string.Format("{0} {1}", array); // Compliant we don't know the size of the array
 ----
 
-* This rule doesn't check whether the format specifier (defined after the ``++:++``) is actually valid.
+* This rule doesn't check whether the format specifier (defined after the `:`) is actually valid.
 
+== How to fix it
+
+A composite format string contains placeholders, replaced by values when the string is printed or logged. Mismatch in the format specifiers and the arguments provided can lead to incorrect strings being created.
+
+To avoid issues, a developer should ensure that the provided arguments match format specifiers.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
+----
+s = string.Format("{0}", arg0, arg1); // Noncompliant, arg1 is declared but not used.
+s = string.Format("{0} {2}", arg0, arg1, arg2); // Noncompliant, the format item with index 1 is missing, so arg1 will not be used.
+s = string.Format("foo"); // Noncompliant; there is no need to use "string.Format" here.
+----
+
+==== Compliant solution
+
+[source,csharp,diff-id=1,diff-type=compliant]
+----
+s = string.Format("{0}", arg0);
+s = string.Format("{0} {1}", arg0, arg2);
+s = "foo";
+----
 
 ifdef::env-github,rspecator-view[]
 
 '''
 == Implementation Specification
 (visible only on this page)
-
-include::../message.adoc[]
 
 '''
 == Comments And Links

--- a/rules/S3457/csharp/rule.adoc
+++ b/rules/S3457/csharp/rule.adoc
@@ -1,19 +1,19 @@
 == Why is this an issue?
 
-A composite format string is a string that contains placeholders, represented by indices inside curly braces "{0}", "{1}", etc. These placeholders are replaced by values when the string is printed or logged.
+A [composite format string](https://learn.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting) is a string that contains placeholders, represented by indices inside curly braces "{0}", "{1}", etc. These placeholders are replaced by values when the string is printed or logged.
 
 Because composite format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behaviors or runtime errors.
 
-This rule statically validates the correspondence between arguments and composite formats when calling the methods of `String.Format`, `StringBuilder.AppendFormat`, `Console.Write`, `Console.WriteLine`, `TextWriter.Write`, `TextWriter.WriteLine`, `Debug.WriteLine(String, Object[])`, `Trace.TraceError(String, Object[])`, `Trace.TraceInformation(String, Object[])`, `Trace.TraceWarning(String, Object[])` and `TraceSource.TraceInformation(String, Object[])`.
+This rule validates the correspondence between arguments and composite formats when calling the methods of `String.Format`, `StringBuilder.AppendFormat`, `Console.Write`, `Console.WriteLine`, `TextWriter.Write`, `TextWriter.WriteLine`, `Debug.WriteLine(String, Object[])`, `Trace.TraceError(String, Object[])`, `Trace.TraceInformation(String, Object[])`, `Trace.TraceWarning(String, Object[])` and `TraceSource.TraceInformation(String, Object[])`.
 
 === Exceptions
 
-* No issue is raised if the format string is not a `const`.
+* No issue is raised if the format string is not a string literal, but comes from a variable.
 
 [source,csharp]
 ----
 var pattern = "{0} {1} {2}";
-var res = string.Format(pattern, 1, 2);
+var res = string.Format(pattern, 1, 2); // Incorrect, but the analyzer doesn't raise any warnings here
 ----
 
 * No issue is raised if the argument is not an inline created array.
@@ -21,7 +21,7 @@ var res = string.Format(pattern, 1, 2);
 [source,csharp]
 ----
 var array = new int[] {};
-var res = string.Format("{0} {1}", array); // Compliant we don't know the size of the array
+var res = string.Format("{0} {1}", array); // Compliant; we don't know the size of the array
 ----
 
 * This rule doesn't check whether the format specifier (defined after the `:`) is actually valid.
@@ -31,6 +31,27 @@ var res = string.Format("{0} {1}", array); // Compliant we don't know the size o
 A composite format string contains placeholders, replaced by values when the string is printed or logged. Mismatch in the format specifiers and the arguments provided can lead to incorrect strings being created.
 
 To avoid issues, a developer should ensure that the provided arguments match format specifiers.
+
+Moreover, use https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation[string interpolation] when possible.
+
+Instead of
+
+[source,csharp]
+----
+string str = string.Format("Hello {0} {1}!", firstName, lastName);
+----
+
+use
+
+[source,csharp]
+----
+string str = $"Hello {firstName} {lastName}!";
+----
+
+With string interpolation:
+
+* the arguments are validated at compilation time rather than runtime
+* modern code editors provide auto-completion when typing the interpolation expression
 
 === Code examples
 

--- a/rules/S3457/java/rule.adoc
+++ b/rules/S3457/java/rule.adoc
@@ -14,7 +14,7 @@ This rule checks whether every format string specifier can be correctly matched 
 * https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#printf-java.lang.String-java.lang.Object...-[`java.io.PrintStream#printf`]
 * https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html#printf-java.lang.String-java.lang.Object...-[`java.io.PrintWriter#printf`]
 * https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#formatted(java.lang.Object...)[`java.lang.String#formatted`] (since Java 15)
-* logging methods of `org.slf4j.Logger`, `java.util.logging.Logger`, `org.apache.logging.log4j.Logger`.
+* logging methods of https://www.slf4j.org/api/org/slf4j/Logger.html[`org.slf4j.Logger`], https://docs.oracle.com/javase/8/docs/api/java/util/logging/Logger.html[`java.util.logging.Logger`], https://logging.apache.org/log4j/2.x/javadoc/log4j-api/org/apache/logging/log4j/Logger.html[`org.apache.logging.log4j.Logger`].
 
 == How to fix it
 

--- a/rules/S3457/java/rule.adoc
+++ b/rules/S3457/java/rule.adoc
@@ -4,7 +4,17 @@ A `printf-`-style format string is a string that contains placeholders, usually 
 
 Because `printf`-style format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created.
 
-This rule statically validates the correlation of `printf`-style format strings to their arguments when calling the ``++format(...)++`` methods of `java.util.Formatter`, `java.lang.String`, `java.io.PrintStream`, `java.text.MessageFormat`, and `java.io.PrintWriter` classes, the ``++printf(...)++`` methods of `java.io.PrintStream` or `java.io.PrintWriter` classes, the `formatted()` method of `java.lang.String` (since Java 15), as well as invocations of logging methods of `org.slf4j.Logger`, `java.util.logging.Logger`, `org.apache.logging.log4j.Logger`.
+This rule checks whether every format string specifier can be correctly matched with one of the additional arguments when calling the following methods:
+
+* https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#format-java.lang.String-java.lang.Object...-[`java.lang.String#format`]
+* https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#format-java.lang.String-java.lang.Object...-[`java.util.Formatter#format`]
+* https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#format-java.lang.String-java.lang.Object...-[`java.io.PrintStream#format`]
+* https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html#format-java.lang.String-java.lang.Object...-[`java.text.MessageFormat#format`]
+* https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html#format-java.lang.String-java.lang.Object...-[`java.io.PrintWriter#format`]
+* https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#printf-java.lang.String-java.lang.Object...-[`java.io.PrintStream#printf`]
+* https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html#printf-java.lang.String-java.lang.Object...-[`java.io.PrintWriter#printf`]
+* https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#formatted(java.lang.Object...)[`java.lang.String#formatted`] (since Java 15)
+* logging methods of `org.slf4j.Logger`, `java.util.logging.Logger`, `org.apache.logging.log4j.Logger`.
 
 == How to fix it
 
@@ -39,6 +49,7 @@ slf4jLog.debug("The number: {}", 1);
 == Resources
 
 * https://wiki.sei.cmu.edu/confluence/x/J9YxBQ[CERT, FIO47-C.] - Use valid format strings
+* https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html[java.text.MessageFormat]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3457/java/rule.adoc
+++ b/rules/S3457/java/rule.adoc
@@ -1,72 +1,40 @@
 == Why is this an issue?
 
-Because ``++printf++``-style format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created. This rule statically validates the correlation of ``++printf++``-style format strings to their arguments when calling the ``++format(...)++`` methods of ``++java.util.Formatter++``, ``++java.lang.String++``, ``++java.io.PrintStream++``, ``++MessageFormat++``, and ``++java.io.PrintWriter++`` classes and the ``++printf(...)++`` methods of ``++java.io.PrintStream++`` or ``++java.io.PrintWriter++`` classes.
+A `printf-`-style format string is a string that contains placeholders, usually represented by special characters such as "%s" or "{}", depending on the technology in use. These placeholders are replaced by values when the string is printed or logged.
 
+Because `printf`-style format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that result in the wrong strings being created.
 
-=== Noncompliant code example
+This rule statically validates the correlation of `printf`-style format strings to their arguments when calling the ``++format(...)++`` methods of `java.util.Formatter`, `java.lang.String`, `java.io.PrintStream`, `java.text.MessageFormat`, and `java.io.PrintWriter` classes, the ``++printf(...)++`` methods of `java.io.PrintStream` or `java.io.PrintWriter` classes, the `formatted()` method of `java.lang.String` (since Java 15), as well as invocations of logging methods of `org.slf4j.Logger`, `java.util.logging.Logger`, `org.apache.logging.log4j.Logger`.
 
-[source,java]
+== How to fix it
+
+A `printf-`-style format string is a string that contains placeholders, which are replaced by values when the string is printed or logged. Mismatch in the format specifiers and the arguments provided can lead to incorrect strings being created.
+
+To avoid issues, a developer should ensure that the provided arguments match format specifiers.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,java,diff-id=1,diff-type=noncompliant]
 ----
-String.format("First {0} and then {1}", "foo", "bar");  //Noncompliant. Looks like there is a confusion with the use of {{java.text.MessageFormat}}, parameters "foo" and "bar" will be simply ignored here
-String.format("Display %3$d and then %d", 1, 2, 3);   //Noncompliant; the second argument '2' is unused
-String.format("Too many arguments %d and %d", 1, 2, 3);  //Noncompliant; the third argument '3' is unused
-String.format("First Line\n");   //Noncompliant; %n should be used in place of \n to produce the platform-specific line separator
-String.format("Is myObject null ? %b", myObject);   //Noncompliant; when a non-boolean argument is formatted with %b, it prints true for any nonnull value, and false for null. Even if intended, this is misleading. It's better to directly inject the boolean value (myObject == null in this case)
-String.format("value is " + value); // Noncompliant
-String s = String.format("string without arguments"); // Noncompliant
-
-MessageFormat.format("Result '{0}'.", value); // Noncompliant; String contains no format specifiers. (quote are discarding format specifiers)
-MessageFormat.format("Result {0}.", value, value);  // Noncompliant; 2nd argument is not used
-MessageFormat.format("Result {0}.", myObject.toString()); // Noncompliant; no need to call toString() on objects
-
-java.util.Logger logger;
-logger.log(java.util.logging.Level.SEVERE, "Result {0}.", myObject.toString()); // Noncompliant; no need to call toString() on objects
-logger.log(java.util.logging.Level.SEVERE, "Result.", new Exception()); // compliant, parameter is an exception
-logger.log(java.util.logging.Level.SEVERE, "Result '{0}'", 14); // Noncompliant - String contains no format specifiers.
-logger.log(java.util.logging.Level.SEVERE, "Result " + param, exception); // Noncompliant; Lambda should be used to differ string concatenation.
+String.format("Too many arguments %d and %d", 1, 2, 3); // Noncompliant; the third argument '3' is unused
+String.format("First {0} and then {1}", "foo", "bar");  //Noncompliant. It appears there is confusion with the use of "java.text.MessageFormat"; parameters "foo" and "bar" will be ignored here
 
 org.slf4j.Logger slf4jLog;
-org.slf4j.Marker marker;
-
-slf4jLog.debug(marker, "message {}");
-slf4jLog.debug(marker, "message", 1); // Noncompliant - String contains no format specifiers.
-
-org.apache.logging.log4j.Logger log4jLog;
-log4jLog.debug("message", 1); // Noncompliant - String contains no format specifiers.
+slf4jLog.debug("The number: ", 1); // Noncompliant - String contains no format specifiers.
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,java]
+[source,java,diff-id=1,diff-type=compliant]
 ----
+String.format("Too many arguments %d and %d", 1, 2);
 String.format("First %s and then %s", "foo", "bar");
-String.format("Display %2$d and then %d", 1, 3);
-String.format("Too many arguments %d %d", 1, 2);
-String.format("First Line%n");
-String.format("Is myObject null ? %b", myObject == null);
-String.format("value is %d", value);
-String s = "string without arguments"; 
-
-MessageFormat.format("Result {0}.", value);
-MessageFormat.format("Result '{0}'  =  {0}", value);
-MessageFormat.format("Result {0}.", myObject);
-
-java.util.Logger logger;
-logger.log(java.util.logging.Level.SEVERE, "Result {0}.", myObject);
-logger.log(java.util.logging.Level.SEVERE, "Result {0}'", 14);
-logger.log(java.util.logging.Level.SEVERE, exception, () -> "Result " + param);
 
 org.slf4j.Logger slf4jLog;
-org.slf4j.Marker marker;
-
-slf4jLog.debug(marker, "message {}");
-slf4jLog.debug(marker, "message {}", 1);
-
-org.apache.logging.log4j.Logger log4jLog;
-log4jLog.debug("message {}", 1);
+slf4jLog.debug("The number: {}", 1);
 ----
-
 
 == Resources
 
@@ -77,8 +45,6 @@ ifdef::env-github,rspecator-view[]
 '''
 == Implementation Specification
 (visible only on this page)
-
-include::../message.adoc[]
 
 '''
 == Comments And Links

--- a/rules/S3457/message.adoc
+++ b/rules/S3457/message.adoc
@@ -1,4 +1,0 @@
-=== Message
-
-XXXX
-

--- a/rules/S3457/metadata.json
+++ b/rules/S3457/metadata.json
@@ -10,7 +10,7 @@
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "10min"
+    "constantCost": "1min"
   },
   "tags": [
     "confusing"

--- a/rules/S3457/metadata.json
+++ b/rules/S3457/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Printf-style format strings should be used correctly",
+  "title": "Format strings should be used correctly",
   "type": "CODE_SMELL",
   "code": {
     "impacts": {

--- a/rules/S3457/python/rule.adoc
+++ b/rules/S3457/python/rule.adoc
@@ -1,14 +1,14 @@
 == Why is this an issue?
 
-A `printf-`-style format string is a string that contains placeholders, usually represented by special characters such as "%s" or "{}", depending on the technology in use. These placeholders are replaced by values when the string is printed or logged. Thus, it is required that a string is valid and arguments match replacement fields in this string.
+A format string is a string that contains placeholders, usually represented by special characters such as "%s" or "{}", depending on the technology in use. These placeholders are replaced by values when the string is printed or logged. Thus, it is required that a string is valid and arguments match replacement fields in this string.
 
-This applies to the ``++%++`` operator, `str.format` method, and loggers from the `logging` module. Internally, the latter use ``++%-formatting++``. The only difference is that they will log an error instead of raising an exception when provided arguments are invalid.
+This applies to https://docs.python.org/3/tutorial/inputoutput.html#old-string-formatting[the % operator], the https://docs.python.org/3/tutorial/inputoutput.html#the-string-format-method[str.format] method, and loggers from the https://docs.python.org/3/library/logging.html[logging] module. Internally, the latter use the `%-formatting`. The only difference is that they will log an error instead of raising an exception when the provided arguments are invalid.
 
 Formatted string literals (also called "f-strings"; available since Python 3.6) are generally simpler to use, and any syntax mistake will cause a failure at compile time. However, it is easy to forget curly braces, which will not lead to any detectable errors.
 
 This rule raises an issue when:
 
-* A string formatted with ``++%++`` will not return the expected string because some arguments are unused.
+* A string formatted with `%` will not return the expected text because some arguments are unused.
 * A string formatted with `str.format` will not return the expected string because some arguments are unused.
 * An "f-string" doesn't contain any replacement field, which probably means some curly braces are missing.
 * Loggers will log an error because their message is not formatted properly.

--- a/rules/S3457/python/rule.adoc
+++ b/rules/S3457/python/rule.adoc
@@ -1,26 +1,31 @@
 == Why is this an issue?
 
-Formatting strings, either with the ``++%++`` operator or ``++str.format++`` method, requires a valid string and arguments matching this string's replacement fields.
+A `printf-`-style format string is a string that contains placeholders, usually represented by special characters such as "%s" or "{}", depending on the technology in use. These placeholders are replaced by values when the string is printed or logged. Thus, it is required that a string is valid and arguments match replacement fields in this string.
 
+This applies to the ``++%++`` operator, `str.format` method, and loggers from the `logging` module. Internally, the latter use ``++%-formatting++``. The only difference is that they will log an error instead of raising an exception when provided arguments are invalid.
 
-This also applies to loggers from the ``++logging++`` module. Internally they use ``++%-formatting++``. The only difference is that they will log an error instead of raising an exception when provided arguments are invalid.
-
-
-Formatted string literals, also called "f-strings", are generally simpler to use, and any syntax mistake will fail at compile time. However it is easy to forget curly braces  and it won't raise any error.
-
+Formatted string literals (also called "f-strings"; available since Python 3.6) are generally simpler to use, and any syntax mistake will cause a failure at compile time. However, it is easy to forget curly braces, which will not lead to any detectable errors.
 
 This rule raises an issue when:
 
-* A string formatted with ``++%++`` will not return the expected string because some arguments are not used.
-* A string formatted with ``++str.format++`` will not return the expected string because some arguments are not used.
-* An "f-string" doesn't contain any replacement field, which probably means that some curly braces are missing.
+* A string formatted with ``++%++`` will not return the expected string because some arguments are unused.
+* A string formatted with `str.format` will not return the expected string because some arguments are unused.
+* An "f-string" doesn't contain any replacement field, which probably means some curly braces are missing.
 * Loggers will log an error because their message is not formatted properly.
 
 Rule S2275 covers cases where formatting a string will raise an exception.
 
-=== Noncompliant code example
+== How to fix it
 
-[source,python]
+A `printf-`-style format string is a string that contains placeholders, which are replaced by values when the string is printed or logged. Mismatch in the format specifiers and the arguments provided can lead to incorrect strings being created.
+
+To avoid issues, a developer should ensure that the provided arguments match format specifiers.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,python,diff-id=1,diff-type=noncompliant]
 ----
 "Error %(message)s" % {"message": "something failed", "extra": "some dead code"}  # Noncompliant. Remove the unused argument "extra" or add a replacement field.
 
@@ -34,9 +39,9 @@ import logging
 logging.error("Error: User %s has not been able to access %s", "Alice")  # Noncompliant. Add 1 missing argument.
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,python]
+[source,python,diff-id=1,diff-type=compliant]
 ----
 "Error %(message)s" % {"message": "something failed"}
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

