### PR TITLE
Modify rule S6359: Change text to education framework format (APPSEC-1239)

### DIFF
--- a/rules/S6359/xml/rule.adoc
+++ b/rules/S6359/xml/rule.adoc
@@ -4,9 +4,11 @@ Namespaces act as a container for grouping together permissions with a common th
 
 The ``android.permission`` namespace holds all of the permissions defined by the Android operating system. It is not intended to be a general use container for all permissions.
 
+Defining permissions in the ``android.permission`` namespace increases the risk of a permission name collision. The collision could be due to a new Android system permission, or it could be due to another app using the same permission name.
+
 === What is the potential impact?
 
-Defining permissions in the ``android.permission`` namespace increases the risk of a permission name collision. The collision could be due to a new Android system permission, or it could be due to another app using the same permission name.
+Below are some examples of the problems caused by a collision of Android permission names.
 
 ==== App installations may fail
 

--- a/rules/S6359/xml/rule.adoc
+++ b/rules/S6359/xml/rule.adoc
@@ -1,43 +1,77 @@
 == Why is this an issue?
 
-Defining a custom permission in the ``android.permission`` namespace may result in an unexpected permission assignment if a newer version of Android adds a permission with the same name. It is recommended to use a namespace specific to the application for custom permissions.
+Namespaces act as a container for grouping together permissions with a common theme or purpose. They also prevent conflicts when multiple apps want to use the same permission name.
 
+The ``android.permission`` namespace holds all of the permissions defined by the Android operating system. It is not intended to be a general use container for all permissions.
 
-=== Noncompliant code example
+=== What is the potential impact?
 
-[source,xml]
+Defining permissions in the ``android.permission`` namespace increases the risk of a permission name collision. The collision could be due to a new Android system permission, or it could be due to another app using the same permission name.
+
+==== App installations may fail
+
+Android will not allow multiple apps to define the same permission unless they are signed with the same key. This will be checked during when an app is installed or upgraded, and can cause the installation to fail with an ``INSTALL_FAILED_DUPLICATE_PERMISSION`` error.
+
+If the permission name collision is with an Android system permission, your app will no longer be allowed to install or upgrade.
+
+If the permission name collision is with another app, only one of the apps can be installed at a time. The presence of either app on the device will prevent the other app from being installed.
+
+==== Unexpected permission grants
+
+Permissions can be restricted so that they are only granted to apps signed with the same key. This allows apps from the same developer to work together but doesn't expose that functionality to other apps.
+
+When an app is granted a permission, that grant exists for as long as the app is installed. It remains in place even if the app that defined the permission is removed.
+
+If your app reuses a permission that had previously been defined, any apps that retain the that permission will be able to bypass the signing key check.
+
+== How to fix it
+
+Applications should define custom permissions in an application-specific namespace. This greatly reduces the chance of a permission name conflict.
+
+It is common practice to use the application package name as part of the namespace.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,xml,diff-id=1,diff-type=noncompliant]
 ----
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.organization.app">
 
     <permission
-        android:name="android.permission.MYPERMISSION" /> <!-- Noncompliant -->
+        android:name="android.permission.MY_PERMISSION" /> <!-- Noncompliant -->
 
 </manifest>
 ----
 
-=== Compliant solution
+==== Compliant solution
 
-[source,xml]
+[source,xml,diff-id=1,diff-type=compliant]
 ----
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.organization.app">
 
     <permission
-        android:name="com.organization.app.permission.MYPERMISSION" />
+        android:name="com.organization.app.permission.MY_PERMISSION" />
 
 </manifest> 
 ----
 
 == Resources
 
-* https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Mobile AppSec Verification Standard] - Platform Interaction Requirements
-* https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage[OWASP Mobile Top 10 2016 Category M1] - Improper Platform Usage
-* https://cwe.mitre.org/data/definitions/265[MITRE, CWE-265] - Privilege Issues
-* https://cwe.mitre.org/data/definitions/732[MITRE, CWE-732] - Incorrect Permission Assignment for Critical Resource
-* https://developer.android.com/guide/topics/permissions/defining[developer.android.com] - Define a Custom App Permission
+=== Standards
+
+* Mobile AppSec Verification Standard - https://mobile-security.gitbook.io/masvs/security-requirements/0x11-v6-interaction_with_the_environment[Platform Interaction Requirements]
+* OWASP - https://owasp.org/www-project-mobile-top-10/2016-risks/m1-improper-platform-usage[Mobile Top 10 2016 Category M1 - Improper Platform Usage]
+* MITRE - https://cwe.mitre.org/data/definitions/265[CWE-265 - Privilege Issues]
+* MITRE - https://cwe.mitre.org/data/definitions/732[CWE-732 - Incorrect Permission Assignment for Critical Resource]
+
+=== External coding guidelines
+
+* Android Developers - https://developer.android.com/guide/topics/permissions/defining[Define a Custom App Permission]
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

