### PR TITLE
Migrate links from JavaScript RSPECs to the LaYC format

### DIFF
--- a/rules/S1068/javascript/rule.adoc
+++ b/rules/S1068/javascript/rule.adoc
@@ -43,8 +43,9 @@ class MyClass {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields[MDN - Private class features]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[MDN - Classes]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields[Private class features]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[Classes]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1119/javascript/rule.adoc
+++ b/rules/S1119/javascript/rule.adoc
@@ -28,9 +28,9 @@ if (x <= 0) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label[MDN - label]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[MDN - ``++break++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[MDN - ``++continue++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label[label]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[``++break++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[``++continue++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1125/javascript/rule.adoc
+++ b/rules/S1125/javascript/rule.adoc
@@ -27,8 +27,8 @@ doSomething(true);
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness[MDN - Equality comparisons and sameness]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean[MDN - Boolean]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness[Equality comparisons and sameness]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean[Boolean]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1126/javascript/rule.adoc
+++ b/rules/S1126/javascript/rule.adoc
@@ -30,9 +30,9 @@ return !!expression;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean[MDN - Boolean]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[MDN - ``++if...else++``]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT#double_not_!!++[MDN - Double NOT (``++!!++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean[Boolean]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[``++if...else++``]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT#double_not_!!++[Double NOT (``++!!++``)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1128/javascript/rule.adoc
+++ b/rules/S1128/javascript/rule.adoc
@@ -22,7 +22,7 @@ console.log(B1);
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[MDN - ``++import++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[``++import++``]
 
 === Related rules
 

--- a/rules/S1143/javascript/rule.adoc
+++ b/rules/S1143/javascript/rule.adoc
@@ -52,12 +52,12 @@ async function foo() {
 == Resources
 === Documentation
 
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#the_finally_block++[MDN - The ``++finally++`` block]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[MDN - ``++try...catch++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[MDN - ``++return++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - ``++throw++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[MDN - ``++break++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[MDN - ``++continue++``]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#the_finally_block++[The ``++finally++`` block]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[``++try...catch++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[``++return++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[``++throw++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[``++break++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[``++continue++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S117/javascript/rule.adoc
+++ b/rules/S117/javascript/rule.adoc
@@ -30,7 +30,7 @@ const _baz = 2;
 
 === Documentation
 
-* Mozilla Developer - https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript#variable_names[Guidelines for writing JavaScript code: Variable names]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript#variable_names[Guidelines for writing JavaScript code: Variable names]
 * Wikipedia - https://en.wikipedia.org/wiki/Naming_convention_(programming)[Naming Convention (programming)]
 
 === Related rules

--- a/rules/S1186/javascript/rule.adoc
+++ b/rules/S1186/javascript/rule.adoc
@@ -57,7 +57,7 @@ function onClick() {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions[MDN - Functions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions[Functions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1226/javascript/rule.adoc
+++ b/rules/S1226/javascript/rule.adoc
@@ -52,11 +52,11 @@ function myFunction(param, optionalParam, cb) {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[MDN - Functions]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#catch_binding++[MDN - Catch binding]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[MDN - ``++for...of++``]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in++[MDN - ``++for...in++``]
-* https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing[Wikipedia - Call by sharing]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[Functions]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#catch_binding++[Catch binding]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[``++for...of++``]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in++[``++for...in++``]
+* Wikipedia - https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing[Call by sharing]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1264/javascript/rule.adoc
+++ b/rules/S1264/javascript/rule.adoc
@@ -29,8 +29,8 @@ while (condition) { /*...*/ }
 == Resources
 
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[MDN - `for`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while[MDN - `while`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[`for`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while[`while`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1301/javascript/rule.adoc
+++ b/rules/S1301/javascript/rule.adoc
@@ -32,8 +32,8 @@ if (condition === 0) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[MDN - ``++switch++``]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[MDN - ``++if...else++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[``++switch++``]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[``++if...else++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1314/javascript/rule.adoc
+++ b/rules/S1314/javascript/rule.adoc
@@ -25,9 +25,10 @@ const myNumber = 0o10;
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#octal_numbers[MDN - Octal numbers]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal[MDN - SyntaxError: "0"-prefixed octal literals are deprecated]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[MDN - Strict mode]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#octal_numbers[Octal numbers]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal[SyntaxError: "0"-prefixed octal literals are deprecated]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[Strict mode]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1321/javascript/rule.adoc
+++ b/rules/S1321/javascript/rule.adoc
@@ -45,8 +45,8 @@ console.log(foo.x + " " + x); // Prints: 3 a
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with[MDN - ``++with++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[MDN - Strict mode]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with[``++with++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[Strict mode]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1439/javascript/rule.adoc
+++ b/rules/S1439/javascript/rule.adoc
@@ -44,7 +44,7 @@ outerLoop: for (let i = 0; i < 10; i++) { // Compliant
 
 === Documentation
 
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label[MDN - label]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label[label]
 
 === Related rules
 

--- a/rules/S1440/javascript/rule.adoc
+++ b/rules/S1440/javascript/rule.adoc
@@ -47,13 +47,13 @@ The rule does not report on these cases:
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality[MDN - Strict equality]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality[MDN - Strict inequality]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality[MDN - Equality]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality[MDN - Inequality]
-* https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion[MDN - Type coercion]
-* https://developer.mozilla.org/en-US/docs/Glossary/Truthy[MDN - Truthy]
-* https://developer.mozilla.org/en-US/docs/Glossary/Falsy[MDN - Falsy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality[Strict equality]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality[Strict inequality]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality[Equality]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality[Inequality]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion[Type coercion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Truthy[Truthy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Falsy[Falsy]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1472/javascript/rule.adoc
+++ b/rules/S1472/javascript/rule.adoc
@@ -88,9 +88,9 @@ const foo = function() {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion[MDN - Automatic semicolon insertion]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Grouping#grouping_operator_and_automatic_semicolon_insertion[MDN - Grouping operator and automatic semicolon insertion]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates[MDN - Tagged templates]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion[Automatic semicolon insertion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Grouping#grouping_operator_and_automatic_semicolon_insertion[Grouping operator and automatic semicolon insertion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates[Tagged templates]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1481/javascript/rule.adoc
+++ b/rules/S1481/javascript/rule.adoc
@@ -81,7 +81,7 @@ const [, params] = url.split(path);
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#ignoring_some_returned_values[MDN - Destructuring assignment / Ignoring some values]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#ignoring_some_returned_values[Destructuring assignment / Ignoring some values]
 
 
 === Articles & blog posts

--- a/rules/S1515/javascript/rule.adoc
+++ b/rules/S1515/javascript/rule.adoc
@@ -35,8 +35,8 @@ for (let i = 0; i < 5; i++) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures[MDN - Closures]
-* https://developer.mozilla.org/en-US/docs/Glossary/Scope[MDN - Scope]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures[Closures]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Scope[Scope]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1516/javascript/rule.adoc
+++ b/rules/S1516/javascript/rule.adoc
@@ -31,7 +31,7 @@ let myString = 'A rather long string of English text, an error message ' +
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#string_operators[MDN - String operators]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#string_operators[String operators]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1527/javascript/rule.adoc
+++ b/rules/S1527/javascript/rule.adoc
@@ -42,9 +42,9 @@ const someData = { package: true };                // Compliant: `package` is no
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#future_reserved_words[MDN - Future reserved words]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[MDN - Strict mode]
-* https://en.wikipedia.org/wiki/Syntax_error[Wikipedia - Syntax error]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#future_reserved_words[Future reserved words]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[Strict mode]
+* Wikipedia - https://en.wikipedia.org/wiki/Syntax_error[Syntax error]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1529/javascript/rule.adoc
+++ b/rules/S1529/javascript/rule.adoc
@@ -28,12 +28,12 @@ When a file contains other bitwise operations, (``++^++``, ``++<<++``, ``++>>>++
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND[MDN - Bitwise AND (``++&++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR[MDN - Bitwise OR (``++|++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND[MDN - Logical AND (``++&&++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[MDN - Logical OR (``++||++``)]
-* https://developer.mozilla.org/en-US/docs/Glossary/Truthy[MDN - Truthy]
-* https://developer.mozilla.org/en-US/docs/Glossary/Falsy[MDN - Falsy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND[Bitwise AND (``++&++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR[Bitwise OR (``++|++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND[Logical AND (``++&&++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[Logical OR (``++||++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Truthy[Truthy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Falsy[Falsy]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1533/javascript/rule.adoc
+++ b/rules/S1533/javascript/rule.adoc
@@ -34,10 +34,11 @@ if (x) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Glossary/Primitive[MDN - Primitive]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number[MDN - ``++ Number()++``  constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String[MDN - ``++ String()++``  constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean[MDN - ``++Boolean()++`` constructor]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Primitive[Primitive]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number[``++ Number()++``  constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String[``++ String()++``  constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean[``++Boolean()++`` constructor]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1534/javascript/rule.adoc
+++ b/rules/S1534/javascript/rule.adoc
@@ -51,7 +51,8 @@ function MyComponent(props) {
 == Resources
 
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#property_definitions[MDN - Property definitions]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#property_definitions[Property definitions]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1536/javascript/rule.adoc
+++ b/rules/S1536/javascript/rule.adoc
@@ -42,9 +42,9 @@ f(1, 2, 3);
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions[MDN - Functions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[MDN - The arguments object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[MDN - Strict mode]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions[Functions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[The arguments object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[Strict mode]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1763/javascript/rule.adoc
+++ b/rules/S1763/javascript/rule.adoc
@@ -26,11 +26,11 @@ function func(a) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[MDN - `return`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[MDN - `break`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - `throw`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[MDN - `continue`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return[MDN - Warning: unreachable code after return statement]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[`return`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[`break`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[`throw`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[`continue`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return[Warning: unreachable code after return statement]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1788/javascript/rule.adoc
+++ b/rules/S1788/javascript/rule.adoc
@@ -42,8 +42,8 @@ export default function appReducer(state = initialState, action) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters[MDN - Default parameters]
-* https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#writing-reducers[Redux - Writing Reducers]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters[Default parameters]
+* Redux Documentation - https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#writing-reducers[Writing Reducers]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1848/javascript/rule.adoc
+++ b/rules/S1848/javascript/rule.adoc
@@ -33,9 +33,9 @@ try {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor[MDN - ``Object.prototype.constructor``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[MDN - constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[MDN - `new` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor[``Object.prototype.constructor``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[`new` operator]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1862/javascript/rule.adoc
+++ b/rules/S1862/javascript/rule.adoc
@@ -58,9 +58,9 @@ switch (event) {
 == Resources
 === Documentation
 
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[MDN - ``++if...else++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[MDN - ``++switch++``]
-* https://en.wikipedia.org/wiki/Unreachable_code[Wikipedia - Unreachable code]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[``++if...else++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[``++switch++``]
+* Wikipedia - https://en.wikipedia.org/wiki/Unreachable_code[Unreachable code]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2137/javascript/rule.adoc
+++ b/rules/S2137/javascript/rule.adoc
@@ -57,9 +57,9 @@ function fun() {
 
 === Documentation 
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words[MDN - Reserved words]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers_with_special_meanings[MDN - Identifiers with special meanings]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects[MDN - Global Objects]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words[Reserved words]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers_with_special_meanings[Identifiers with special meanings]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects[Global Objects]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2189/javascript/rule.adoc
+++ b/rules/S2189/javascript/rule.adoc
@@ -56,12 +56,12 @@ while (b) {
 ----
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration[MDN - Loops and iteration]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[MDN - `for`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while[MDN - `while`]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while++[MDN - ``++do...while++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[MDN - `break`]
-* https://en.wikipedia.org/wiki/Infinite_loop[Wikipedia - Infinite loop]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration[Loops and iteration]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[`for`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while[`while`]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while++[``++do...while++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[`break`]
+* Wikipedia - https://en.wikipedia.org/wiki/Infinite_loop[Infinite loop]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2201/javascript/rule.adoc
+++ b/rules/S2201/javascript/rule.adoc
@@ -29,12 +29,13 @@ console.log('hello'.lastIndexOf('e'));
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String[MDN - ``++String++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number[MDN - ``++Number++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date[MDN - ``++Date++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[MDN - ``++Array++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math[MDN - ``++Math++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[MDN - ``++RegExp++``]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String[``++String++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number[``++Number++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date[``++Date++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[``++Array++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math[``++Math++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[``++RegExp++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2234/javascript/rule.adoc
+++ b/rules/S2234/javascript/rule.adoc
@@ -59,7 +59,7 @@ function doTheThing() {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[MDN - Functions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[Functions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2251/javascript/rule.adoc
+++ b/rules/S2251/javascript/rule.adoc
@@ -24,7 +24,7 @@ for (let i = 0; i < strings.length; i++) {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[MDN - ``++for++``]
-* https://en.wikipedia.org/wiki/Infinite_loop[Wikipedia - Infinite loop]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[``++for++``]
+* Wikipedia - https://en.wikipedia.org/wiki/Infinite_loop[Infinite loop]
 
 include::../rspecator.adoc[]

--- a/rules/S2259/javascript/rule.adoc
+++ b/rules/S2259/javascript/rule.adoc
@@ -28,12 +28,13 @@ console.log(foo?.bar);
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[MDN - `undefined`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null[MDN - `null`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError[MDN - `TypeError`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_properties[MDN - TypeError: "x" has no properties]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[MDN - Optional chaining (``++?.++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND[MDN - Logical AND (``++&&++``)]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[`undefined`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null[`null`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError[`TypeError`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/No_properties[TypeError: "x" has no properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[Optional chaining (``++?.++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND[Logical AND (``++&&++``)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2310/javascript/rule.adoc
+++ b/rules/S2310/javascript/rule.adoc
@@ -45,9 +45,9 @@ for (const name of names) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[MDN - for]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[MDN - ``++for...of++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols[MDN - Iteration protocols]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for[for]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[``++for...of++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols[Iteration protocols]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2392/javascript/rule.adoc
+++ b/rules/S2392/javascript/rule.adoc
@@ -53,11 +53,12 @@ function doSomething(a, b) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Glossary/Scope[MDN - Scope]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - `var`]
-* https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[MDN - Hoisting]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[MDN - const]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - let]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Scope[Scope]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[`var`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[Hoisting]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[const]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[let]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2432/javascript/rule.adoc
+++ b/rules/S2432/javascript/rule.adoc
@@ -34,7 +34,7 @@ console.log(person.firstname = 'bob'); // Prints 'bob'
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set[MDN - set]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set[set]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2639/javascript/rule.adoc
+++ b/rules/S2639/javascript/rule.adoc
@@ -22,8 +22,8 @@ Use a non-empty character class or a different regular expression pattern that a
 
 === Documentation
 
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[MDN - Character classes]
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[Character classes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2685/javascript/rule.adoc
+++ b/rules/S2685/javascript/rule.adoc
@@ -28,11 +28,12 @@ function whoCalled() {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[MDN - The arguments object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee#description[MDN - arguments.callee]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller[MDN - Function.prototype.caller]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments[MDN - Function.prototype.arguments]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage[MDN - ReferenceError: deprecated caller or arguments usage]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[The arguments object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee#description[arguments.callee]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller[Function.prototype.caller]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments[Function.prototype.arguments]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage[ReferenceError: deprecated caller or arguments usage]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2688/javascript/rule.adoc
+++ b/rules/S2688/javascript/rule.adoc
@@ -52,10 +52,10 @@ if (!Number.isNaN(a)) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN[MDN - ``++NaN++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN[MDN - ``++isNaN()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN[MDN - ``++Number.isNaN()++``]
-* https://developer.mozilla.org/en-US/docs/Glossary/Type_Conversion[MDN - Type conversion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN[``++NaN++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN[``++isNaN()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN[``++Number.isNaN()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Type_Conversion[Type conversion]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2692/javascript/rule.adoc
+++ b/rules/S2692/javascript/rule.adoc
@@ -27,6 +27,6 @@ This rule raises an issue when an `indexOf` value retrieved from an array is tes
 == Resources
 === Documentation
 
-https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes[MDN - ``++Array.prototype.includes()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes[``++Array.prototype.includes()++``]
 
 include::../rspecator.adoc[]

--- a/rules/S2699/javascript/rule.adoc
+++ b/rules/S2699/javascript/rule.adoc
@@ -36,8 +36,8 @@ describe("Assertions", function() {
 == Resources
 === Documentation
 
-* https://www.chaijs.com/api/[Chai.js - API Reference]
-* https://sinonjs.org/releases/latest/assertions/[Sinon.JS - Assertions]
+* Chai.js Documentation - https://www.chaijs.com/api/[API Reference]
+* Sinon.js Documentation - https://sinonjs.org/releases/latest/assertions/[Assertions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2703/javascript/rule.adoc
+++ b/rules/S2703/javascript/rule.adoc
@@ -37,12 +37,12 @@ function f() {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Glossary/Variable[MDN - Variable]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#declaring_variables[MDN - Declaring variables]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variable_scope[MDN - Variable scope]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - var]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - let]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[MDN - const]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Variable[Variable]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#declaring_variables[Declaring variables]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variable_scope[Variable scope]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[var]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[let]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[const]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2737/javascript/rule.adoc
+++ b/rules/S2737/javascript/rule.adoc
@@ -9,8 +9,8 @@ include::../description.adoc[]
 == Resources
 === Documentation
 
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[MDN - ``++try...catch++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - ``++throw++``]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[``++try...catch++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[``++throw++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2870/javascript/rule.adoc
+++ b/rules/S2870/javascript/rule.adoc
@@ -34,13 +34,13 @@ console.log(myArray[2]); // outputs 'd'
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete[MDN - delete operator]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays[MDN - Sparse arrays]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#deleting_array_elements[MDN - Deleting array elements]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods[Copying methods and mutating methods]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop[Array.prototype.pop()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift[Array.prototype.shift()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice[Array.prototype.splice()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete[delete operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays[Sparse arrays]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#deleting_array_elements[Deleting array elements]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods[Copying methods and mutating methods]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop[Array.prototype.pop()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift[Array.prototype.shift()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice[Array.prototype.splice()]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2871/javascript/rule.adoc
+++ b/rules/S2871/javascript/rule.adoc
@@ -39,9 +39,9 @@ console.log([code1, code2, code3].sort((a, b) => a.localeCompare(b))); // ["eΔ"
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort[MDN - ``++Array.prototype.sort()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted[MDN - ``++Array.prototype.toSorted()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare[MDN - ``++String.prototype.localeCompare()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort[``++Array.prototype.sort()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted[``++Array.prototype.toSorted()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare[``++String.prototype.localeCompare()++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2933/javascript/rule.adoc
+++ b/rules/S2933/javascript/rule.adoc
@@ -34,7 +34,7 @@ class Person {
 
 === Documentation
 
-* TypeScript - https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly[readonly]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly[readonly]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2970/javascript/rule.adoc
+++ b/rules/S2970/javascript/rule.adoc
@@ -56,8 +56,8 @@ describe("complete assertions", function() {
 == Resources
 === Documentation
 
-* https://www.chaijs.com/api/assert[Chai.js - Assert]
-* https://www.chaijs.com/api/bdd[Chai.js - `expect` and `should`]
+* Chai.js Documentation - https://www.chaijs.com/api/assert[Assert]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd[`expect` and `should`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2990/javascript/rule.adoc
+++ b/rules/S2990/javascript/rule.adoc
@@ -52,15 +52,15 @@ MyObj.func1 = function() {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context[MDN - this]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#no_this_substitution[MDN - No this substitution]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[MDN - globalThis]
-* https://developer.mozilla.org/en-US/docs/Glossary/Global_object[MDN - Global object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[MDN - Strict mode]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply[MDN - Reflect.apply()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call[MDN - Function.prototype.call()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[MDN - Function.prototype.apply()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind[MDN - Function.prototype.bind()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context[this]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#no_this_substitution[No this substitution]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[globalThis]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Global_object[Global object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode[Strict mode]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply[Reflect.apply()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call[Function.prototype.call()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[Function.prototype.apply()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind[Function.prototype.bind()]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2999/javascript/rule.adoc
+++ b/rules/S2999/javascript/rule.adoc
@@ -42,9 +42,9 @@ const obj2 = new MyClass();
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[MDN - ``++new++`` operator]
-* https://developer.mozilla.org/en-US/docs/Glossary/Constructor[MDN - Constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_constructor[MDN - `TypeError: "x" is not a constructor`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[``++new++`` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Constructor[Constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_constructor[`TypeError: "x" is not a constructor`]
 
 
 

--- a/rules/S3001/javascript/rule.adoc
+++ b/rules/S3001/javascript/rule.adoc
@@ -42,11 +42,11 @@ delete obj.foo;
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete[MDN - `delete` operator]
-* https://developer.mozilla.org/en-US/docs/Glossary/Global_object[MDN - Global object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[MDN - `globalThis`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[MDN - ECMAScript modules]
-* https://nodejs.org/api/modules.html[Node.js - CommonJS modules]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete[`delete` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Global_object[Global object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[`globalThis`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[ECMAScript modules]
+* Node.js Documentation - https://nodejs.org/api/modules.html[CommonJS modules]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3257/javascript/rule.adoc
+++ b/rules/S3257/javascript/rule.adoc
@@ -39,4 +39,4 @@ class Bar {
 == Resources
 === Documentation
 
-* TypeScript - https://www.typescriptlang.org/docs/handbook/type-inference.html[Type Inference]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/type-inference.html[Type Inference]

--- a/rules/S3415/javascript/rule.adoc
+++ b/rules/S3415/javascript/rule.adoc
@@ -37,9 +37,9 @@ it("inverts arguments", function() {
 == Resources
 === Documentation
 
-* https://nodejs.org/api/assert.html[Node.js API - Assert]
-* https://www.chaijs.com/api/assert[Chai.js - Assert]
-* https://www.chaijs.com/api/bdd[Chai.js - `expect` and `should`]
+* Node.js Documentation - https://nodejs.org/api/assert.html[Assert]
+* Chai.js Documentation - https://www.chaijs.com/api/assert[Assert]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd[`expect` and `should`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3498/javascript/rule.adoc
+++ b/rules/S3498/javascript/rule.adoc
@@ -35,9 +35,9 @@ let myObj = {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer[MDN - Object initializer]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#property_definitions[MDN - Property definitions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#method_definitions[MDN - Method definitions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer[Object initializer]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#property_definitions[Property definitions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#method_definitions[Method definitions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3500/javascript/rule.adoc
+++ b/rules/S3500/javascript/rule.adoc
@@ -26,10 +26,10 @@ pi = 3.14159;
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[MDN - `const`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - `let`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze[MDN - `Object.freeze()`]
-* https://en.wikipedia.org/wiki/ECMAScript_version_history#ES2015[Wikipedia - ECMAScript 2015]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[`const`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[`let`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze[`Object.freeze()`]
+* Wikipedia - https://en.wikipedia.org/wiki/ECMAScript_version_history#ES2015[ECMAScript 2015]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3504/javascript/rule.adoc
+++ b/rules/S3504/javascript/rule.adoc
@@ -43,12 +43,12 @@ let size = 4;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - var]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - let]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[MDN - const]
-* https://developer.mozilla.org/en-US/docs/Glossary/Scope[MDN - Scope]
-* https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[MDN - Hoisting]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz[MDN - Temporal dead zone (TDZ)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[var]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[let]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const[const]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Scope[Scope]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[Hoisting]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz[Temporal dead zone (TDZ)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3516/javascript/rule.adoc
+++ b/rules/S3516/javascript/rule.adoc
@@ -37,8 +37,8 @@ function f(a, g) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[MDN - ``++return++``]
-* https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Return_values[MDN - Function return values]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[``++return++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Return_values[Function return values]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3524/javascript/rule.adoc
+++ b/rules/S3524/javascript/rule.adoc
@@ -38,7 +38,7 @@ const bar = (a, b) => 0;
 
 === Documentation
 
-* MDN - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions[Arrow function expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions[Arrow function expressions]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3531/javascript/rule.adoc
+++ b/rules/S3531/javascript/rule.adoc
@@ -42,8 +42,8 @@ function* range(start, end) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator[MDN - Generator]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield[MDN - ``++yield++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator[Generator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield[``++yield++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3579/javascript/rule.adoc
+++ b/rules/S3579/javascript/rule.adoc
@@ -35,9 +35,9 @@ let obj = {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[MDN - Array]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_indices[MDN - Array indices]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object[MDN - Object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[Array]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_indices[Array indices]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object[Object]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3616/javascript/rule.adoc
+++ b/rules/S3616/javascript/rule.adoc
@@ -59,9 +59,9 @@ function weekStatus (day) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[MDN - ``++switch++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator[MDN - Comma operator ``++(,)++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[MDN - Logical OR ``++(||)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[``++switch++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator[Comma operator ``++(,)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[Logical OR ``++(||)++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3626/javascript/rule.adoc
+++ b/rules/S3626/javascript/rule.adoc
@@ -35,9 +35,9 @@ function redundantJump(x) {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[MDN - `continue`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[MDN - `break`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[MDN - `return`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue[`continue`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break[`break`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[`return`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3686/javascript/rule.adoc
+++ b/rules/S3686/javascript/rule.adoc
@@ -45,7 +45,7 @@ The rule checks that the ``++new++`` operator is consistently used with each fun
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[MDN - ``++new++`` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[``++new++`` operator]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3696/javascript/rule.adoc
+++ b/rules/S3696/javascript/rule.adoc
@@ -23,8 +23,8 @@ throw new RangeError("Invalid negative index.");
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - ``++throw++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[MDN - Error]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[``++throw++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[Error]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3699/javascript/rule.adoc
+++ b/rules/S3699/javascript/rule.adoc
@@ -34,8 +34,8 @@ foo();
 == Resources
 === Documentation
 
-* MDN - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[``++undefined++`` global property]
-* MDN - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[``++return++`` statement]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[``++undefined++`` global property]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[``++return++`` statement]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3735/javascript/rule.adoc
+++ b/rules/S3735/javascript/rule.adoc
@@ -54,9 +54,9 @@ void runPromise();
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void[MDN - `void` operator]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[MDN - `undefined`]
-* https://developer.mozilla.org/en-US/docs/Glossary/IIFE[MDN - IIFE (Immediately Invoked Function Expression)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void[`void` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[`undefined`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/IIFE[IIFE (Immediately Invoked Function Expression)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3782/javascript/rule.adoc
+++ b/rules/S3782/javascript/rule.adoc
@@ -20,8 +20,8 @@ const isTooSmall = Math.abs(x) < 0.0042;
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects[MDN - Global Objects]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#type_coercion[MDN - Type coercion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects[Global Objects]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#type_coercion[Type coercion]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3785/javascript/rule.adoc
+++ b/rules/S3785/javascript/rule.adoc
@@ -25,11 +25,11 @@ let x = new String("Foo");
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[MDN - in operator]
-* https://developer.mozilla.org/en-US/docs/Glossary/Primitive[MDN - Primitive]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number[MDN - Number() constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String[MDN - String() constructor]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean[MDN - Boolean() constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[in operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Primitive[Primitive]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number[Number() constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String[String() constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean[Boolean() constructor]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3796/javascript/rule.adoc
+++ b/rules/S3796/javascript/rule.adoc
@@ -43,7 +43,8 @@ let merged = arr.reduce(function(a, b) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[MDN - Array]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[Array]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3799/javascript/rule.adoc
+++ b/rules/S3799/javascript/rule.adoc
@@ -33,7 +33,8 @@ function foo({p: [a, b, c]}) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment[MDN - Destructuring assignment]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment[Destructuring assignment]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S3800/javascript/rule.adoc
+++ b/rules/S3800/javascript/rule.adoc
@@ -46,7 +46,7 @@ function foo() {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[MDN - `return`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return[`return`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3812/javascript/rule.adoc
+++ b/rules/S3812/javascript/rule.adoc
@@ -33,11 +33,11 @@ if (!(foo instanceof MyClass)) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence[MDN - Operator precedence]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table[MDN - Operator precedence table]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT[MDN - Logical NOT (``++!++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof[MDN - ``++instanceof++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[MDN - ``++in++`` operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence[Operator precedence]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table[Operator precedence table]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT[Logical NOT (``++!++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof[``++instanceof++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[``++in++`` operator]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3834/javascript/rule.adoc
+++ b/rules/S3834/javascript/rule.adoc
@@ -25,9 +25,9 @@ For the `BigInt` type to be recognized correctly, the environment should be `es2
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol[MDN - Symbol]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt[MDN - BigInt]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[MDN - new operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol[Symbol]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt[BigInt]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[new operator]
 
 
 

--- a/rules/S3854/javascript/rule.adoc
+++ b/rules/S3854/javascript/rule.adoc
@@ -40,9 +40,9 @@ Some issues are not raised if the base class is not defined in the same file as 
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super[MDN - `super`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[MDN - Classes]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain[MDN - Inheritance and the prototype chain]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super[`super`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[Classes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain[Inheritance and the prototype chain]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3863/javascript/rule.adoc
+++ b/rules/S3863/javascript/rule.adoc
@@ -19,8 +19,8 @@ import { B1, B2 } from 'b';
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[MDN - `import`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[MDN - JavaScript modules]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[`import`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[JavaScript modules]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S3984/javascript/rule.adoc
+++ b/rules/S3984/javascript/rule.adoc
@@ -21,9 +21,9 @@ if (x < 0) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[MDN - Error]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[MDN - throw]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling[MDN - Control flow and error handling]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[Error]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw[throw]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling[Control flow and error handling]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4030/javascript/rule.adoc
+++ b/rules/S4030/javascript/rule.adoc
@@ -28,8 +28,9 @@ function getLength(a, b, c) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections[MDN - Indexed collections]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Keyed_collections[MDN - Keyed collections]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections[Indexed collections]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Keyed_collections[Keyed collections]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4043/javascript/rule.adoc
+++ b/rules/S4043/javascript/rule.adoc
@@ -46,13 +46,13 @@ const sorted = b.slice().sort();
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods[MDN - Array copying methods and mutating methods]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse[MDN - Array.prototype.reverse()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort[MDN - Array.prototype.sort()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed[MDN - Array.prototype.toReversed()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted[MDN - Array.prototype.toSorted()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax[MDN - Spread syntax (``++...++``)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[MDN - Array.prototype.slice()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods[Array copying methods and mutating methods]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse[Array.prototype.reverse()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort[Array.prototype.sort()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed[Array.prototype.toReversed()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted[Array.prototype.toSorted()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax[Spread syntax (``++...++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice[Array.prototype.slice()]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4123/javascript/rule.adoc
+++ b/rules/S4123/javascript/rule.adoc
@@ -23,9 +23,9 @@ await x;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await[MDN - await]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[MDN - Promise]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#conversion_to_promise[MDN - Conversion to promise]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await[await]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#conversion_to_promise[Conversion to promise]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4124/javascript/rule.adoc
+++ b/rules/S4124/javascript/rule.adoc
@@ -36,7 +36,8 @@ declare class C {
 
 == Resources
 === Documentation
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#interfaces[TypeScript - Interfaces]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[MDN - Classes]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[MDN - `constructor`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[MDN - `new` operator]
+
+* MDN web docs - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#interfaces[TypeScript - Interfaces]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes[Classes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[`constructor`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new[`new` operator]

--- a/rules/S4125/javascript/rule.adoc
+++ b/rules/S4125/javascript/rule.adoc
@@ -32,5 +32,5 @@ function isNumber(x) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof[MDN - typeof]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#primitive_values[MDN - Primitive values]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof[typeof]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#primitive_values[Primitive values]

--- a/rules/S4138/javascript/rule.adoc
+++ b/rules/S4138/javascript/rule.adoc
@@ -28,8 +28,8 @@ for (let value of arr) {
 
 === Documentation
 
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[MDN - ``++for...of++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol[MDN - Iterator protocol]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of++[``++for...of++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol[Iterator protocol]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4140/javascript/rule.adoc
+++ b/rules/S4140/javascript/rule.adoc
@@ -28,7 +28,7 @@ let a = [1, undefined, 3, 6, 9];
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays[MDN - Sparse arrays]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays[Sparse arrays]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4156/javascript/rule.adoc
+++ b/rules/S4156/javascript/rule.adoc
@@ -29,9 +29,9 @@ namespace myMod {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/namespaces.html[TypeScript - Namespaces]
-* https://www.typescriptlang.org/docs/handbook/modules.html[TypeScript - Modules]
-* https://262.ecma-international.org/6.0/[ECMAScript 2015]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/namespaces.html[Namespaces]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/modules.html[Modules]
+* ECMAScript - https://262.ecma-international.org/6.0/[ECMAScript 2015]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4158/javascript/rule.adoc
+++ b/rules/S4158/javascript/rule.adoc
@@ -30,8 +30,9 @@ strings.forEach(str => doSomething(str));
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[MDN - Array]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol[MDN - Iterable protocol]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array[Array]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol[Iterable protocol]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4204/javascript/rule.adoc
+++ b/rules/S4204/javascript/rule.adoc
@@ -35,9 +35,9 @@ logValue('Hello');
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown[TypeScript `unknown`]
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any[TypeScript - `any`]
-* https://www.typescriptlang.org/docs/handbook/2/narrowing.html[TypeScript - Narrowing]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown[`unknown`]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any[`any`]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/narrowing.html[Narrowing]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4275/javascript/rule.adoc
+++ b/rules/S4275/javascript/rule.adoc
@@ -94,9 +94,9 @@ Object.defineProperty(o, 'x', {
 
 === Documentation
 
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get[MDN - get]
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set[MDN - set]
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields[MDN - Private class features]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get[get]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set[set]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields[Private class features]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4323/javascript/rule.adoc
+++ b/rules/S4323/javascript/rule.adoc
@@ -46,9 +46,9 @@ function baz(): MyType {
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases[TypeScript - Type Aliases]
-* https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html[TypeScript - Unions and Intersection Types]
-* https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)[Wikipedia - Rule of three (computer programming)]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-aliases[Type Aliases]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html[Unions and Intersection Types]
+* Wikipedia - https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)[Rule of three (computer programming)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4325/javascript/rule.adoc
+++ b/rules/S4325/javascript/rule.adoc
@@ -46,8 +46,8 @@ function getName(x?: string | Person) {
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions[TypeScript - Type Assertions]
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-[TypeScript - Non-null Assertion Operator (Postfix ``++!++``)]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions[Type Assertions]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-[Non-null Assertion Operator (Postfix ``++!++``)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4335/javascript/rule.adoc
+++ b/rules/S4335/javascript/rule.adoc
@@ -37,11 +37,12 @@ type Baz = T & U;
 == Resources
 
 === Documentation
-* https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types[TypeScript - Intersection Types]
-* https://www.typescriptlang.org/docs/handbook/basic-types.html#never[TypeScript - `never`]
-* https://www.typescriptlang.org/docs/handbook/basic-types.html#any[TypeScript - `any`]
-* https://www.typescriptlang.org/docs/handbook/basic-types.html#null-and-undefined[TypeScript - `null` and `undefined`]
-* https://www.typescriptlang.org/docs/handbook/basic-types.html#void[TypeScript - `void`]
+
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types[Intersection Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/basic-types.html#never[`never`]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/basic-types.html#any[`any`]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/basic-types.html#null-and-undefined[`null` and `undefined`]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/basic-types.html#void[`void`]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4524/javascript/rule.adoc
+++ b/rules/S4524/javascript/rule.adoc
@@ -3,7 +3,7 @@ include::../rule.adoc[]
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[MDN - ``++switch++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch[``++switch++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4619/javascript/rule.adoc
+++ b/rules/S4619/javascript/rule.adoc
@@ -36,9 +36,10 @@ function func() {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[MDN - `in` operator]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in++[MDN - ``++for...in++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes[MDN - `Array.prototype.includes()`]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in[`in` operator]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in++[``++for...in++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes[`Array.prototype.includes()`]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S4621/javascript/rule.adoc
+++ b/rules/S4621/javascript/rule.adoc
@@ -34,7 +34,7 @@ function extend(p : Person) : Person & Loggable {
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html[TypeScript - Unions and Intersection Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html[Unions and Intersection Types]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4622/javascript/rule.adoc
+++ b/rules/S4622/javascript/rule.adoc
@@ -80,4 +80,4 @@ endif::env-github,rspecator-view[]
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/utility-types.html[TypeScript Utility Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/utility-types.html[Utility Types]

--- a/rules/S4623/javascript/rule.adoc
+++ b/rules/S4623/javascript/rule.adoc
@@ -36,7 +36,7 @@ foo(42);
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters[TypeScript - Optional Parameters]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters[Optional Parameters]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4624/javascript/rule.adoc
+++ b/rules/S4624/javascript/rule.adoc
@@ -39,7 +39,7 @@ It can span multiple lines.`;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals[MDN - Template literals (Template strings)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals[Template literals (Template strings)]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4634/javascript/rule.adoc
+++ b/rules/S4634/javascript/rule.adoc
@@ -87,11 +87,11 @@ Using `Promise.resolve` and `Promise.reject` is particularly useful when you wan
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous[MDN - Asynchronous JavaScript]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[MDN - Promise]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then[MDN - Promise.prototype.then()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve[MDN - Promise.resolve()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject[MDN - Promise.reject()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous[Asynchronous JavaScript]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then[Promise.prototype.then()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve[Promise.resolve()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject[Promise.reject()]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4782/javascript/rule.adoc
+++ b/rules/S4782/javascript/rule.adoc
@@ -50,8 +50,8 @@ interface Person {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/objects.html#optional-properties[TypeScript - Optional Properties]
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types[TypeScript - Union Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/objects.html#optional-properties[Optional Properties]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types[Union Types]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4822/javascript/rule.adoc
+++ b/rules/S4822/javascript/rule.adoc
@@ -43,11 +43,11 @@ This rule reports ``++try...catch++`` statements containing nothing else but cal
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[MDN - Promise]
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[MDN - ``++try...catch++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await[MDN - `await`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function[MDN - `async function`]
-* https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide[MDN - Microtasks]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch++[``++try...catch++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await[`await`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function[`async function`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide[Microtasks]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5843/javascript/rule.adoc
+++ b/rules/S5843/javascript/rule.adoc
@@ -36,14 +36,15 @@ if (dateString.match(datePattern)) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[MDN - `RegExp`]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction[MDN - Disjunction: ``++|++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers[MDN - Quantifiers]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion[MDN - Lookahead assertion: ``++(?=...), (?!...)++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion[MDN - Lookbehind assertion: ``++(?<=...), (?<!...)++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[MDN - Character classes]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences[MDN - Groups and backreferences]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[`RegExp`]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction[Disjunction: ``++|++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers[Quantifiers]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion[Lookahead assertion: ``++(?=...), (?!...)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion[Lookbehind assertion: ``++(?<=...), (?<!...)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[Character classes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences[Groups and backreferences]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5850/javascript/rule.adoc
+++ b/rules/S5850/javascript/rule.adoc
@@ -36,7 +36,7 @@ const regex = /(?:^a)|b|(?:c$)/;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Assertions[MDN - Assertions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction[MDN - Disjunction: ``++|++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group[MDN - Non-capturing group: ``++(?:...)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Assertions[Assertions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction[Disjunction: ``++|++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group[Non-capturing group: ``++(?:...)++``]

--- a/rules/S5860/javascript/rule.adoc
+++ b/rules/S5860/javascript/rule.adoc
@@ -55,5 +55,5 @@ if (dateMatcher) {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences[MDN - Groups and backreferences]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences[Groups and backreferences]

--- a/rules/S5863/javascript/rule.adoc
+++ b/rules/S5863/javascript/rule.adoc
@@ -39,7 +39,7 @@ describe("test the same object", function() {
 == Resources
 === Documentation
 
-* https://www.chaijs.com/api/[Chai.js - API Reference]
+* Chai.js Documentation - https://www.chaijs.com/api/[API Reference]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5876/javascript/rule.adoc
+++ b/rules/S5876/javascript/rule.adoc
@@ -16,7 +16,7 @@ include::how-to-fix-it/passportjs.adoc[]
 
 include::../common/resources/docs.adoc[]
 
-* http://expressjs.com/en/resources/middleware/session.html[express-session]
+* Express.js Documentation - http://expressjs.com/en/resources/middleware/session.html[express-session]
 
 === Articles & blog posts
 

--- a/rules/S5958/javascript/rule.adoc
+++ b/rules/S5958/javascript/rule.adoc
@@ -74,9 +74,9 @@ describe("exceptions are tested properly", function() {
 == Resources
 === Documentation
 
-* https://nodejs.org/api/assert.html[Node.js API - Assert]
-* https://www.chaijs.com/api/assert[Chai.js - Assert]
-* https://www.chaijs.com/api/bdd[Chai.js - `expect` and `should`]
+* Node.js Documentation - https://nodejs.org/api/assert.html[Assert]
+* Chai.js Documentation - https://www.chaijs.com/api/assert[Assert]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd[`expect` and `should`]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6079/javascript/rule.adoc
+++ b/rules/S6079/javascript/rule.adoc
@@ -47,7 +47,7 @@ describe('My test suite', function() {
 == Resources
 === Documentation
 
-* https://mochajs.org/#asynchronous-code[Mocha - Asynchronous code]
+* Mocha Documentation - https://mochajs.org/#asynchronous-code[Asynchronous code]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6080/javascript/rule.adoc
+++ b/rules/S6080/javascript/rule.adoc
@@ -36,9 +36,9 @@ describe("testing this.timeout", function() {
 == Resources
 === Documentation
 
-* https://mochajs.org/#timeouts[Mocha - Timeouts]
-* https://mochajs.org/#hook-level[Mocha - Disabling timeouts]
-* https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value[MDN - Maximum_delay_value]
+* Mocha Documentation - https://mochajs.org/#timeouts[Timeouts]
+* Mocha Documentation - https://mochajs.org/#hook-level[Disabling timeouts]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value[Maximum_delay_value]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S6092/javascript/rule.adoc
+++ b/rules/S6092/javascript/rule.adoc
@@ -102,16 +102,16 @@ Having only one reason to succeed also helps to make the test more maintainable.
 == Resources
 === Documentation
 
-* https://www.chaijs.com/api/bdd/#method_by[Chai.js - ``++.by++``]
-* https://www.chaijs.com/api/bdd/#method_change[Chai.js - ``++.change++``]
-* https://www.chaijs.com/api/bdd/#method_decrease[Chai.js - ``++.decrease++``]
-* https://www.chaijs.com/api/bdd/#method_finite[Chai.js - ``++.finite++``]
-* https://www.chaijs.com/api/bdd/#method_include[Chai.js - ``++.include++``]
-* https://www.chaijs.com/api/bdd/#method_increase[Chai.js - ``++.increase++``]
-* https://www.chaijs.com/api/bdd/#method_members[Chai.js - ``++.members++``]
-* https://www.chaijs.com/api/bdd/#method_ownpropertydescriptor[Chai.js - ``++.ownPropertyDescriptor++``]
-* https://www.chaijs.com/api/bdd/#method_property[Chai.js - ``++.property++``]
-* https://www.chaijs.com/api/bdd/#method_throw[Chai.js - ``++.throw++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_by[``++.by++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_change[``++.change++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_decrease[``++.decrease++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_finite[``++.finite++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_include[``++.include++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_increase[``++.increase++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_members[``++.members++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_ownpropertydescriptor[``++.ownPropertyDescriptor++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_property[``++.property++``]
+* Chai.js Documentation - https://www.chaijs.com/api/bdd/#method_throw[``++.throw++``]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S6324/javascript/rule.adoc
+++ b/rules/S6324/javascript/rule.adoc
@@ -20,6 +20,6 @@ const pattern2 = new RegExp('\x20');
 
 === Documentation
 
-* https://en.wikipedia.org/wiki/ASCII[Wikipedia - ASCII]
-* https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_controls[Wikipedia - C0 and C1 control codes]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[MDN - Character classes]
+* Wikipedia - https://en.wikipedia.org/wiki/ASCII[ASCII]
+* Wikipedia - https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_controls[C0 and C1 control codes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[Character classes]

--- a/rules/S6325/javascript/rule.adoc
+++ b/rules/S6325/javascript/rule.adoc
@@ -27,5 +27,5 @@ new RegExp(`Dear ${title},`);
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[MDN - ``++RegExp++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp[``++RegExp++``]

--- a/rules/S6328/javascript/rule.adoc
+++ b/rules/S6328/javascript/rule.adoc
@@ -35,7 +35,7 @@ console.log(str.replace(/(?<firstName>\w+)\s(?<lastName>\w+)/, '$<lastName>, $<f
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace[MDN - ``++String.prototype.replace()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll[MDN - ``++String.prototype.replaceAll()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[MDN - Regular expressions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group[MDN - Capturing group: ``++(...)++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace[``++String.prototype.replace()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll[``++String.prototype.replaceAll()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions[Regular expressions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group[Capturing group: ``++(...)++``]

--- a/rules/S6351/javascript/rule.adoc
+++ b/rules/S6351/javascript/rule.adoc
@@ -66,6 +66,6 @@ Overall, this rule raises an issue when:
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags[MDN - Regular expression flags]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec[MDN - ``++RegExp.prototype.exec()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test[MDN - ``++RegExp.prototype.test()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags[Regular expression flags]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec[``++RegExp.prototype.exec()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test[``++RegExp.prototype.test()++``]

--- a/rules/S6426/javascript/rule.adoc
+++ b/rules/S6426/javascript/rule.adoc
@@ -26,6 +26,6 @@ describe("MyClass", function () {
 
 === Documentation
 
-- https://mochajs.org/#exclusive-tests[Mocha - Exclusive tests]
-- https://jestjs.io/docs/next/api#testonlyname-fn-timeout[Jest - ``++test.only()++``]
-- https://jestjs.io/docs/next/api#describeonlyname-fn[Jest - ``++describe.only()++``]
+* Mocha Documentation - https://mochajs.org/#exclusive-tests[Exclusive tests]
+* Jest Documentation - https://jestjs.io/docs/next/api#testonlyname-fn-timeout[``++test.only()++``]
+* Jest Documentation - https://jestjs.io/docs/next/api#describeonlyname-fn[``++describe.only()++``]

--- a/rules/S6435/javascript/rule.adoc
+++ b/rules/S6435/javascript/rule.adoc
@@ -41,5 +41,5 @@ class MyComponent extends React.Component {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component[React - Component]
-* https://react.dev/reference/react/Component#render[React - ``++render()++``]
+* React Documentation - https://react.dev/reference/react/Component[Component]
+* React Documentation - https://react.dev/reference/react/Component#render[``++render()++``]

--- a/rules/S6438/javascript/rule.adoc
+++ b/rules/S6438/javascript/rule.adoc
@@ -47,4 +47,4 @@ If the additional text node is intentional, prefer using a JavaScript string lit
 == Resources
 === Documentation
 
-* https://react.dev/learn/javascript-in-jsx-with-curly-braces[React.dev - JavaScript in JSX with Curly Braces]
+* React Documentation - https://react.dev/learn/javascript-in-jsx-with-curly-braces[JavaScript in JSX with Curly Braces]

--- a/rules/S6439/javascript/rule.adoc
+++ b/rules/S6439/javascript/rule.adoc
@@ -46,4 +46,4 @@ function Profile(props) {
 
 === Documentation
 
-* https://react.dev/learn/conditional-rendering#logical-and-operator-[React.dev - Conditional Rendering]
+* React Documentation - https://react.dev/learn/conditional-rendering#logical-and-operator-[Conditional Rendering]

--- a/rules/S6440/javascript/rule.adoc
+++ b/rules/S6440/javascript/rule.adoc
@@ -45,5 +45,5 @@ function Profile() {
 
 === Documentation
 
-* https://react.dev/warnings/invalid-hook-call-warning#breaking-rules-of-hooks[React.dev - Breaking Rules of Hooks]
-* https://legacy.reactjs.org/docs/hooks-rules.html[React documentation - Rules of Hooks]
+* React Documentation - https://react.dev/warnings/invalid-hook-call-warning#breaking-rules-of-hooks[Breaking Rules of Hooks]
+* React Documentation - https://legacy.reactjs.org/docs/hooks-rules.html[Rules of Hooks]

--- a/rules/S6441/javascript/rule.adoc
+++ b/rules/S6441/javascript/rule.adoc
@@ -36,5 +36,5 @@ class Profile extends React.Component {
 
 === Documentation
 
-* https://reactjs.org/docs/components-and-props.html[React Documentation - Components and Props]
-* https://legacy.reactjs.org/docs/state-and-lifecycle.html#adding-lifecycle-methods-to-a-class[React Documentation - Adding Lifecycle Methods to a Class]
+* React Documentation - https://reactjs.org/docs/components-and-props.html[Components and Props]
+* React Documentation - https://legacy.reactjs.org/docs/state-and-lifecycle.html#adding-lifecycle-methods-to-a-class[Adding Lifecycle Methods to a Class]

--- a/rules/S6442/javascript/rule.adoc
+++ b/rules/S6442/javascript/rule.adoc
@@ -43,6 +43,6 @@ function ShowLanguage() {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react[React Hooks]
-* https://react.dev/reference/react/useState[React useState - API reference]
-* https://react.dev/reference/react/useState#im-getting-an-error-too-many-re-renders[React useState - Troubleshooting]
+* React Documentation - https://react.dev/reference/react[React Hooks]
+* React Documentation - https://react.dev/reference/react/useState[useState - API reference]
+* React Documentation - https://react.dev/reference/react/useState#im-getting-an-error-too-many-re-renders[useState - Troubleshooting]

--- a/rules/S6443/javascript/rule.adoc
+++ b/rules/S6443/javascript/rule.adoc
@@ -44,6 +44,6 @@ function ShowLanguage() {
 
 === Documentation
 
-* https://react.dev/learn/state-a-components-memory[React.dev - State: A Component's Memory]
-* https://react.dev/reference/react/useState[React.dev - useState]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is[MDN - Object.is()]
+* React Documentation - https://react.dev/learn/state-a-components-memory[State: A Component's Memory]
+* React Documentation - https://react.dev/reference/react/useState[useState]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is[Object.is()]

--- a/rules/S6477/javascript/rule.adoc
+++ b/rules/S6477/javascript/rule.adoc
@@ -42,10 +42,10 @@ function Blog(props) {
 
 === Documentation
 
-* https://react.dev/learn/rendering-lists#rules-of-keys[React API reference - Rendering lists]
-* https://reactjs.org/docs/reconciliation.html#recursing-on-children[React API reference - Recursing On Children]
-* https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[MDN - Crypto: randomUUID() method]
-* https://en.wikipedia.org/wiki/Universally_unique_identifier[Wikipedia - UUID]
+* React Documentation - https://react.dev/learn/rendering-lists#rules-of-keys[Rendering lists]
+* React Documentation - https://reactjs.org/docs/reconciliation.html#recursing-on-children[Recursing On Children]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[Crypto: randomUUID() method]
+* Wikipedia - https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID]
 
 === Related rules
 

--- a/rules/S6479/javascript/rule.adoc
+++ b/rules/S6479/javascript/rule.adoc
@@ -40,10 +40,10 @@ function Blog(props) {
 
 === Documentation
 
-* https://react.dev/learn/rendering-lists#rules-of-keys[React API reference - Rendering lists]
-* https://reactjs.org/docs/reconciliation.html#recursing-on-children[React API reference - Recursing On Children]
-* https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[MDN - Crypto: randomUUID() method]
-* https://en.wikipedia.org/wiki/Universally_unique_identifier[Wikipedia - UUID]
+* React Documentation - https://react.dev/learn/rendering-lists#rules-of-keys[Rendering lists]
+* React Documentation - https://reactjs.org/docs/reconciliation.html#recursing-on-children[Recursing On Children]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[Crypto: randomUUID() method]
+* Wikipedia - https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID]
 
 === Related rules
 

--- a/rules/S6481/javascript/rule.adoc
+++ b/rules/S6481/javascript/rule.adoc
@@ -31,7 +31,7 @@ function Component() {
 
 === Documentation
 
-* https://reactjs.org/docs/context.html#caveats[React documentation - Context Caveats]
-* https://react.dev/learn/passing-data-deeply-with-context[React documentation - Passing Data Deeply with Context]
-* https://react.dev/reference/react/useCallback[React documentation - `useCallback` hook]
-* https://react.dev/reference/react/useMemo[React documentation - `useMemo` hook]
+* React Documentation - https://reactjs.org/docs/context.html#caveats[Context Caveats]
+* React Documentation - https://react.dev/learn/passing-data-deeply-with-context[Passing Data Deeply with Context]
+* React Documentation - https://react.dev/reference/react/useCallback[`useCallback` hook]
+* React Documentation - https://react.dev/reference/react/useMemo[`useMemo` hook]

--- a/rules/S6486/javascript/rule.adoc
+++ b/rules/S6486/javascript/rule.adoc
@@ -43,10 +43,10 @@ function Blog(props) {
 
 === Documentation
 
-* https://react.dev/learn/rendering-lists#rules-of-keys[React API reference - Rendering lists]
-* https://reactjs.org/docs/reconciliation.html#recursing-on-children[React API reference - Recursing On Children]
-* https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[MDN - Crypto: randomUUID() method]
-* https://en.wikipedia.org/wiki/Universally_unique_identifier[Wikipedia - UUID]
+* React Documentation - https://react.dev/learn/rendering-lists#rules-of-keys[Rendering lists]
+* React Documentation - https://reactjs.org/docs/reconciliation.html#recursing-on-children[Recursing On Children]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID[Crypto: randomUUID() method]
+* Wikipedia - https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID]
 
 === Related rules
 

--- a/rules/S6509/javascript/rule.adoc
+++ b/rules/S6509/javascript/rule.adoc
@@ -28,10 +28,10 @@ if (foo) {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion[MDN - Boolean coercion]
-* https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion[MDN - Type coercion]
-* https://developer.mozilla.org/en-US/docs/Glossary/Truthy[MDN - Truthy]
-* https://developer.mozilla.org/en-US/docs/Glossary/Falsy[MDN - Falsy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion[Boolean coercion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion[Type coercion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Truthy[Truthy]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Falsy[Falsy]
 
 
 === Articles & blog posts

--- a/rules/S6522/javascript/rule.adoc
+++ b/rules/S6522/javascript/rule.adoc
@@ -61,10 +61,13 @@ moduleDefault.newAttribute = 'hello world!'; // module.default now contains newA
 ----
 
 == Resources
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[MDN - import]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object[MDN - Module namespace object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed#description[MDN - Sealed Objects]
-//=== Documentation
+
+=== Documentation
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[import]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object[Module namespace object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed#description[Sealed Objects]
+
 //=== Articles & blog posts
 //=== Conference presentations
 //=== Standards

--- a/rules/S6523/javascript/rule.adoc
+++ b/rules/S6523/javascript/rule.adoc
@@ -43,10 +43,11 @@ In order to prevent runtime errors, you should provide fallbacks for when the op
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[MDN - Optional chaining (?.)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing[MDN - Nullish coalescing operator (??)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[MDN - Logical OR (||)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator[MDN - Conditional (ternary) operator]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[Optional chaining (?.)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing[Nullish coalescing operator (??)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[Logical OR (||)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator[Conditional (ternary) operator]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6534/javascript/rule.adoc
+++ b/rules/S6534/javascript/rule.adoc
@@ -88,10 +88,11 @@ const bar = new Decimal('0.123456789123456789');
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding[MDN - Number encoding]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt[MDN - BigInt]
-* https://en.wikipedia.org/wiki/Double-precision_floating-point_format[Wikipedia - Double-precision floating-point format]
-* https://en.wikipedia.org/wiki/IEEE_754[Wikipedia - IEEE 754 Standard]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding[Number encoding]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt[BigInt]
+* Wikipedia - https://en.wikipedia.org/wiki/Double-precision_floating-point_format[Double-precision floating-point format]
+* Wikipedia - https://en.wikipedia.org/wiki/IEEE_754[IEEE 754 Standard]
+
 //=== Articles & blog posts
 //=== Conference presentations
 //=== Standards

--- a/rules/S6535/javascript/rule.adoc
+++ b/rules/S6535/javascript/rule.adoc
@@ -28,5 +28,5 @@ const path  = `/${some}/${dir}`;
 
 === Documentation
 
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping[MDN - Escaping in Regular expressions]
-- https://www.w3schools.com/js/js_strings.asp[W3 schools - JavaScript strings]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping[Escaping in Regular expressions]
+* W3Schools - https://www.w3schools.com/js/js_strings.asp[JavaScript strings]

--- a/rules/S6544/javascript/rule.adoc
+++ b/rules/S6544/javascript/rule.adoc
@@ -146,10 +146,11 @@ The logic of the promise is executed when it is called, however, its result is o
 == Resources
 
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[MDN - Promise]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises[MDN - Using promises]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function[MDN - Async function]
-* https://developer.mozilla.org/en-US/docs/Glossary/IIFE[MDN - IIFE]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises[Using promises]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function[Async function]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/IIFE[IIFE]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6550/javascript/rule.adoc
+++ b/rules/S6550/javascript/rule.adoc
@@ -50,4 +50,4 @@ enum Foo {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/enums.html#handbook-content[TypeScript Enums]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/enums.html#handbook-content[Enums]

--- a/rules/S6551/javascript/rule.adoc
+++ b/rules/S6551/javascript/rule.adoc
@@ -66,7 +66,7 @@ foo.toString();
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString[MDN - ``++Object.prototype.toString()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString[``++Object.prototype.toString()++``]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6557/javascript/rule.adoc
+++ b/rules/S6557/javascript/rule.adoc
@@ -59,5 +59,5 @@ str.endsWith('abc');
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith[String#startsWith]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith[String#endsWith]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith[String#startsWith]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith[String#endsWith]

--- a/rules/S6565/javascript/rule.adoc
+++ b/rules/S6565/javascript/rule.adoc
@@ -121,5 +121,6 @@ class A {
 
 == Resources
 === Documentation
-* https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types[TypeScript - ``++this++`` Types]
-* https://en.wikipedia.org/wiki/Fluent_interface[Wikipedia - Fluent interface]
+
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types[``++this++`` Types]
+* Wikipedia - https://en.wikipedia.org/wiki/Fluent_interface[Fluent interface]

--- a/rules/S6568/javascript/rule.adoc
+++ b/rules/S6568/javascript/rule.adoc
@@ -54,7 +54,7 @@ if (foo === bar) {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-[TypeScript - Non-null Assertion Operator (Postfix ``++!++``)]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-[Non-null Assertion Operator (Postfix ``++!++``)]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6569/javascript/rule.adoc
+++ b/rules/S6569/javascript/rule.adoc
@@ -31,5 +31,5 @@ class C<T> {
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/generics.html[TypeScript - Generics]
-* https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints[TypeScript - Generic Constraints]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/generics.html[Generics]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints[Generic Constraints]

--- a/rules/S6571/javascript/rule.adoc
+++ b/rules/S6571/javascript/rule.adoc
@@ -45,5 +45,5 @@ type IntersectionWithLiteral = 'override';
 == Resources
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types[TypeScript - Union Types]
-* https://www.typescriptlang.org/docs/handbook/2/objects.html#intersection-types[TypeScript - Intersection Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types[Union Types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/objects.html#intersection-types[Intersection Types]

--- a/rules/S6572/javascript/rule.adoc
+++ b/rules/S6572/javascript/rule.adoc
@@ -76,7 +76,7 @@ enum RGB {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/enums.html[TypeScript - Enums]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/enums.html[Enums]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6578/javascript/rule.adoc
+++ b/rules/S6578/javascript/rule.adoc
@@ -40,7 +40,7 @@ enum E {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/enums.html[TypeScript - Enums]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/enums.html[Enums]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6582/javascript/rule.adoc
+++ b/rules/S6582/javascript/rule.adoc
@@ -35,4 +35,4 @@ function foo(param) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[MDN - Optional chaining]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining[Optional chaining]

--- a/rules/S6583/javascript/rule.adoc
+++ b/rules/S6583/javascript/rule.adoc
@@ -58,4 +58,4 @@ enum Direction {
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/enums.html[TypeScript - Enums]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/enums.html[Enums]

--- a/rules/S6590/javascript/rule.adoc
+++ b/rules/S6590/javascript/rule.adoc
@@ -61,7 +61,7 @@ let foo = { bar: 'baz' as const };
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types[TypeScript Literal types]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types[Literal types]
 
 //=== Articles & blog posts
 //=== Conference presentations

--- a/rules/S6594/javascript/rule.adoc
+++ b/rules/S6594/javascript/rule.adoc
@@ -20,5 +20,5 @@ Rewrite the pattern matching from `string.match(regex)` to `regex.exec(string)`.
 
 === Documentation
 
-* https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/String/match[MDN - ``++String.prototype.match()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec[MDN - ``++RegExp.prototype.exec()++``]
+* MDN web docs - https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/String/match[``++String.prototype.match()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec[``++RegExp.prototype.exec()++``]

--- a/rules/S6598/javascript/rule.adoc
+++ b/rules/S6598/javascript/rule.adoc
@@ -51,4 +51,4 @@ type Foo = () => number;
 
 === Documentation
 
-* https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions[TypeScript - Function Type Expressions]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions[Function Type Expressions]

--- a/rules/S6635/javascript/rule.adoc
+++ b/rules/S6635/javascript/rule.adoc
@@ -49,4 +49,4 @@ class TextMsg2 {
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[MDN - constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[constructor]

--- a/rules/S6637/javascript/rule.adoc
+++ b/rules/S6637/javascript/rule.adoc
@@ -43,4 +43,4 @@ let y = (function print(x) {
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind[MDN - ``++Function.prototype.bind()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind[``++Function.prototype.bind()++``]

--- a/rules/S6643/javascript/rule.adoc
+++ b/rules/S6643/javascript/rule.adoc
@@ -15,5 +15,5 @@ Object.defineProperty(Array.prototype, "size", { value: 0 });
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_prototypes[MDN - Object prototypes]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty[MDN - ``++Object.defineProperty()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_prototypes[Object prototypes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty[``++Object.defineProperty()++``]

--- a/rules/S6644/javascript/rule.adoc
+++ b/rules/S6644/javascript/rule.adoc
@@ -22,6 +22,6 @@ let a = x ? x : y;  // Non-compliant, replace with x || y
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator[MDN - Ternary operator]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT[MDN - Logical NOT (!)]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[MDN - Logical OR (||)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator[Ternary operator]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT[Logical NOT (!)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR[Logical OR (||)]

--- a/rules/S6645/javascript/rule.adoc
+++ b/rules/S6645/javascript/rule.adoc
@@ -13,7 +13,7 @@ let bar = undefined; // Noncompliant: replace with let foo;
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[MDN - ``++undefined++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[MDN - ``++let++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[MDN - ``++var++``]
-* https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[MDN - hoisting]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[``++undefined++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let[``++let++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var[``++var++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Hoisting[hoisting]

--- a/rules/S6647/javascript/rule.adoc
+++ b/rules/S6647/javascript/rule.adoc
@@ -27,4 +27,4 @@ class Bar extends Foo {}
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[MDN - constructor]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor[constructor]

--- a/rules/S6650/javascript/rule.adoc
+++ b/rules/S6650/javascript/rule.adoc
@@ -22,6 +22,6 @@ let { foo } = bar;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[MDN - import]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export[MDN - export]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment[MDN - Destructuring assignment]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import[import]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export[export]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment[Destructuring assignment]

--- a/rules/S6653/javascript/rule.adoc
+++ b/rules/S6653/javascript/rule.adoc
@@ -24,5 +24,5 @@ Object.hasOwn(obj, "propertyName");
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn[MDN - Object.hasOwn()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty[MDN - Object.prototype.hasOwnProperty()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn[Object.hasOwn()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty[Object.prototype.hasOwnProperty()]

--- a/rules/S6654/javascript/rule.adoc
+++ b/rules/S6654/javascript/rule.adoc
@@ -21,7 +21,7 @@ Object.setPrototype(foo, bar);
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain[MDN - inheritance and the prototype chain]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto[MDN - \\__proto__]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf[MDN - Object.getPrototypeOf]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf[MDN - Object.setPrototypeOf]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain[inheritance and the prototype chain]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto[\\__proto__]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf[Object.getPrototypeOf]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf[Object.setPrototypeOf]

--- a/rules/S6657/javascript/rule.adoc
+++ b/rules/S6657/javascript/rule.adoc
@@ -20,5 +20,6 @@ let message2 = "Copyright \xA9";    // hexadecimal
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#string_literals[MDN - String literals]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal[MDN - SyntaxError: Octal escape sequences are deprecated]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#string_literals[String literals]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal[SyntaxError: Octal escape sequences are deprecated]

--- a/rules/S6660/javascript/rule.adoc
+++ b/rules/S6660/javascript/rule.adoc
@@ -49,4 +49,5 @@ if (condition3) {
 
 == Resources
 === Documentation
-* link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[MDN - ``++if...else++``]
+
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else++[``++if...else++``]

--- a/rules/S6661/javascript/rule.adoc
+++ b/rules/S6661/javascript/rule.adoc
@@ -25,5 +25,5 @@ const d = {};
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals[MDN - Spread in object literals]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign[MDN - ``Object.assign()``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals[Spread in object literals]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign[``Object.assign()``]

--- a/rules/S6666/javascript/rule.adoc
+++ b/rules/S6666/javascript/rule.adoc
@@ -21,5 +21,6 @@ obj.foo( ...args);
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_function_calls[MDN - spread syntax]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[MDN - ``apply()``]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_function_calls[spread syntax]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[``apply()``]

--- a/rules/S6671/javascript/rule.adoc
+++ b/rules/S6671/javascript/rule.adoc
@@ -30,8 +30,9 @@ new Promise(function(resolve, reject) {
 
 == Resources
 === Documentation
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[MDN - Promise]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[MDN - Error]
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error[Error]
 
 === Related rules
 

--- a/rules/S6676/javascript/rule.adoc
+++ b/rules/S6676/javascript/rule.adoc
@@ -41,8 +41,8 @@ bar(x, y, z);
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[MDN - Functions]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call[MDN - Function.prototype.call()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[MDN - Function.prototype.apply()]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this[MDN - this]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[MDN - globalThis]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions[Functions]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call[Function.prototype.call()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply[Function.prototype.apply()]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this[this]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis[globalThis]

--- a/rules/S6679/javascript/rule.adoc
+++ b/rules/S6679/javascript/rule.adoc
@@ -46,10 +46,10 @@ if (value !== anotherValue){
 
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN[MDN - ``++NaN++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN[MDN - ``++Number.isNaN()++``]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN[MDN - ``++isNaN()++``]
-* https://developer.mozilla.org/en-US/docs/Glossary/Type_Conversion[MDN - Type conversion]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN[``++NaN++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN[``++Number.isNaN()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN[``++isNaN()++``]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Type_Conversion[Type conversion]
 
 === Related rules
 

--- a/rules/S6746/javascript/rule.adoc
+++ b/rules/S6746/javascript/rule.adoc
@@ -68,6 +68,6 @@ class MyComponent extends React.Component {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component#setstate[React - ``setState()`` method]
-* https://react.dev/learn/managing-state[React - Managing state]
+* React Documentation - https://react.dev/reference/react/Component#setstate[``setState()`` method]
+* React Documentation - https://react.dev/learn/managing-state[Managing state]
 

--- a/rules/S6747/javascript/rule.adoc
+++ b/rules/S6747/javascript/rule.adoc
@@ -49,9 +49,9 @@ const Image = <img src={myImage} />;
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes[MDN - HTML attribute reference]
-* https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes[MDN - HTML global attributes]
-* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute[MDN - SVG attribute reference]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[MDN - ARIA states and properties]
-* link:++https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*++[MDN - data-*]
-* https://react.dev/reference/react-dom/components/common#common-props[React - Standard DOM props]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes[HTML attribute reference]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes[HTML global attributes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute[SVG attribute reference]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[ARIA states and properties]
+* MDN web docs - link:++https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*++[data-*]
+* React Documentation - https://react.dev/reference/react-dom/components/common#common-props[Standard DOM props]

--- a/rules/S6748/javascript/rule.adoc
+++ b/rules/S6748/javascript/rule.adoc
@@ -25,4 +25,4 @@ React.createElement("div", {}, 'Children');
 == Resources
 === Documentation
 
-* https://react.dev/learn/passing-props-to-a-component[React - Passing Props to a Component]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component[Passing Props to a Component]

--- a/rules/S6749/javascript/rule.adoc
+++ b/rules/S6749/javascript/rule.adoc
@@ -21,4 +21,4 @@ You can safely remove the redundant fragment while preserving the original behav
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Fragment[React - Fragments]
+* React Documentation - https://react.dev/reference/react/Fragment[Fragments]

--- a/rules/S6750/javascript/rule.adoc
+++ b/rules/S6750/javascript/rule.adoc
@@ -23,5 +23,5 @@ ReactDOM.render(<App />, document.body, callbackRef);
 == Resources
 === Documentation
 
-* https://react.dev/reference/react-dom/render[React - ReactDom#render]
-* https://react.dev/learn/referencing-values-with-refs#adding-a-ref-to-your-component[React - Adding a ref to your component]
+* React Documentation - https://react.dev/reference/react-dom/render[ReactDom#render]
+* React Documentation - https://react.dev/learn/referencing-values-with-refs#adding-a-ref-to-your-component[Adding a ref to your component]

--- a/rules/S6754/javascript/rule.adoc
+++ b/rules/S6754/javascript/rule.adoc
@@ -31,4 +31,4 @@ function MyComponent() {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/useState[React - useState]
+* React Documentation - https://react.dev/reference/react/useState[useState]

--- a/rules/S6756/javascript/rule.adoc
+++ b/rules/S6756/javascript/rule.adoc
@@ -21,5 +21,5 @@ function increment() {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component#setstate[React - setState]
-* https://react.dev/reference/react/Component#setstate-caveats[React - setState caveats]
+* React Documentation - https://react.dev/reference/react/Component#setstate[setState]
+* React Documentation - https://react.dev/reference/react/Component#setstate-caveats[setState caveats]

--- a/rules/S6757/javascript/rule.adoc
+++ b/rules/S6757/javascript/rule.adoc
@@ -40,6 +40,6 @@ function MyComponent({bar}){
 == Resources
 === Documentation
 
-* https://react.dev/learn/your-first-component#defining-a-component[React - Defining a Component]
-* https://react.dev/learn/passing-props-to-a-component[React - Passing Props to a Component]
-* https://react.dev/reference/react/Component[React - Legacy class components]
+* React Documentation - https://react.dev/learn/your-first-component#defining-a-component[Defining a Component]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component[Passing Props to a Component]
+* React Documentation - https://react.dev/reference/react/Component[Legacy class components]

--- a/rules/S6759/javascript/rule.adoc
+++ b/rules/S6759/javascript/rule.adoc
@@ -46,6 +46,6 @@ function Welcome(props: Props) {
 == Resources
 === Documentation
 
-* https://react.dev/learn/passing-props-to-a-component[React - Passing Props to a Component]
-* https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype[TypeScript - Readonly<Type>]
-* https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly[TypeScript - readonly]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component[Passing Props to a Component]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/utility-types.html#readonlytype[Readonly<Type>]
+* TypeScript Documentation - https://www.typescriptlang.org/docs/handbook/2/classes.html#readonly[readonly]

--- a/rules/S6761/javascript/rule.adoc
+++ b/rules/S6761/javascript/rule.adoc
@@ -27,5 +27,5 @@ function MyComponent() {
 == Resources
 === Documentation
 
-* https://react.dev/learn/passing-props-to-a-component#passing-jsx-as-children[React - Passing JSX as children]
-* https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html[React - Dangerously setting the inner HTML]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component#passing-jsx-as-children[Passing JSX as children]
+* React Documentation - https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html[Dangerously setting the inner HTML]

--- a/rules/S6763/javascript/rule.adoc
+++ b/rules/S6763/javascript/rule.adoc
@@ -37,5 +37,5 @@ class MyComponent extends React.Component {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component#shouldcomponentupdate[React - shouldComponentUpdate]
-* https://react.dev/reference/react/PureComponent[React - PureComponent]
+* React Documentation - https://react.dev/reference/react/Component#shouldcomponentupdate[shouldComponentUpdate]
+* React Documentation - https://react.dev/reference/react/PureComponent[PureComponent]

--- a/rules/S6766/javascript/rule.adoc
+++ b/rules/S6766/javascript/rule.adoc
@@ -32,5 +32,5 @@ The characters `<` and `{` should also be escaped, but they are not checked by t
 == Resources
 === Documentation
 
-* https://react.dev/learn#writing-markup-with-jsx[React - Writing markup with JSX]
-* https://developer.mozilla.org/en-US/docs/Glossary/Entity[MDN - Entity codes]
+* React Documentation - https://react.dev/learn#writing-markup-with-jsx[Writing markup with JSX]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Glossary/Entity[Entity codes]

--- a/rules/S6767/javascript/rule.adoc
+++ b/rules/S6767/javascript/rule.adoc
@@ -89,6 +89,6 @@ class Hello extends React.Component<Props> {
 == Resources
 === Documentation
 
-* https://react.dev/learn/passing-props-to-a-component[React - Passing Props to a Component]
-* https://react.dev/reference/react/Component#static-proptypes[React - static propTypes]
-* https://react.dev/learn/typescript#typescript-with-react-components[React - TypeScript with React Components]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component[Passing Props to a Component]
+* React Documentation - https://react.dev/reference/react/Component#static-proptypes[static propTypes]
+* React Documentation - https://react.dev/learn/typescript#typescript-with-react-components[TypeScript with React Components]

--- a/rules/S6770/javascript/rule.adoc
+++ b/rules/S6770/javascript/rule.adoc
@@ -19,4 +19,4 @@ You should rename your component according to Pascal case and all its usages as 
 == Resources
 === Documentation
 
-* https://react.dev/learn#components[React - Creating and nesting components]
+* React Documentation - https://react.dev/learn#components[Creating and nesting components]

--- a/rules/S6772/javascript/rule.adoc
+++ b/rules/S6772/javascript/rule.adoc
@@ -36,5 +36,5 @@ To fix the issue, either insert an explicit JSX space as a string expression `{'
 == Resources
 === Documentation
 
-* https://react.dev/learn#writing-markup-with-jsx[React - Writing markup with JSX]
-* https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#spaces_in_between_inline_and_inline-block_elements[MDN - Spaces in between inline and inline-block elements]
+* React Documentation - https://react.dev/learn#writing-markup-with-jsx[Writing markup with JSX]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#spaces_in_between_inline_and_inline-block_elements[Spaces in between inline and inline-block elements]

--- a/rules/S6774/javascript/rule.adoc
+++ b/rules/S6774/javascript/rule.adoc
@@ -63,5 +63,5 @@ Hello.propTypes = {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component#static-proptypes[React - static propTypes]
-* https://flow.org/en/docs/react/[Flow.js - React]
+* React Documentation - https://react.dev/reference/react/Component#static-proptypes[static propTypes]
+* Flow.js Documentation - https://flow.org/en/docs/react/[React]

--- a/rules/S6775/javascript/rule.adoc
+++ b/rules/S6775/javascript/rule.adoc
@@ -84,6 +84,6 @@ MyComponent.defaultProps = {
 == Resources
 === Documentation
 
-* https://react.dev/learn/typescript#typescript-with-react-components[React - TypeScript with React Components]
-* https://react.dev/learn/passing-props-to-a-component#specifying-a-default-value-for-a-prop[React - Specifying a default value for a prop]
-* https://legacy.reactjs.org/docs/typechecking-with-proptypes.html[React Legacy APIs - Typechecking With PropTypes]
+* React Documentation - https://react.dev/learn/typescript#typescript-with-react-components[TypeScript with React Components]
+* React Documentation - https://react.dev/learn/passing-props-to-a-component#specifying-a-default-value-for-a-prop[Specifying a default value for a prop]
+* React Documentation - https://legacy.reactjs.org/docs/typechecking-with-proptypes.html[Typechecking With PropTypes]

--- a/rules/S6788/javascript/rule.adoc
+++ b/rules/S6788/javascript/rule.adoc
@@ -45,7 +45,8 @@ class AutoselectingInput extends Component {
 
 == Resources
 === Documentation
-* https://react.dev/reference/react-dom/findDOMNode[React - `findDOMNode`]
-* https://react.dev/reference/react/createRef[React - `createRef`]
-* https://react.dev/reference/react/useRef[React - `useRef`]
-* https://react.dev/learn/manipulating-the-dom-with-refs[React - Manipulating the DOM with Refs]
+
+* React Documentation - https://react.dev/reference/react-dom/findDOMNode[`findDOMNode`]
+* React Documentation - https://react.dev/reference/react/createRef[`createRef`]
+* React Documentation - https://react.dev/reference/react/useRef[`useRef`]
+* React Documentation - https://react.dev/learn/manipulating-the-dom-with-refs[Manipulating the DOM with Refs]

--- a/rules/S6789/javascript/rule.adoc
+++ b/rules/S6789/javascript/rule.adoc
@@ -43,4 +43,5 @@ class MyComponent extends React.Component {
 
 == Resources
 === Documentation
-* https://legacy.reactjs.org/blog/2015/12/16/ismounted-antipattern.html[React - `isMounted` is an Antipattern]
+
+* React Documentation - https://legacy.reactjs.org/blog/2015/12/16/ismounted-antipattern.html[`isMounted` is an Antipattern]

--- a/rules/S6790/javascript/rule.adoc
+++ b/rules/S6790/javascript/rule.adoc
@@ -39,8 +39,8 @@ const Hello = createReactClass({
 == Resources
 === Documentation
 
-* https://react.dev/reference/react-dom/components/common#ref-callback[React - `ref` callback function]
-* https://legacy.reactjs.org/docs/refs-and-the-dom.html[React - Refs and the DOM]
-* https://react.dev/learn/manipulating-the-dom-with-refs[React - Manipulating the DOM with Refs]
-* https://react.dev/reference/react/useRef[React - `useRef`]
-* https://react.dev/reference/react/createRef#createref[React - `createRef`]
+* React Documentation - https://react.dev/reference/react-dom/components/common#ref-callback[`ref` callback function]
+* React Documentation - https://legacy.reactjs.org/docs/refs-and-the-dom.html[Refs and the DOM]
+* React Documentation - https://react.dev/learn/manipulating-the-dom-with-refs[Manipulating the DOM with Refs]
+* React Documentation - https://react.dev/reference/react/useRef[`useRef`]
+* React Documentation - https://react.dev/reference/react/createRef#createref[`createRef`]

--- a/rules/S6791/javascript/rule.adoc
+++ b/rules/S6791/javascript/rule.adoc
@@ -75,7 +75,7 @@ class myComponent extends React.Component {
 == Resources
 === Documentation
 
-* https://react.dev/reference/react/Component#unsafe_componentwillmount[React - `UNSAFE_componentWillMount`]
-* https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops[React - `UNSAFE_componentWillReceiveProps`]
-* https://react.dev/reference/react/Component#unsafe_componentwillupdate[React - `UNSAFE_componentWillUpdate`]
-* https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#migrating-from-legacy-lifecycles[React - Migrating from Legacy Lifecycles]
+* React Documentation - https://react.dev/reference/react/Component#unsafe_componentwillmount[`UNSAFE_componentWillMount`]
+* React Documentation - https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops[`UNSAFE_componentWillReceiveProps`]
+* React Documentation - https://react.dev/reference/react/Component#unsafe_componentwillupdate[`UNSAFE_componentWillUpdate`]
+* React Documentation - https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#migrating-from-legacy-lifecycles[Migrating from Legacy Lifecycles]

--- a/rules/S6793/javascript/rule.adoc
+++ b/rules/S6793/javascript/rule.adoc
@@ -23,8 +23,8 @@ To fix the code use a valid value for the aria-* attribute.
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[MDN - ARIA states and properties (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[ARIA states and properties (Reference)]
 
 === Standards
 

--- a/rules/S6807/javascript/rule.adoc
+++ b/rules/S6807/javascript/rule.adoc
@@ -27,9 +27,9 @@ To fix the code add missing aria-* attributes.
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[MDN - ARIA roles (Reference)]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[MDN - ARIA states and properties (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[ARIA roles (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[ARIA states and properties (Reference)]
 
 === Standards
 

--- a/rules/S6811/javascript/rule.adoc
+++ b/rules/S6811/javascript/rule.adoc
@@ -25,9 +25,9 @@ To fix the code remove non-compatible attributes or replace them with the correc
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[MDN - ARIA states and properties (Reference)]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[MDN - ARIA roles (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes[ARIA states and properties (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[ARIA roles (Reference)]
 
 === Standards
 

--- a/rules/S6819/javascript/rule.adoc
+++ b/rules/S6819/javascript/rule.adoc
@@ -29,8 +29,8 @@ Replace the ARIA role with an appropriate HTML tag.
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[MDN - ARIA roles (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[ARIA roles (Reference)]
 
 === Standards
 

--- a/rules/S6821/javascript/rule.adoc
+++ b/rules/S6821/javascript/rule.adoc
@@ -29,8 +29,8 @@ To fix the code use a valid value for the ARIA role attribute.
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[MDN - ARIA roles (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[ARIA roles (Reference)]
 
 === Standards
 

--- a/rules/S6824/javascript/rule.adoc
+++ b/rules/S6824/javascript/rule.adoc
@@ -23,8 +23,8 @@ To fix the code, remove the extra ARIA role or `aria-*` attributes from the unsu
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[MDN - Using ARIA: Roles, states, and properties]
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[MDN - ARIA roles (Reference)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques[Using ARIA: Roles, states, and properties]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles[ARIA roles (Reference)]
 
 === Standards
 

--- a/rules/S878/javascript/rule.adoc
+++ b/rules/S878/javascript/rule.adoc
@@ -37,7 +37,8 @@ i = (a += 2, a + b); // Compliant by exception
 
 === Documentation
 
-* MDN - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator[Comma operator (,)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator[Comma operator (,)]
+
 ifdef::env-github,rspecator-view[]
 
 '''

--- a/rules/S930/javascript/rule.adoc
+++ b/rules/S930/javascript/rule.adoc
@@ -62,9 +62,9 @@ doSomething(1, 2, 3); // Compliant
 == Resources
 === Documentation
 
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[MDN - The ``++arguments++`` object]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters[MDN - Rest parameters]
-* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax[MDN - Spread syntax (``++...++``)]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments[The ``++arguments++`` object]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters[Rest parameters]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax[Spread syntax (``++...++``)]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

