### PR TITLE
Modify rule S5144: Add HTTPX support (APPSEC-1247)

### DIFF
--- a/docs/header_names/allowed_framework_names.adoc
+++ b/docs/header_names/allowed_framework_names.adoc
@@ -87,6 +87,7 @@
 * Python Standard Library
 * PyYAML
 * Requests
+* HTTPX
 * SQLAlchemy
 * Amazon DynamoDB
 * python-ldap

--- a/rules/S5144/python/how-to-fix-it/httpx.adoc
+++ b/rules/S5144/python/how-to-fix-it/httpx.adoc
@@ -23,7 +23,8 @@ def example(url: str):
 
 [source,python,diff-id=21,diff-type=compliant]
 ----
-from fastapi import FastAPI, Response, status
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import httpx
 from urllib.parse import urlparse
 
@@ -31,10 +32,9 @@ DOMAINS_ALLOWLIST = ['trusted1.example.com', 'trusted2.example.com']
 app = FastAPI()
 
 @app.get('/example')
-def example(url: str, response: Response):
+def example(url: str):
     if not urlparse(url).hostname in DOMAINS_ALLOWLIST:
-        response.status_code = status.HTTP_400_BAD_REQUEST
-        return {"error": f"URL {url} is not in whitelist"}
+        return JSONResponse({"error": f"URL {url} is not whitelisted."}, 400)
 
     r = httpx.get(url)
     return {"response": r.text}

--- a/rules/S5144/python/how-to-fix-it/httpx.adoc
+++ b/rules/S5144/python/how-to-fix-it/httpx.adoc
@@ -15,8 +15,8 @@ app = FastAPI()
 
 @app.get('/example')
 def example(url: str):
-    response = httpx.get(url)  # Noncompliant
-    return {"response": response.text}
+    r = httpx.get(url)  # Noncompliant
+    return {"response": r.text}
 ----
 
 ==== Compliant solution

--- a/rules/S5144/python/how-to-fix-it/httpx.adoc
+++ b/rules/S5144/python/how-to-fix-it/httpx.adoc
@@ -34,10 +34,10 @@ app = FastAPI()
 def example(url: str, response: Response):
     if not urlparse(url).hostname in DOMAINS_ALLOWLIST:
         response.status_code = status.HTTP_400_BAD_REQUEST
-        return
+        return {"error": f"URL {url} is not in whitelist"}
 
-    response = httpx.get(url)
-    return {"response": response.text}
+    r = httpx.get(url)
+    return {"response": r.text}
 ----
 
 === How does this work?

--- a/rules/S5144/python/how-to-fix-it/httpx.adoc
+++ b/rules/S5144/python/how-to-fix-it/httpx.adoc
@@ -1,0 +1,52 @@
+== How to fix it in HTTPX
+
+=== Code examples
+
+include::../../common/fix/code-rationale.adoc[]
+
+==== Noncompliant code example
+
+[source,python,diff-id=21,diff-type=noncompliant]
+----
+from fastapi import FastAPI
+import httpx
+
+app = FastAPI()
+
+@app.get('/example')
+def example(url: str):
+    response = httpx.get(url)  # Noncompliant
+    return {"response": response.text}
+----
+
+==== Compliant solution
+
+[source,python,diff-id=21,diff-type=compliant]
+----
+from fastapi import FastAPI, Response, status
+import httpx
+from urllib.parse import urlparse
+
+DOMAINS_ALLOWLIST = ['trusted1.example.com', 'trusted2.example.com']
+app = FastAPI()
+
+@app.get('/example')
+def example(url: str, response: Response):
+    if not urlparse(url).hostname in DOMAINS_ALLOWLIST:
+        response.status_code = status.HTTP_400_BAD_REQUEST
+        return
+
+    response = httpx.get(url)
+    return {"response": response.text}
+----
+
+=== How does this work?
+
+include::../../common/fix/pre-approved-list.adoc[]
+
+The compliant code example uses such an approach.
+HTTPX implicitly validates the scheme as it only allows `http` and `https` by default.
+
+=== Pitfalls
+
+include::../../common/pitfalls/starts-with.adoc[]

--- a/rules/S5144/python/rule.adoc
+++ b/rules/S5144/python/rule.adoc
@@ -10,6 +10,8 @@ include::how-to-fix-it/python.adoc[]
 
 include::how-to-fix-it/requests.adoc[]
 
+include::how-to-fix-it/httpx.adoc[]
+
 == Resources
 
 include::../common/resources/standards.adoc[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

