### PR TITLE
Modify rule S4830: Add HTTPX support (APPSEC-1259)

### DIFF
--- a/docs/header_names/allowed_framework_names.adoc
+++ b/docs/header_names/allowed_framework_names.adoc
@@ -87,6 +87,7 @@
 * Python Standard Library
 * PyYAML
 * Requests
+* HTTPX
 * SQLAlchemy
 * Amazon DynamoDB
 * python-ldap

--- a/rules/S4830/python/how-to-fix-it/httpx.adoc
+++ b/rules/S4830/python/how-to-fix-it/httpx.adoc
@@ -1,4 +1,4 @@
-== How to fix it in Requests
+== How to fix it in HTTPX
 
 === Code examples
 

--- a/rules/S4830/python/how-to-fix-it/httpx.adoc
+++ b/rules/S4830/python/how-to-fix-it/httpx.adoc
@@ -1,0 +1,34 @@
+== How to fix it in Requests
+
+=== Code examples
+
+include::../../common/fix/code-rationale.adoc[]
+
+:cert_variable_name: verify
+:cert_variable_unsafe_value: False
+:cert_variable_safe_value: True
+
+include::../../common/fix/code-rationale-setting.adoc[]
+
+==== Noncompliant code example
+
+[source,python,diff-id=11,diff-type=noncompliant]
+----
+import httpx
+
+httpx.get('https://example.com', verify=False)  # Noncompliant
+----
+
+==== Compliant solution
+
+[source,python,diff-id=11,diff-type=compliant]
+----
+import httpx
+
+# By default, certificate validation is enabled
+httpx.get('https://example.com')
+----
+
+=== How does this work?
+
+include::../../common/fix/validation.adoc[]

--- a/rules/S4830/python/how-to-fix-it/httpx.adoc
+++ b/rules/S4830/python/how-to-fix-it/httpx.adoc
@@ -12,7 +12,7 @@ include::../../common/fix/code-rationale-setting.adoc[]
 
 ==== Noncompliant code example
 
-[source,python,diff-id=11,diff-type=noncompliant]
+[source,python,diff-id=31,diff-type=noncompliant]
 ----
 import httpx
 
@@ -21,7 +21,7 @@ httpx.get('https://example.com', verify=False)  # Noncompliant
 
 ==== Compliant solution
 
-[source,python,diff-id=11,diff-type=compliant]
+[source,python,diff-id=31,diff-type=compliant]
 ----
 import httpx
 

--- a/rules/S4830/python/rule.adoc
+++ b/rules/S4830/python/rule.adoc
@@ -14,6 +14,8 @@ include::how-to-fix-it/openssl.adoc[]
 
 include::how-to-fix-it/requests.adoc[]
 
+include::how-to-fix-it/httpx.adoc[]
+
 == Resources
 
 include::../common/resources/standards.adoc[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

