### PR TITLE
Modify S2259: Migrate to LaYC - null dereference

### DIFF
--- a/rules/S2259/how-dotnet.adoc
+++ b/rules/S2259/how-dotnet.adoc
@@ -1,6 +1,6 @@
 == How to fix it
 
-To fix the issue the access of the `{null-keyword}` value needs to be prevented by either:
+To fix the issue, the access of the `{null-keyword}` value needs to be prevented by either:
 
 * ensuring the variable has a value, or
 * by checking if the value is not `{null-keyword}`
@@ -14,4 +14,3 @@ include::{language}/noncompliant-code.adoc[]
 ==== Compliant solution
 
 include::{language}/compliant-code.adoc[]
-

--- a/rules/S2259/java/compliant-code.adoc
+++ b/rules/S2259/java/compliant-code.adoc
@@ -1,4 +1,4 @@
-Ensuring the variable `myObject` has a value resolve the issue:
+Ensuring the variable `myObject` has a value resolves the issue:
 
 [source,java,diff-id=1,diff-type=compliant]
 ----
@@ -22,7 +22,7 @@ public void method(Object input)
 }
 ----
 
-Ensuring that no unboxing of `null` value can happen resolve the issue
+Ensuring that no unboxing of `null` value can happen resolves the issue
 
 [source,java,diff-id=3,diff-type=compliant]
 ----
@@ -32,7 +32,7 @@ public boolean method() {
 }
 ----
 
-Ensuring that both `conn` and `stmt` are not `null` resolve the issue:
+Ensuring that both `conn` and `stmt` are not `null` resolves the issue:
 
 [source,java,diff-id=4,diff-type=compliant]
 ----
@@ -54,7 +54,7 @@ try {
 }
 ----
 
-Checking the returned value of `getName()` resolve the issue:
+Checking the returned value of `getName()` resolves the issue:
 
 [source,java,diff-id=5,diff-type=compliant]
 ----
@@ -71,7 +71,7 @@ public boolean isNameEmpty() {
 }
 ----
 
-Ensuring that the provided `color` is not `null` resolve the issue:
+Ensuring that the provided `color` is not `null` resolves the issue:
 
 [source,java,diff-id=6,diff-type=compliant]
 ----

--- a/rules/S2259/java/compliant-code.adoc
+++ b/rules/S2259/java/compliant-code.adoc
@@ -1,0 +1,85 @@
+Ensuring the variable `myObject` has a value resolve the issue:
+
+[source,java,diff-id=1,diff-type=compliant]
+----
+public void method() {
+  Object myObject = new Object();
+  System.out.println(myObject.toString()); // Compliant: myObject is not null
+}
+----
+
+Preventing the non-compliant code to be executed by returning early:
+
+[source,java,diff-id=2,diff-type=compliant]
+----
+public void method(Object input)
+{
+  if (input == null)
+  {
+    return;
+  }
+  System.out.println(input.toString()); // Compliant: if 'input' is null, this is unreachable
+}
+----
+
+Ensuring that no unboxing of `null` value can happen resolve the issue
+
+[source,java,diff-id=3,diff-type=compliant]
+----
+public boolean method() {
+  Boolean boxed = true;
+  return boxed; // Compliant
+}
+----
+
+Ensuring that both `conn` and `stmt` are not `null` resolve the issue:
+
+[source,java,diff-id=4,diff-type=compliant]
+----
+Connection conn = null;
+Statement stmt = null;
+try {
+  conn = DriverManager.getConnection(DB_URL,USER,PASS);
+  stmt = conn.createStatement();
+  // ...
+} catch(Exception e) {
+  e.printStackTrace();
+} finally {
+  if (stmt != null) {
+    stmt.close();  // Compliant
+  }
+  if (conn != null) {
+    conn.close();  // Compliant
+  }
+}
+----
+
+Checking the returned value of `getName()` resolve the issue:
+
+[source,java,diff-id=5,diff-type=compliant]
+----
+@CheckForNull
+String getName() {...}
+
+public boolean isNameEmpty() {
+  String name = getName();
+  if (name != null) {
+    return name.length() == 0; // Compliant
+  } else {
+    // ...
+  }
+}
+----
+
+Ensuring that the provided `color` is not `null` resolve the issue:
+
+[source,java,diff-id=6,diff-type=compliant]
+----
+private void merge(@Nonnull Color firstColor, @Nonnull Color secondColor) {...}
+
+public void append(@CheckForNull Color color) {
+  if (color != null) {
+    merge(currentColor, color);  // Compliant
+  }
+}
+----

