### PR TITLE
Modify rule S6012: fix some typos

### DIFF
--- a/rules/S6012/cfamily/rule.adoc
+++ b/rules/S6012/cfamily/rule.adoc
@@ -3,13 +3,13 @@
 Since {cpp}17, class template arguments can be automatically deduced by the compiler, either by looking at the arguments of the class constructors or by using an explicitly defined deduction guide.
 
 
-Using the class template argument deduction allow to:
+Using the class template argument deduction allows to:
 
 * Avoid verbose specification of all template parameter types for a class template.
 * Avoid writing helper function that only serves the purpose of deducing the type of a class from its arguments. For example, ``++std::make_pair++``.
-* Be able to instantiate a class template with hard to spell or unutterable names, such as the closure type of a lambda.
+* Be able to instantiate a class template with hard-to-spell or unutterable names, such as the closure type of a lambda.
 
-This rule raises an issue when explicit class template arguments that can be automatically deduced is specified.
+This rule raises an issue when explicit class template arguments that can be automatically deduced are specified.
 
 
 === Noncompliant code example
@@ -18,8 +18,7 @@ This rule raises an issue when explicit class template arguments that can be aut
 ----
 void f() {
     std::vector<int> v1 {1, 2, 3}; // Noncompliant, int could have been deduced
-}{code}
-
+}
 ----
 
 === Compliant solution


### PR DESCRIPTION
The intent here is only to fix critical typos, not to rewrite the rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

