### PR TITLE
Modify rule S1079: Change text to education framework format (APPSEC-1209)

### DIFF
--- a/rules/S1079/cfamily/rule.adoc
+++ b/rules/S1079/cfamily/rule.adoc
@@ -1,42 +1,58 @@
 == Why is this an issue?
 
-The ``++%s++`` placeholder is used to read a word into a string.
+The ``++%s++`` format specifier is used to read a string into a buffer.
 
-By default, there is no restriction on the length of that word, and the developer is required to pass a sufficiently large buffer for storing it.
+By default, there is no restriction on the length of that string. The ``scanf`` family of functions will continue to read characters into the buffer until they find a whitespace character.
 
-No matter how large the buffer is, there will always be a longer word.
+If the input contains a sufficiently long string with no whitespace characters, it can cause memory beyond the end of the buffer to be overwritten. This is a buffer overflow vulnerability.
 
-Therefore, programs relying on ``++%s++`` are vulnerable to buffer overflows.
+=== What is the potential impact?
 
+If the buffer is stored on the stack, the attacker can overwrite pieces of memory that control program flow. The attacker can exploit a technique called return-oriented programming to execute arbitrary code.
 
-A field width specifier can be used together with the ``++%s++`` placeholder to limit the number of bytes which will by written to the buffer.
+If the buffer is stored on the heap, the attacker can corrupt other memory on the heap. This allows the attacker to control the application's state, cause unexpected behavior, or cause the program to crash.
 
-Note that an additional byte is required to store the null terminator.
+== How to fix it
 
+A field width can be used together with the ``++%s++`` format specifier. This places a maximum limit on the number of characters that will be read into the buffer.
 
-=== Noncompliant code example
+Note that the ``++%s++`` format specifier always null-terminates the string in the buffer. You will need to ensure that the buffer is large enough to hold the required input and the null terminator.
 
-[source,cpp]
+=== Code examples
+
+==== Noncompliant code example
+
+[source,C++,diff-id=1,diff-type=noncompliant]
 ----
 char buffer[10];
-scanf("%s", buffer);      // Noncompliant - will overflow when a word longer than 9 characters is entered
+scanf("%s", buffer);  // Noncompliant
 ----
 
+If this code is given the word ``noncompliant`` as an input, ``noncomplia`` will be stored in ``buffer`` and ``nt␀`` will overwrite the contents of the memory immediately following ``buffer``.
 
-=== Compliant solution
+==== Compliant solution
 
-[source,cpp]
+[source,C++,diff-id=1,diff-type=compliant]
 ----
 char buffer[10];
-scanf("%9s", buffer);     // Compliant - will not overflow
+scanf("%9s", buffer);
 ----
+
+If this code is given the word ``noncompliant`` as an input, ``noncompli␀`` will be stored in ``buffer``.
 
 
 == Resources
 
-* https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/120[MITRE, CWE-120] - Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-* https://cwe.mitre.org/data/definitions/676[MITRE, CWE-676] - Use of Potentially Dangerous Function
+=== Articles & blog posts
+
+* Wikipedia - https://en.wikipedia.org/wiki/Buffer_overflow[Buffer overflow]
+* Wikipedia - https://en.wikipedia.org/wiki/Return-oriented_programming[Return-oriented programming]
+
+=== Standards
+
+* OWASP - https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities[Top 10 2017 Category A9 - Using Components with Known Vulnerabilities]
+* MITRE - https://cwe.mitre.org/data/definitions/120[CWE-120 - Buffer Copy without Checking Size of Input] ('Classic Buffer Overflow')
+* MITRE - https://cwe.mitre.org/data/definitions/676[CWE-676 - Use of Potentially Dangerous Function]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1079/cfamily/rule.adoc
+++ b/rules/S1079/cfamily/rule.adoc
@@ -1,20 +1,18 @@
+The ``++%s++`` format specifier is used to read a string into a buffer. If the input string exceeds the size of this buffer, a buffer overflow can occur.
+
 == Why is this an issue?
 
-The ``++%s++`` format specifier is used to read a string into a buffer.
+By default, there is no limit on the length of the string being read. The ``scanf`` family of functions will continue to read characters into the buffer until they encounter a whitespace character.
 
-By default, there is no restriction on the length of that string. The ``scanf`` family of functions will continue to read characters into the buffer until they find a whitespace character.
-
-If the input contains a sufficiently long string with no whitespace characters, it can cause memory beyond the end of the buffer to be overwritten. This is a buffer overflow vulnerability.
+If the input contains a string that is long enough and lacks whitespace characters, it can result in memory beyond the end of the buffer being overwritten. This situation is known as a buffer overflow vulnerability.
 
 === What is the potential impact?
 
-If the buffer is stored on the stack, the attacker can overwrite pieces of memory that control program flow. The attacker can exploit a technique called return-oriented programming to execute arbitrary code.
-
-If the buffer is stored on the heap, the attacker can corrupt other memory on the heap. This allows the attacker to control the application's state, cause unexpected behavior, or cause the program to crash.
+An attacker could exploit this vulnerability to overwrite memory used by the application. This could result in the modification of application data, unexpected behavior, or even cause the application to become unstable or crash. In some cases, the attacker might also gain control over the execution flow of the application, leading to arbitrary code execution.
 
 == How to fix it
 
-A field width can be used together with the ``++%s++`` format specifier. This places a maximum limit on the number of characters that will be read into the buffer.
+A field width can be used together with the ``++%s++`` format specifier. This places an upper limit on the number of characters that will be read into the buffer.
 
 Note that the ``++%s++`` format specifier always null-terminates the string in the buffer. You will need to ensure that the buffer is large enough to hold the required input and the null terminator.
 
@@ -46,7 +44,6 @@ If this code is given the word ``noncompliant`` as an input, ``noncompli␀`` wi
 === Articles & blog posts
 
 * Wikipedia - https://en.wikipedia.org/wiki/Buffer_overflow[Buffer overflow]
-* Wikipedia - https://en.wikipedia.org/wiki/Return-oriented_programming[Return-oriented programming]
 
 === Standards
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

