### PR TITLE
Modify S5915 (Python): Add to default quality profile

### DIFF
--- a/rules/S5915/python/metadata.json
+++ b/rules/S5915/python/metadata.json
@@ -4,5 +4,8 @@
     "unused",
     "pitfall"
   ],
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ],
   "quickfix": "covered"
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

