### PR TITLE
Modify S3394(COBOL): Remove compliant samples

### DIFF
--- a/rules/S3394/cobol/rule.adoc
+++ b/rules/S3394/cobol/rule.adoc
@@ -68,33 +68,6 @@ EXAMPLE-PROCEDURE.
     STOP RUN.
 ----
 
-==== Compliant solution
-
-[source,cobol,diff-id=1,diff-type=compliant]
-----
-IDENTIFICATION DIVISION.
-PROGRAM-ID. EXAMPLE.
-
-DATA DIVISION.
-WORKING-STORAGE SECTION.
-01 WS-NUMERIC PIC X VALUE 'N'.
-01 USER-INPUT PIC X(4).
-
-PROCEDURE DIVISION.
-EXAMPLE-PROCEDURE.
-    MOVE 'N' TO WS-NUMERIC.
-    PERFORM UNTIL WS-NUMERIC = 'Y'
-        DISPLAY 'ENTER YOUR 4 DIGIT RECORD NUMBER: ' NO ADVANCING
-        ACCEPT USER-INPUT FROM CONSOLE
-        IF USER-INPUT IS NUMERIC THEN
-            MOVE 'Y' TO WS-NUMERIC
-        ELSE
-            DISPLAY 'INVALID INPUT. PLEASE ENTER A NUMERIC VALUE.'
-        END-IF
-    END-PERFORM
-    STOP RUN.
-----
-
 === How does this work?
 
 To mitigate the risks associated with the ACCEPT keyword in COBOL, you should

--- a/rules/S3394/cobol/rule.adoc
+++ b/rules/S3394/cobol/rule.adoc
@@ -47,7 +47,7 @@ In this specific example, `USER-INPUT` is expected to be numeric by the system.
 
 ==== Noncompliant code example
 
-[source,cobol,diff-id=1,diff-type=noncompliant]
+[source,cobol]
 ----
 IDENTIFICATION DIVISION.
 PROGRAM-ID. EXAMPLE.


### PR DESCRIPTION
 ## Why
https://github.com/SonarSource/rspec/commit/b4812424ee5b9cd210f926252566ac6c3bb291dd#r131831666
This code sample will raise, as the COBOL logic is pretty simple. The idea is to make this rule a "review" rule instead of a vulnerability. We do not have the bandwidth to convert it to a hotspot but that's ok.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

