### PR TITLE
BUILD-4131 Use GitHub token from Vault instead of sonartech api token

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TMP_BRANCH: temporary/coverage_update
-
+    permissions:
+      id-token: write # required for SonarSource/vault-action-wrapper
     steps:
     - name: get secrets
       id: secrets

--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -10,12 +10,19 @@ jobs:
       TMP_BRANCH: temporary/coverage_update
 
     steps:
+    - name: get secrets
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@v2
+      with:
+        secrets: |
+          development/kv/data/slack webhook | SLACK_WEBHOOK;
+          development/github/token/{REPO_OWNER_NAME_DASH}-coverage token | coverage_token;
     - uses: actions/checkout@v4
       with:
         persist-credentials: true
         ref: master
         path: 'rspec'
-        token: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
+        token: ${{ fromJSON(steps.secrets.outputs.vault).coverage_token }}
 
     - uses: actions/setup-python@v4
       with:
@@ -31,7 +38,7 @@ jobs:
 
     - name: 'Regenerate coverage information'
       env:
-        GITHUB_TOKEN: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).coverage_token }}
       id: gen-coverage
       working-directory: 'rspec/rspec-tools'
       run: |


### PR DESCRIPTION
# BUILD-4131 Use GitHub token from Vault instead of sonartech api token

## Changes
* Update pipeline to no longer use a secret from Github and use Vault instead
   That way the token can be rotated easily

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

