### PR TITLE
Deprecate rule S4792 (APPSEC-1407)

### DIFF
--- a/rules/S4792/metadata.json
+++ b/rules/S4792/metadata.json
@@ -7,17 +7,11 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
-  "tags": [
-    "cwe"
-  ],
+  "status": "deprecated",
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-4792",
@@ -48,7 +42,5 @@
       "7.1.2"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
This rule is noisy and was planned to be deprecated [for a long time](https://discuss.sonarsource.com/t/are-we-doing-right-the-security-hotspots-review-on-sonarqube/5706/6).

As we are currently looking to remove unwanted hotspots as part of our ongoing sprint, we are now deprecating this rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

