### PR TITLE
Modify Rule S4830: Add aiohttp support (APPSEC-1361)

### DIFF
--- a/rules/S4830/python/how-to-fix-it/aiohttp.adoc
+++ b/rules/S4830/python/how-to-fix-it/aiohttp.adoc
@@ -1,0 +1,39 @@
+== How to fix it in aiohttp
+
+=== Code examples
+
+include::../../common/fix/code-rationale.adoc[]
+
+:cert_variable_name: verify_ssl
+:cert_variable_unsafe_value: False
+:cert_variable_safe_value: True
+
+include::../../common/fix/code-rationale-setting.adoc[]
+
+==== Noncompliant code example
+
+[source,python,diff-id=41,diff-type=noncompliant]
+----
+import aiohttp
+
+async def example():
+  async with aiohttp.ClientSession() as session:
+    session.get("https://example.com", verify_ssl=False) # Noncompliant
+----
+
+==== Compliant solution
+
+[source,python,diff-id=41,diff-type=compliant]
+----
+import aiohttp
+
+# By default, certificate validation is enabled
+
+async def example():
+  async with aiohttp.ClientSession() as session:
+    session.get("https://example.com")
+----
+
+=== How does this work?
+
+include::../../common/fix/validation.adoc[]

--- a/rules/S4830/python/rule.adoc
+++ b/rules/S4830/python/rule.adoc
@@ -14,6 +14,7 @@ include::how-to-fix-it/openssl.adoc[]
 
 include::how-to-fix-it/requests.adoc[]
 
+include::how-to-fix-it/aiohttp.adoc[]
 
 == Resources
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