--- a/rules/S2259/java/noncompliant-code.adoc
+++ b/rules/S2259/java/noncompliant-code.adoc
@@ -1,0 +1,74 @@
+The variable `myObject` is equal to `null`, meaning it has no value:
+
+[source,java,diff-id=1,diff-type=noncompliant]
+----
+public void method() {
+  Object myObject = null;
+  System.out.println(myObject.toString()); // Noncompliant: myObject is null
+}
+----
+
+The parameter `input` might be `null` as suggested by the `if` condition:
+
+[source,java,diff-id=2,diff-type=noncompliant]
+----
+public void method(Object input)
+{
+  if (input == null)
+  {
+    // ...
+  }
+  System.out.println(input.toString()); // Noncompliant
+}
+----
+
+The unboxing triggered in the return statement will throw an `NullPointerException`:
+
+[source,java,diff-id=3,diff-type=noncompliant]
+----
+public boolean method() {
+  Boolean boxed = null;
+  return boxed; // Noncompliant
+}
+----
+
+Both `conn` and `stmt` might be `null` in case an exception was thrown in the try{} block:
+
+[source,java,diff-id=4,diff-type=noncompliant]
+----
+Connection conn = null;
+Statement stmt = null;
+try {
+  conn = DriverManager.getConnection(DB_URL,USER,PASS);
+  stmt = conn.createStatement();
+  // ...
+} catch(Exception e) {
+  e.printStackTrace();
+} finally {
+  stmt.close();  // Noncompliant
+  conn.close();  // Noncompliant
+}
+----
+
+As `getName()` is annotated with `@CheckForNull`, there is a risk of `NullPointerException` here:
+
+[source,java,diff-id=5,diff-type=noncompliant]
+----
+@CheckForNull
+String getName() {...}
+
+public boolean isNameEmpty() {
+  return getName().length() == 0; // Noncompliant
+}
+----
+
+As `merge(...)` parameter is annotated with `@Nonnull`, passing an identified potential null value (thanks to @CheckForNull) is not safe:
+
+[source,java,diff-id=6,diff-type=noncompliant]
+----
+private void merge(@Nonnull Color firstColor, @Nonnull Color secondColor) {...}
+
+public void append(@CheckForNull Color color) {
+  merge(currentColor, color);  // Noncompliant: color should be null-checked because merge(...) doesn't accept nullable parameters
+}
+----

--- a/rules/S2259/java/noncompliant-code.adoc
+++ b/rules/S2259/java/noncompliant-code.adoc
@@ -22,7 +22,7 @@ public void method(Object input)
 }
 ----
 
-The unboxing triggered in the return statement will throw an `NullPointerException`:
+The unboxing triggered in the return statement will throw a `NullPointerException`:
 
 [source,java,diff-id=3,diff-type=noncompliant]
 ----

--- a/rules/S2259/java/rule.adoc
+++ b/rules/S2259/java/rule.adoc
@@ -1,58 +1,20 @@
 == Why is this an issue?
 
-A reference to ``++null++`` should never be dereferenced/accessed. Doing so will cause a ``++NullPointerException++`` to be thrown. At best, such an exception will cause abrupt program termination. At worst, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures.
+A reference to `null` should never be dereferenced/accessed. Doing so will cause a `NullPointerException` to be thrown. At best, such an exception will cause abrupt program termination. At worst, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures.
 
+Note that when they are present, this rule takes advantage of `@CheckForNull` and `@Nonnull` annotations defined in https://jcp.org/en/jsr/detail?id=305[JSR-305] to understand which values are and are not nullable except when `@Nonnull` is used on the parameter to `equals`, which by contract should always work with null.
 
-Note that when they are present, this rule takes advantage of ``++@CheckForNull++`` and ``++@Nonnull++`` annotations defined in https://jcp.org/en/jsr/detail?id=305[JSR-305] to understand which values are and are not nullable except when ``++@Nonnull++`` is used on the parameter to ``++equals++``, which by contract should always work with null.
+== How to fix it
 
-=== Noncompliant code example
+=== Code examples
 
-[source,java]
-----
-@CheckForNull
-String getName(){...}
+==== Noncompliant code example
 
