### PR TITLE
Modify rule S5832: Change text to education framework format (APPSEC-1213)

### DIFF
--- a/rules/S5832/cfamily/rule.adoc
+++ b/rules/S5832/cfamily/rule.adoc
@@ -4,11 +4,13 @@ Pluggable authentication module (PAM) is a mechanism used on many UNIX variants 
 
 When authenticating users, if the validity of the account is not checked (not locked, not expired ...), it may lead to unauthorized access to resources.
 
+== How to fix it
+
 === Code examples
 
 ==== Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=noncompliant]
 ----
 int valid(pam_handle_t *pamh) {
     if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) { // Noncompliant
@@ -21,7 +23,7 @@ int valid(pam_handle_t *pamh) {
 
 ==== Compliant solution
 
-[source,cpp]
+[source,cpp,diff-id=1,diff-type=compliant]
 ----
 int valid(pam_handle_t *pamh) {
     if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) {

--- a/rules/S5832/cfamily/rule.adoc
+++ b/rules/S5832/cfamily/rule.adoc
@@ -1,14 +1,12 @@
+Pluggable authentication module (PAM) is a mechanism used on many UNIX variants to provide a unified way to authenticate users, independently of the underlying authentication scheme.
+
 == Why is this an issue?
 
-Pluggable authentication module (PAM) is a mechanism used on many unix variants to provide a unified way to authenticate users, independently of the underlying authentication scheme.
+When authenticating users, if the validity of the account is not checked (not locked, not expired ...), it may lead to unauthorized access to resources.
 
+=== Code examples
 
-When authenticating users, it is strongly recommended to check the validity of the account (not locked, not expired ...), otherwise it leads to unauthorized access to resources.
-
-
-=== Noncompliant code example
-
-The account validity is not checked with ``++pam_acct_mgmt++`` when authenticating a user with ``++pam_authenticate++``:
+==== Noncompliant code example
 
 [source,cpp]
 ----
@@ -21,7 +19,7 @@ int valid(pam_handle_t *pamh) {
 }
 ----
 
-The return value of ``++pam_acct_mgmt++`` is not checked:
+==== Compliant solution
 
 [source,cpp]
 ----
@@ -29,35 +27,24 @@ int valid(pam_handle_t *pamh) {
     if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) {
         return -1;
     }
-    pam_acct_mgmt(pamh, 0); // Noncompliant
-    return 0;
-}
-----
-
-
-=== Compliant solution
-
-When authenticating a user with ``++pam_authenticate++``, check the account validity with ``++pam_acct_mgmt++``:
-
-[source,cpp]
-----
-int valid(pam_handle_t *pamh) {
-    if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) {
-        return -1;
-    }
-    if (pam_acct_mgmt(pamh, 0) != PAM_SUCCESS) { // Compliant
+    if (pam_acct_mgmt(pamh, 0) != PAM_SUCCESS) {
         return -1;
     }
     return 0;
 }
 ----
+
+=== How does this work?
+
+The account validity is checked with ``++pam_acct_mgmt++`` when authenticating a user with ``++pam_authenticate++``.
 
 == Resources
 
-* https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[OWASP Top 10 2021 Category A7] - Identification and Authentication Failures
-* https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[OWASP Top 10 2017 Category A5] - Broken Access Control
-* https://cwe.mitre.org/data/definitions/304[MITRE, CWE-304] - Missing Critical Step in Authentication
+=== Standards
 
+* OWASP - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/[Top 10 2021 Category A7 - Identification and Authentication Failures]
+* OWASP - https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A5-Broken_Access_Control[Top 10 2017 Category A5 - Broken Access Control]
+* CWE - https://cwe.mitre.org/data/definitions/304[CWE-304 - Missing Critical Step in Authentication]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5832/cfamily/rule.adoc
+++ b/rules/S5832/cfamily/rule.adoc
@@ -11,7 +11,7 @@ When authenticating users, if the validity of the account is not checked (not lo
 [source,cpp]
 ----
 int valid(pam_handle_t *pamh) {
-    if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) { // Noncompliant - missing pam_acct_mgmt
+    if (pam_authenticate(pamh, PAM_DISALLOW_NULL_AUTHTOK) != PAM_SUCCESS) { // Noncompliant
         return -1;
     }
 
@@ -30,6 +30,7 @@ int valid(pam_handle_t *pamh) {
     if (pam_acct_mgmt(pamh, 0) != PAM_SUCCESS) {
         return -1;
     }
+    
     return 0;
 }
 ----
@@ -39,6 +40,14 @@ int valid(pam_handle_t *pamh) {
 The account validity is checked with ``++pam_acct_mgmt++`` when authenticating a user with ``++pam_authenticate++``.
 
 == Resources
+
+=== Documentation
+
+* The Open Group - https://pubs.opengroup.org/onlinepubs/8329799/pam_acct_mgmt.htm[``pam_acct_mgmt``]
+
+=== Articles & blog posts
+
+* Packt hub - https://hub.packtpub.com/development-pluggable-authentication-modules-pam/[Development with Pluggable Authentication Modules (PAM)]
 
 === Standards
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

