### PR TITLE
Modify rule S2819: Change text to education framework format (APPSEC-1208)

### DIFF
--- a/rules/S2819/common/resources/docs.adoc
+++ b/rules/S2819/common/resources/docs.adoc
@@ -1,0 +1,4 @@
+
+=== Documentation
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage[postMessage API]

--- a/rules/S2819/common/resources/standards.adoc
+++ b/rules/S2819/common/resources/standards.adoc
@@ -1,0 +1,6 @@
+
+=== Standards
+
+* OWASP - https://owasp.org/Top10/A01_2021-Broken_Access_Control/[Top 10 2021 Category A1 - Broken Access Control]
+* OWASP - https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication[Top 10 2017 Category A2 - Broken Authentication]
+* CWE - https://cwe.mitre.org/data/definitions/345.html[CWE-345 - Insufficient Verification of Data Authenticity]

--- a/rules/S2819/impact.adoc
+++ b/rules/S2819/impact.adoc
@@ -1,0 +1,11 @@
+=== What is the potential impact?
+
+The absence of origin verification during cross-origin communications can lead to serious security issues.
+
+==== Data Breach
+
+If an attacker can successfully exploit this vulnerability, they may gain unauthorized access to sensitive data. For instance, a user's personal information, financial details, or other confidential data could be exposed. This not only compromises the user's privacy but can also lead to identity theft or financial loss.
+
+==== Unauthorized Actions
+
+An attacker could manipulate the communication between websites to perform actions on behalf of the user without their knowledge. This could range from making unauthorized purchases to changing user settings or even deleting accounts.

--- a/rules/S2819/javascript/how-to-fix-it/origin.adoc
+++ b/rules/S2819/javascript/how-to-fix-it/origin.adoc
@@ -1,6 +1,8 @@
 
-
 === Code examples
+
+When sending a message, avoid using `*` for the target origin (it means no preference). Instead define it explicitly so the message will only be dispatched to this URI.
+When receiving the message, verify the orgin to be sure that it is sent by an authorized sender.
 
 ==== Noncompliant code example
 
@@ -43,9 +45,3 @@ window.addEventListener("message", function(event) {
   console.log(event.data)
 }); 
 ----
-
-=== How does this work?
-
-When sending a message, the target origin is explicitly defined so the message will only be dispatched to this URI.
-
-When receiving the message, the orgin is verified to be sure that it is sent by an authorized sender.

--- a/rules/S2819/javascript/how-to-fix-it/origin.adoc
+++ b/rules/S2819/javascript/how-to-fix-it/origin.adoc
@@ -1,8 +1,8 @@
 
-=== Code examples
-
 When sending a message, avoid using `*` for the target origin (it means no preference). Instead define it explicitly so the message will only be dispatched to this URI.
 When receiving the message, verify the orgin to be sure that it is sent by an authorized sender.
+
+=== Code examples
 
 ==== Noncompliant code example
 

--- a/rules/S2819/javascript/how-to-fix-it/origin.adoc
+++ b/rules/S2819/javascript/how-to-fix-it/origin.adoc
@@ -1,0 +1,51 @@
+
+
+=== Code examples
+
+==== Noncompliant code example
+
+When sending a message:
+
+[source,javascript,diff-id=1,diff-type=noncompliant]
+----
+var iframe = document.getElementById("testiframe");
+iframe.contentWindow.postMessage("hello", "*"); // Noncompliant: * is used
+----
+
+When receiving a message:
+
+[source,javascript,diff-id=2,diff-type=noncompliant]
+----
+window.addEventListener("message", function(event) { // Noncompliant: no checks are done on the origin property.
+  console.log(event.data);
+ }); 
+----
+
+
+==== Compliant solution
+
+When sending a message:
+
+[source,javascript,diff-id=1,diff-type=compliant]
+----
+var iframe = document.getElementById("testiframe");
+iframe.contentWindow.postMessage("hello", "https://secure.example.com");
+----
+
+When receiving a message:
+
+[source,javascript,diff-id=2,diff-type=compliant]
+----
+window.addEventListener("message", function(event) {
+  if (event.origin !== "http://example.org")
+    return;
+
+  console.log(event.data)
+}); 
+----
+
+=== How does this work?
+
+When sending a message, the target origin is explicitly defined so the message will only be dispatched to this URI.
+
+When receiving the message, the orgin is verified to be sure that it is sent by an authorized sender.

--- a/rules/S2819/javascript/rule.adoc
+++ b/rules/S2819/javascript/rule.adoc
@@ -1,62 +1,20 @@
+include::../summary.adoc[]
+
 == Why is this an issue?
 
-Browsers https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage[allow message exchanges] between Window objects of different origins. 
+include::../rationale.adoc[]
 
-Because any window can send or receive messages from another window, it is important to verify the sender's/receiver's identity:
+include::../impact.adoc[]
 
-* When sending a message with the postMessage method, the identity's receiver should be defined (the wildcard keyword (``++*++``) should not be used).
-* When receiving a message with a message event, the sender's identity should be verified using the origin and possibly source properties.
+== How to fix it
 
-
-=== Noncompliant code example
-
-When sending a message:
-
-[source,javascript]
-----
-var iframe = document.getElementById("testiframe");
-iframe.contentWindow.postMessage("secret", "*"); // Noncompliant: * is used
-----
-When receiving a message:
-
-[source,javascript]
-----
-window.addEventListener("message", function(event) { // Noncompliant: no checks are done on the origin property.
-      console.log(event.data);
- }); 
-----
-
-
-=== Compliant solution
-
-When sending a message:
-
-[source,javascript]
-----
-var iframe = document.getElementById("testsecureiframe");
-iframe.contentWindow.postMessage("hello", "https://secure.example.com"); // Compliant
-----
-When receiving a message:
-
-[source,javascript]
-----
-window.addEventListener("message", function(event) {
-
-  if (event.origin !== "http://example.org") // Compliant
-    return;
-
-  console.log(event.data)
-}); 
-----
-
+include::how-to-fix-it/origin.adoc[]
 
 == Resources
 
-* https://owasp.org/Top10/A01_2021-Broken_Access_Control/[OWASP Top 10 2021 Category A1] - Broken Access Control
-* https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication[OWASP Top 10 2017 Category A2] - Broken Authentication
-* https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage[developer.mozilla.org] - postMessage API
-* https://cwe.mitre.org/data/definitions/345.html[MITRE, CWE-345] - Insufficient Verification of Data Authenticity
+include::../common/resources/docs.adoc[]
 
+include::../common/resources/standards.adoc[]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S2819/rationale.adoc
+++ b/rules/S2819/rationale.adoc
@@ -1,0 +1,3 @@
+Without origin verification, the target website cannot distinguish between legitimate requests from its own pages and malicious requests from an attacker's site. The attacker can craft a malicious website or script that sends requests to a target website where the user is already authenticated.
+
+This vulnerability class is not about a single specific user input or action, but rather a series of actions that lead to an insecure cross-origin communication.

--- a/rules/S2819/summary.adoc
+++ b/rules/S2819/summary.adoc
@@ -1,0 +1,1 @@
+Cross-origin communication allows different websites to interact with each other. This interaction is typically achieved through mechanisms like AJAX requests, WebSockets, or postMessage API. However, a vulnerability can arise when these communications are not properly secured by verifying their origins.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

