### PR TITLE
Use NodeJS 16 to run Sonar analysis

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && \
                                                ca-certificates gnupg && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
       gpg --dearmor -o /etc/apt/nodesource-keyring.gpg && \
-    echo "deb [signed-by=/etc/apt/nodesource-keyring.gpg] https://deb.nodesource.com/node_16.x nodistro main" | \
-      tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/nodesource-keyring.gpg] https://deb.nodesource.com/node_16.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,17 @@
 FROM public.ecr.aws/docker/library/python:3.9-slim-buster
 
+# Also install NodeJS 16 to run Sonar analysis
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor pipenv git curl
+    apt-get install -y --no-install-recommends jq php-json-schema asciidoctor pipenv git curl \
+                                               ca-certificates gnupg && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+      gpg --dearmor -o /etc/apt/nodesource-keyring.gpg && \
+    echo "deb [signed-by=/etc/apt/nodesource-keyring.gpg] https://deb.nodesource.com/node_16.x nodistro main" | \
+      tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
 
 CMD ["bash"]

--- a/ci/frontend-tests-dockerfile
+++ b/ci/frontend-tests-dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/docker/library/node:14.17.0
+FROM public.ecr.aws/docker/library/node:16.20.2
 
 CMD ["bash"]


### PR DESCRIPTION
A fix for
> ERROR: Error during SonarScanner execution
java.lang.IllegalStateException: Error while running Node.js. A supported version of Node.js is required for running the analysis of JS in HTML files. Please make sure a supported version of Node.js is available in the PATH. Alternatively, you can exclude JS in HTML files from your analysis using the 'sonar.exclusions' configuration property. See the docs for configuring the analysis environment: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/javascript-typescript-css/