### PR TITLE
Fix S6790: Use method definition in code snippets

### DIFF
--- a/rules/S6790/javascript/rule.adoc
+++ b/rules/S6790/javascript/rule.adoc
@@ -11,11 +11,11 @@ Older React versions allowed the ref attribute to be a string, like `"textInput"
 [source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 const Hello = createReactClass({
-  componentDidMount: function() {
+  componentDidMount() {
     const component = this.refs.hello; // Noncompliant
     // ...
   },
-  render: function() {
+  render() {
     return <div ref="hello">Hello, world.</div>;
   }
 });
@@ -26,7 +26,7 @@ Instead, reference callbacks should be used. These do not have the limitations m
 [source,javascript,diff-id=1,diff-type=compliant]
 ----
 const Hello = createReactClass({
-  componentDidMount: function() {
+  componentDidMount() {
     const component = this.hello;
     // ...
   },


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