-public boolean isNameEmpty() {
-  return getName().length() == 0; // Noncompliant; the result of getName() could be null, but isn't null-checked
-}
-----
+include::noncompliant-code.adoc[]
 
-[source,java]
-----
-Connection conn = null;
-Statement stmt = null;
-try{
-  conn = DriverManager.getConnection(DB_URL,USER,PASS);
-  stmt = conn.createStatement();
-  // ...
+==== Compliant solution
 
-}catch(Exception e){
-  e.printStackTrace();
-}finally{
-  stmt.close();   // Noncompliant; stmt could be null if an exception was thrown in the try{} block
-  conn.close();  // Noncompliant; conn could be null if an exception was thrown 
-}
-----
-
-[source,java]
-----
-private void merge(@Nonnull Color firstColor, @Nonnull Color secondColor){...}
-
-public  void append(@CheckForNull Color color) {
-    merge(currentColor, color);  // Noncompliant; color should be null-checked because merge(...) doesn't accept nullable parameters
-}
-----
-
-[source,java]
-----
-void paint(Color color) {
-  if(color == null) {
-    System.out.println("Unable to apply color " + color.toString());  // Noncompliant; NullPointerException will be thrown
-    return;
-  }
-  ...
-}
-----
+include::compliant-code.adoc[]
 
 == Resources
 
