### PR TITLE
Modify rule S1081: Change text to education framework format (APPSEC-1210)

### DIFF
--- a/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
+++ b/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
@@ -1,0 +1,41 @@
+== How to fix it
+
+Fixing vulnerabilities related to insecure functions involves replacing these functions with safer alternatives and implementing proper checks.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+char str[20];
+gets(str); // Noncompliant; `str` buffer size is not checked and it is vulnerable to overflows
+----
+
+[source,cpp,diff-id=2,diff-type=noncompliant]
+----
+char buffer[20];
+strcpy(buffer, input); // Noncompliant; `input` length is not checked and it may overflow `buffer`
+----
+
+
+==== Compliant solution
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+char str[20];
+gets_s(str, sizeof(str));
+----
+
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+char buffer[20];
+if(strlen(input) < sizeof(buffer))
+  strcpy(buffer, input);
+----
+
+=== How does this work?
+
+C and C++ have a number of functions that are considered insecure because they do not perform bounds checking. Functions like ``gets`` are known to be risky. Replace these with safer alternatives that include bounds checking. For example, instead of ``gets``, use ``gets_s``.
+
+The code can also checks if the size of input data is less than or equal to the size of a buffer (including the terminating null byte when dealing with strings).

--- a/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
+++ b/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
@@ -1,6 +1,6 @@
 == How to fix it
 
-Fixing vulnerabilities related to insecure functions involves replacing these functions with safer alternatives and implementing proper checks.
+Insecure functions should be replaced with safer alternatives that limit how much data can be written to the buffer.
 
 === Code examples
 
@@ -8,6 +8,8 @@ Fixing vulnerabilities related to insecure functions involves replacing these fu
 
 [source,cpp,diff-id=1,diff-type=noncompliant]
 ----
+#include <stdio.h>
+
 char str[20];
 gets(str); // Noncompliant; `str` buffer size is not checked and it is vulnerable to overflows
 ----
@@ -23,6 +25,9 @@ strcpy(buffer, input); // Noncompliant; `input` length is not checked and it may
 
 [source,cpp,diff-id=1,diff-type=compliant]
 ----
+#define __STDC_WANT_LIB_EXT1__
+#include <stdio.h>
+
 char str[20];
 gets_s(str, sizeof(str));
 ----
@@ -39,3 +44,7 @@ if(strlen(input) < sizeof(buffer))
 C and C++ have a number of functions that are considered insecure because they do not perform bounds checking. Functions like ``gets`` are known to be risky. Replace these with safer alternatives that include bounds checking. For example, instead of ``gets``, use ``gets_s``.
 
 The code can also checks if the size of input data is less than or equal to the size of a buffer (including the terminating null byte when dealing with strings).
+
+The ``++gets_s++`` function is defined in annex K of C11 and is optional for C11 compilers. It will only be available if the macro ``++__STDC_LIB_EXT1__++`` is defined, and it must be enabled by defining the macro ``++__STDC_WANT_LIB_EXT1__++`` before including ``++<stdio.h>++``.
+
+Other platform-specific functions can perform the same operations. For example, ``++strcpy++`` can be substituted with https://learn.microsoft.com/en-us/windows/win32/api/strsafe/nf-strsafe-stringcbcopya[StringCbCopyA] (Windows) or https://www.freebsd.org/cgi/man.cgi?query=strlcpy[strlcpy] (FreeBSD).

--- a/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
+++ b/rules/S1081/cfamily/how-to-fix-it/buffer-overflow.adoc
@@ -16,6 +16,8 @@ gets(str); // Noncompliant; `str` buffer size is not checked and it is vulnerabl
 
 [source,cpp,diff-id=2,diff-type=noncompliant]
 ----
+#include <string.h>
+
 char buffer[20];
 strcpy(buffer, input); // Noncompliant; `input` length is not checked and it may overflow `buffer`
 ----
@@ -34,9 +36,11 @@ gets_s(str, sizeof(str));
 
 [source,cpp,diff-id=2,diff-type=compliant]
 ----
+#define __STDC_WANT_LIB_EXT1__
+#include <string.h>
+
 char buffer[20];
-if(strlen(input) < sizeof(buffer))
-  strcpy(buffer, input);
+strcpy_s(buffer, sizeof buffer, input);
 ----
 
 === How does this work?

--- a/rules/S1081/cfamily/rule.adoc
+++ b/rules/S1081/cfamily/rule.adoc
@@ -1,40 +1,18 @@
+include::../summary.adoc[]
+
 == Why is this an issue?
 
-When using typical C functions, it's up to the developer to make sure the size of the buffer to be written to is large enough to avoid buffer overflows. Buffer overflows can cause the program to crash at a minimum. At worst, a carefully crafted overflow can cause malicious code to be executed.
+include::../rationale.adoc[]
 
+include::../impact.adoc[]
 
-This rule reports use of the following insecure functions, for which knowing the required size is not generally possible: ``++gets()++`` and ``++getpw()++``.
+// How to fix it section
 
-
-In such cases. The only way to prevent buffer overflow while using these functions would be to control the execution context of the application.
-
-It is much safer to secure the application from within and to use an alternate, secure function which allows you to define the maximum number of characters to be written to the buffer:
-
-* ``++fgets++`` or ``++gets_s++``
-* ``++getpwuid++``
-
-
-=== Noncompliant code example
-
-[source,cpp]
-----
-gets(str); // Noncompliant; `str` buffer size is not checked and it is vulnerable to overflows
-----
-
-
-=== Compliant solution
-
-[source,cpp]
-----
-gets_s(str, sizeof(str)); // Prevent overflows by enforcing a maximum size for `str` buffer
-----
-
+include::how-to-fix-it/buffer-overflow.adoc[]
 
 == Resources
 
