### PR TITLE
Modify rule S5869: Mention character class escapes

### DIFF
--- a/rules/S5869/javascript/rule.adoc
+++ b/rules/S5869/javascript/rule.adoc
@@ -2,19 +2,34 @@
 
 include::../description.adoc[]
 
-=== Noncompliant code example
+Character ranges can also create duplicates when used with character class escapes. These are a type of escape sequence used in regular expressions to represent a specific set of characters. They are denoted by a backslash followed by a specific letter, such as `++\d++` for digits, `++\w++` for word characters, or `++\s++` for whitespace characters. For example, the character class escape `++\d++` is equivalent to the character range `++[0-9]++`, and the escape `++\w++` is equivalent to `++[a-zA-Z0-9_]++`.
 
-[source,javascript]
+== How to fix it
+
+Remove the extra character, character range, or character class escape.
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 /[0-99]/ // Noncompliant, this won't actually match strings with two digits
 /[0-9.-_]/ // Noncompliant, .-_ is a range that already contains 0-9 (as well as various other characters such as capital letters)
+/[a-z0-9\d]/ // Noncompliant, \d matches a digit and is equivalent to [0-9]
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,javascript]
+[source,javascript,diff-id=1,diff-type=compliant]
 ----
 /[0-9]{1,2}/
 /[0-9.\-_]/
+/[a-z\d]/
 ----
+
+== Resources
+=== Documentation
+
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes[Character classes]
+* MDN web docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape[Character class escape]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

