### PR TITLE
Modify rule S4211: Change text to education framework format (APPSEC-1206)

### DIFF
--- a/rules/S4211/csharp/rule.adoc
+++ b/rules/S4211/csharp/rule.adoc
@@ -1,25 +1,56 @@
+Transparency attributes in .NET Framework are a set of security features designed to protect your code from unauthorized access and to protect security-critical operations. However, they can become a vulnerability if not correctly implemented.
+
 == Why is this an issue?
 
-Transparency attributes, ``++SecurityCriticalAttribute++`` and ``++SecuritySafeCriticalAttribute++`` are used to identify code that performs security-critical operations. The second one indicates that it is safe to call this code from transparent, while the first one does not.  Since the transparency attributes of code elements with larger scope take precedence over transparency attributes of code elements that are contained in the first element a class, for instance, with a ``++SecurityCriticalAttribute++`` can not contain a method with a ``++SecuritySafeCriticalAttribute++``.
-
-
-This rule raises an issue when a member is marked with a ``++System.Security++`` security attribute that has a different transparency than the security attribute of a container of the member.
-
-
-=== Noncompliant code example
+Transparency attributes can be declared at several levels. If two different attributes are declared at two different levels, the result can be surprising and not what you may expect. For example, you can declare that a class is SecuritySafeCritical and that a method of this class is SecurityCritical:
 
 [source,csharp]
+----
+    [SecuritySafeCritical]
+    public class Foo
+    {
+        [SecurityCritical]
+        public void Bar() // Is the method SecurityCritical or SecuritySafeCritical?
+        {
+        }
+    }
+----
+
+You may think the method ``Bar`` is protected by the ``SecurityCritical`` attribute and can't be called from tranparent code. But in fact, the attribute that prevails is the ``SecuritySafeCritical`` attribute at the level of the class and the ``Bar`` method can be called from transparent code.
+
+
+=== What is the potential impact?
+
+Conflicting transparency attributes in .NET Framework can lead to serious security issues. 
+
+==== Elevation of Privileges
+
+An attacker could potentially exploit these conflicting transparency attributes to perform actions with higher privileges than intended. For instance, if a member is marked as SecurityCritical but the class is declared as SecuritySafeCritical, it might be called by regular code to perform security-sensitive operations that it shouldn't be able to.
+
+==== Data Exposure
+
+If a member with conflicting attributes is involved in handling sensitive data, an attacker could exploit the vulnerability to gain unauthorized access to this data. This could lead to breaches of confidentiality and potential data loss.
+
+
+== How to fix it
+
+To fix this vulnerability in the .NET Framework, you need to ensure that all members of a class or structure have consistent transparency attributes.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 using System;
 using System.Security;
 
 namespace MyLibrary
 {
-
-    [SecurityCritical]
+    [SecuritySafeCritical]
     public class Foo
     {
-        [SecuritySafeCritical] // Noncompliant
+        [SecurityCritical] // Noncompliant
         public void Bar()
         {
         }
@@ -28,19 +59,18 @@ namespace MyLibrary
 ----
 
 
-=== Compliant solution
+==== Compliant solution
 
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 using System;
 using System.Security;
 
 namespace MyLibrary
 {
-
-    [SecurityCritical]
     public class Foo
     {
+        [SecurityCritical]
         public void Bar()
         {
         }
@@ -51,8 +81,14 @@ namespace MyLibrary
 
 == Resources
 
-* https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[OWASP Top 10 2021 Category A5] - Security Misconfiguration
-* https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration[OWASP Top 10 2017 Category A6] - Security Misconfiguration
+=== Articles & blog posts
+
+* Redgate Hub - https://www.red-gate.com/simple-talk/development/dotnet-development/whats-new-in-code-access-security-in-net-framework-4-0-part-i/[What’s New in Code Access Security in .NET Framework 4.0 – Part I]
+
+=== Standards
+
+* OWASP - https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[Top 10 2021 Category A5 - Security Misconfiguration]
+* OWASP - https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration[Top 10 2017 Category A6 - Security Misconfiguration]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S4211/csharp/rule.adoc
+++ b/rules/S4211/csharp/rule.adoc
@@ -1,31 +1,17 @@
-Transparency attributes in .NET Framework are a set of security features designed to protect your code from unauthorized access and to protect security-critical operations. However, they can become a vulnerability if not correctly implemented.
+Transparency attributes in the .NET Framework, designed to protect security-critical operations, can lead to ambiguities and vulnerabilities when declared at different levels such as both for the class and a method.
 
 == Why is this an issue?
 
-Transparency attributes can be declared at several levels. If two different attributes are declared at two different levels, the result can be surprising and not what you may expect. For example, you can declare that a class is SecuritySafeCritical and that a method of this class is SecurityCritical:
-
-[source,csharp]
-----
-    [SecuritySafeCritical]
-    public class Foo
-    {
-        [SecurityCritical]
-        public void Bar() // Is the method SecurityCritical or SecuritySafeCritical?
-        {
-        }
-    }
-----
-
-You may think the method ``Bar`` is protected by the ``SecurityCritical`` attribute and can't be called from tranparent code. But in fact, the attribute that prevails is the ``SecuritySafeCritical`` attribute at the level of the class and the ``Bar`` method can be called from transparent code.
-
+Transparency attributes can be declared at several levels. If two different attributes are declared at two different levels, the attribute that prevails is the one in the highest level. 
+For example, you can declare that a class is ``SecuritySafeCritical`` and that a method of this class is ``SecurityCritical``. In this case, the method will be ``SecuritySafeCritical`` and the ``SecurityCritical`` attribute attached to it is ignored.
 
 === What is the potential impact?
 
-Conflicting transparency attributes in .NET Framework can lead to serious security issues. 
+Below are some real-world scenarios that illustrate some impacts of an attacker exploiting the vulnerability.
 
 ==== Elevation of Privileges
 
-An attacker could potentially exploit these conflicting transparency attributes to perform actions with higher privileges than intended. For instance, if a member is marked as SecurityCritical but the class is declared as SecuritySafeCritical, it might be called by regular code to perform security-sensitive operations that it shouldn't be able to.
+An attacker could potentially exploit conflicting transparency attributes to perform actions with higher privileges than intended.
 
 ==== Data Exposure
 
@@ -33,8 +19,6 @@ If a member with conflicting attributes is involved in handling sensitive data, 
 
 
 == How to fix it
-
-To fix this vulnerability in the .NET Framework, you need to ensure that all members of a class or structure have consistent transparency attributes.
 
 === Code examples
 
@@ -77,6 +61,14 @@ namespace MyLibrary
     }
 }
 ----
+
+=== How does this work?
+
+==== Never set class-level annotations
+
+A class should never have class-level annotations if some functions have different permission levels. Instead, make sure every function has its own correct annotation.  
+
+If no function needs a particularly distinct security annotation in a class, just set a class-level ``++[SecurityCritical]++``.
 
 
 == Resources


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