-* https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities[OWASP Top 10 2017 Category A9] - Using Components with Known Vulnerabilities
-* https://cwe.mitre.org/data/definitions/676[MITRE, CWE-676] - Use of Potentially Dangerous Function
-* https://cwe.mitre.org/data/definitions/119[MITRE, CWE-119] - Improper Restriction of Operations within the Bounds of a Memory Buffer
+include::../common/resources/standards.adoc[]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S1081/cfamily/rule.adoc
+++ b/rules/S1081/cfamily/rule.adoc
@@ -12,6 +12,10 @@ include::how-to-fix-it/buffer-overflow.adoc[]
 
 == Resources
 
+=== Articles & blog posts
+
+* Wikipedia - https://en.wikipedia.org/wiki/Buffer_overflow[Buffer overflow]
+
 include::../common/resources/standards.adoc[]
 
 

--- a/rules/S1081/common/resources/standards.adoc
+++ b/rules/S1081/common/resources/standards.adoc
@@ -1,0 +1,7 @@
+
+=== Standards
+
+* OWASP - https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[Top 10 2021 - A06 - Vulnerable and Outdated Components]
+* OWASP - https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities[Top 10 2017 Category A9 - Using Components with Known Vulnerabilities]
+* CWE - https://cwe.mitre.org/data/definitions/676[CWE-676 - Use of Potentially Dangerous Function]
+* CWE - https://cwe.mitre.org/data/definitions/119[CWE-119 - Improper Restriction of Operations within the Bounds of a Memory Buffer]

--- a/rules/S1081/impact.adoc
+++ b/rules/S1081/impact.adoc
@@ -10,7 +10,7 @@ In some scenarios, insecure functions can lead to information disclosure. For in
 
 In some cases, an attacker can craft input in a way that allows them to gain unauthorized access to your system. For example, they might be able to overwrite a function's return address in memory, causing your program to execute code of the attacker's choosing. This could potentially give the attacker full control over your system.
 
-=== Denial of service
+==== Denial of service
 
 If an attacker can trigger a buffer overflow by providing oversized input, it can cause the program to crash. If the attacker repeats this process, it can continually disrupt the service, denying access to other users. This can be particularly damaging for services that require high availability, such as online platforms or databases.
 

--- a/rules/S1081/impact.adoc
+++ b/rules/S1081/impact.adoc
@@ -1,0 +1,17 @@
+=== What is the potential impact?
+
+Using insecure functions can lead to serious security issues.
+
+==== Information disclosure
+
+In some scenarios, insecure functions can lead to information disclosure. For instance, if an attacker can cause a buffer overflow, they might be able to read memory that they're not supposed to have access to. This could potentially allow them to access sensitive information, such as passwords or encryption keys.
+
+==== Code execution
+
+In some cases, an attacker can craft input in a way that allows them to gain unauthorized access to your system. For example, they might be able to overwrite a function's return address in memory, causing your program to execute code of the attacker's choosing. This could potentially give the attacker full control over your system.
+
+=== Denial of service
+
+If an attacker can trigger a buffer overflow by providing oversized input, it can cause the program to crash. If the attacker repeats this process, it can continually disrupt the service, denying access to other users. This can be particularly damaging for services that require high availability, such as online platforms or databases.
+
+In some cases, the input might cause the program to enter an infinite loop or consume excessive memory, slowing down the system or even causing it to become unresponsive. This type of attack is known as a resource exhaustion DoS attack.

--- a/rules/S1081/impact.adoc
+++ b/rules/S1081/impact.adoc
@@ -1,11 +1,5 @@
 === What is the potential impact?
 
-Using insecure functions can lead to serious security issues.
-
-==== Information disclosure
-
-In some scenarios, insecure functions can lead to information disclosure. For instance, if an attacker can cause a buffer overflow, they might be able to read memory that they're not supposed to have access to. This could potentially allow them to access sensitive information, such as passwords or encryption keys.
-
 ==== Code execution
 
 In some cases, an attacker can craft input in a way that allows them to gain unauthorized access to your system. For example, they might be able to overwrite a function's return address in memory, causing your program to execute code of the attacker's choosing. This could potentially give the attacker full control over your system.

--- a/rules/S1081/rationale.adoc
+++ b/rules/S1081/rationale.adoc
@@ -1,3 +1,5 @@
-An attacker typically provides input that exceeds the expected size. This could be through a text field in a user interface, a file that the program reads, or data sent over a network. The insecure function then processes this oversized input, leading to unexpected behavior.
+An attacker typically provides input that exceeds the expected size. This could be through a text field in a user interface, a file that the program reads, or data sent over a network. The insecure function processes this input and places the result into a provided buffer.
+	
+If the input is larger than the buffer can handle, the insecure function will overwrite the memory following the buffer. This situation is known as a buffer overflow vulnerability.
 
 When using typical C or C++ functions, it's up to the developer to make sure the size of the buffer to be written to is large enough to avoid buffer overflows.

--- a/rules/S1081/rationale.adoc
+++ b/rules/S1081/rationale.adoc
@@ -1,0 +1,3 @@
+An attacker typically provides input that exceeds the expected size. This could be through a text field in a user interface, a file that the program reads, or data sent over a network. The insecure function then processes this oversized input, leading to unexpected behavior.
+
+When using typical C or C++ functions, it's up to the developer to make sure the size of the buffer to be written to is large enough to avoid buffer overflows.

--- a/rules/S1081/summary.adoc
+++ b/rules/S1081/summary.adoc
@@ -1,0 +1,1 @@
+Insecure functions often involve handling data, such as strings and memory operations. The vulnerability arises when these functions do not properly check or limit the size of the data they are handling.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

