### PR TITLE
Modify S5906 (Python): Add to default quality profile

### DIFF
--- a/rules/S5906/python/metadata.json
+++ b/rules/S5906/python/metadata.json
@@ -28,7 +28,7 @@
   "sqKey": "S5906",
   "scope": "Tests",
   "defaultQualityProfiles": [
-
+    "Sonar way"
   ],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