@@ -77,46 +39,6 @@ include::../highlighting.adoc[]
 '''
 == Comments And Links
 (visible only on this page)
-
-=== on 23 Mar 2015, 13:15:46 Freddy Mallet wrote:
-@Ann, could you review this sub-task ? Thanks
-
-=== on 24 Mar 2015, 12:47:38 Samuel Mercier wrote:
-first example is wrong, since ``++instanceof++`` would return ``++false++`` if ``++obj++`` is ``++null++``.
-
-Interestingly, from null/notnull point of view, ``++a instanceof b++`` is equivalent to ``++a != null++``
-
-=== on 24 Mar 2015, 13:45:55 Samuel Mercier wrote:
-\[~ann.campbell.2] I updated the first non compliant code snippet.
-
-=== on 24 Mar 2015, 15:02:13 Samuel Mercier wrote:
-Removed message * NullPointerException will be thrown as 'XXXX' is for sure null here, since we are currently unable to make distinction between @Nullable and if (... == null)
-
-=== on 19 Sep 2019, 05:14:31 QXO wrote:
-This code shouldnot should not be a issue ( in `url.substring(0,start)` url never not null)
-
-It's sonarqube(7.9.1) check implements issue, please fix the issue:)
-
-----
-public String testSonarNullCheckIssue(final String url,final boolean isUrl) { 
-   int start = url != null && isUrl ? url.indexOf('?') : -1;
-   if(start != -1 ){ 
-       return url.substring(0,start);
-   }
-   return url;
-} {code}
-
-ref: https://drive.google.com/open?id=1MuZMBm8bkwz_Q5mZIwEaDsJoh-qaopW_
-----
-
-=== on 19 Sep 2019, 07:24:31 Alexandre Gigleux wrote:
-Thanks for the feedback [~qxo]!
-
-Can you report the FP in the community forum \https://community.sonarsource.com/tags/c/bug/fp/java so it gets more visibility and be addressed?
-
-JIRA comments are not convenient to manage FPs.
-
-Thanks
 
 include::../comments-and-links.adoc[]
 

--- a/rules/S2259/java/rule.adoc
+++ b/rules/S2259/java/rule.adoc
@@ -1,8 +1,15 @@
 == Why is this an issue?
 
-A reference to `null` should never be dereferenced/accessed. Doing so will cause a `NullPointerException` to be thrown. At best, such an exception will cause abrupt program termination. At worst, it could expose debugging information that would be useful to an attacker, or it could allow an attacker to bypass security measures.
+A reference to `null` should never be dereferenced/accessed.
+Doing so will cause a `NullPointerException` to be thrown.
+At best, such an exception will cause abrupt program termination.
+At worst, it could expose debugging information that would be useful to an attacker,
+or it could allow an attacker to bypass security measures.
 
-Note that when they are present, this rule takes advantage of `@CheckForNull` and `@Nonnull` annotations defined in https://jcp.org/en/jsr/detail?id=305[JSR-305] to understand which values are and are not nullable except when `@Nonnull` is used on the parameter to `equals`, which by contract should always work with null.
+Note that when they are present, this rule takes advantage of nullability annotations,
+like `@CheckForNull` or `@Nonnull`, defined in https://jcp.org/en/jsr/detail?id=305[JSR-305]
+to understand which values can be null or not.
+`@Nonnull` will be ignored if used on the parameter of the `equals` method, which by contract should always work with null.
 
 == How to fix it
 

--- a/rules/S2259/java/rule.adoc
+++ b/rules/S2259/java/rule.adoc
@@ -25,9 +25,9 @@ include::compliant-code.adoc[]
 
 == Resources
 
-* https://cwe.mitre.org/data/definitions/476[MITRE, CWE-476] - NULL Pointer Dereference
-* https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[CERT, EXP34-C.] - Do not dereference null pointers
-* https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[CERT, EXP01-J.] - Do not use a null in a case where an object is required
+* MITRE, CWE-476 - https://cwe.mitre.org/data/definitions/476[NULL Pointer Dereference]
+* CERT, EXP34-C. - https://wiki.sei.cmu.edu/confluence/x/QdcxBQ[Do not dereference null pointers]
+* CERT, EXP01-J. - https://wiki.sei.cmu.edu/confluence/x/aDdGBQ[Do not use a null in a case where an object is required]
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2259/javascript/rule.adoc
+++ b/rules/S2259/javascript/rule.adoc
@@ -4,11 +4,19 @@ In JavaScript, `null` and `undefined` are primitive values that do not have prop
 
 This can cause the program to crash or behave unexpectedly, which can be difficult to debug.
 
+== How to fix it
+
+=== Code examples
+
+==== Noncompliant code example
+
 [source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 let foo = null;
 console.log(foo.bar); // Noncompliant: TypeError will be thrown
 ----
+
+==== Compliant solution
 
 Use the logical AND operator (`&&`) to check if a variable is truthy before attempting to access its properties. The expression will short-circuit and return the falsy value instead of attempting to access its properties.
 
@@ -26,7 +34,19 @@ let foo = null;
 console.log(foo?.bar);
 ----
 
+Another option is to check in a `if` condition the equality to `null` or `undefined`.
+With the https://262.ecma-international.org/6.0/#sec-abstract-equality-comparison[abstract equality operator] it is not required to check both, as these operators consider `null` and `undefined` to be equals.
+
+[source,javascript,diff-id=1,diff-type=compliant]
+----
+let foo;
+if (foo != null) {
+  console.log(foo.bar);
+}
+----
+
 == Resources
+
 === Documentation
 
 * MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined[`undefined`]

--- a/rules/S2259/javascript/rule.adoc
+++ b/rules/S2259/javascript/rule.adoc
@@ -18,7 +18,20 @@ console.log(foo.bar); // Noncompliant: TypeError will be thrown
 
 ==== Compliant solution
 
-Use the logical AND operator (`&&`) to check if a variable is truthy before attempting to access its properties. The expression will short-circuit and return the falsy value instead of attempting to access its properties.
+The simplest solution is to check in a `if` condition the equality to `null` or `undefined`.
+With the https://262.ecma-international.org/6.0/#sec-abstract-equality-comparison[abstract equality operator] it is not
+required to check both, as these operators consider `null` and `undefined` to be equals.
+
+[source,javascript,diff-id=1,diff-type=compliant]
+----
+let foo;
+if (foo != null) {
+  console.log(foo.bar);
+}
+----
+
+Also, the logical AND operator (`&&`) can be used to check if a variable is truthy before attempting to access its properties.
+The expression will short-circuit and return the falsy value instead of attempting to access its properties.
 
 [source,javascript,diff-id=1,diff-type=compliant]
 ----
@@ -32,17 +45,6 @@ Alternatively, use the optional chaining operator (`?.`) to check if the variabl
 ----
 let foo = null;
 console.log(foo?.bar);
-----
-
-Another option is to check in a `if` condition the equality to `null` or `undefined`.
-With the https://262.ecma-international.org/6.0/#sec-abstract-equality-comparison[abstract equality operator] it is not required to check both, as these operators consider `null` and `undefined` to be equals.
-
-[source,javascript,diff-id=1,diff-type=compliant]
-----
-let foo;
-if (foo != null) {
-  console.log(foo.bar);
-}
 ----
 
 == Resources


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

