### PR TITLE
Don't crash when the asciidoc logger receives a string

### DIFF
--- a/frontend/src/deployment/description.ts
+++ b/frontend/src/deployment/description.ts
@@ -57,6 +57,14 @@ const winstonLogger = asciidoc.LoggerManager.newLogger('WinstonLogger', {
   },
   add: function (severity: any, _: any, message: any) {
     const level = severity >= 3 ? 'error' : 'warning';
+    if (typeof message === "string") {
+      this.logger.log({
+        level: level,
+        message: message,
+        source: path.basename(__filename)
+      });
+      return;
+    }
     const location = message.getSourceLocation();
     this.logger.log({
       level: level,


### PR DESCRIPTION
The asciidoc documentation states that the logger will receive objects with a given interface, but sometimes we receive simple strings that crash the documented code.