### PR TITLE
Modify rule S2091: Add support for Apache Commons JXPath

### DIFF
--- a/rules/S2091/java/how-to-fix-it/apache-commons.adoc
+++ b/rules/S2091/java/how-to-fix-it/apache-commons.adoc
@@ -7,7 +7,7 @@ untrusted data is concatenated to an XPath query without prior validation.
 
 ==== Noncompliant code example
 
-[source,java,diff-id=1,diff-type=noncompliant]
+[source,java,diff-id=11,diff-type=noncompliant]
 ----
 public class Book {
   public String getName() { /* ... */ }
@@ -28,7 +28,7 @@ public Book findBook(HttpServletRequest req, Author author) throws JXPathExcepti
 
 ==== Compliant solution
 
-[source,java,diff-id=1,diff-type=compliant]
+[source,java,diff-id=11,diff-type=compliant]
 ----
 public class Book {
   public String getName() { /* ... */ }

--- a/rules/S2091/java/how-to-fix-it/apache-commons.adoc
+++ b/rules/S2091/java/how-to-fix-it/apache-commons.adoc
@@ -1,0 +1,72 @@
+== How to fix it in Java SE
+
+=== Code examples
+
+The following noncompliant code is vulnerable to XPath injections because
+untrusted data is concatenated to an XPath query without prior validation.
+
+==== Noncompliant code example
+
+[source,java,diff-id=1,diff-type=noncompliant]
+----
+public class Book {
+  public String getName() { /* ... */ }
+}
+
+public class Author {
+  public Book[] getBooks() { /* ... */ }
+}
+
+public Book findBook(HttpServletRequest req, Author author) throws JXPathException {
+  String name = request.getParameter("name"); 
+
+  JXPathContext context = JXPathContext.newContext(author);
+
+  return (Book)context.getValue("books[@name='" + name + "']");
+}
+----
+
+==== Compliant solution
+
+[source,java,diff-id=1,diff-type=compliant]
+----
+public class Book {
+  public String getName() { /* ... */ }
+}
+
+public class Author {
+  public Book[] getBooks() { /* ... */ }
+}
+
+public Book findBook(HttpServletRequest req, Author author) throws JXPathException {
+  String name = request.getParameter("name"); 
+
+  JXPathContext context = JXPathContext.newContext(author);
+  context.getVariables().declareVariable("name", name);
+
+  return (Book)context.getValue("books[@name=$name]");
+}
+----
+
+=== How does this work?
+
+JXPath is slightly different to other XPath implementations because it works on
+object trees rather than just XML documents. This additional functionality can
+lead to a greater range of side-effects, potentially including remote code
+execution (RCE).
+
+As a rule of thumb, the best approach to protect against injections is to
+systematically ensure that untrusted data cannot break out of the initially
+intended logic.
+
+include::../../common/fix/parameterized-queries.adoc[]
+
+In the example, a variable is declared to hold the value of the untrusted data.
+That variable then used to safely reference the value of the untrusted data,
+similar to parameterized SQL queries.
+
+include::../../common/fix/validation.adoc[]
+
+Extra attention should be given to the characters `(` and `)`. These characters
+are commonly used when attempting to exploit JXPath weaknesses and should be
+rejected as unsafe.

--- a/rules/S2091/java/how-to-fix-it/apache-commons.adoc
+++ b/rules/S2091/java/how-to-fix-it/apache-commons.adoc
@@ -9,14 +9,6 @@ untrusted data is concatenated to an XPath query without prior validation.
 
 [source,java,diff-id=11,diff-type=noncompliant]
 ----
-public class Book {
-  public String getName() { /* ... */ }
-}
-
-public class Author {
-  public Book[] getBooks() { /* ... */ }
-}
-
 public Book findBook(HttpServletRequest req, Author author) throws JXPathException {
   String name = request.getParameter("name"); 
 
@@ -30,14 +22,6 @@ public Book findBook(HttpServletRequest req, Author author) throws JXPathExcepti
 
 [source,java,diff-id=11,diff-type=compliant]
 ----
-public class Book {
-  public String getName() { /* ... */ }
-}
-
-public class Author {
-  public Book[] getBooks() { /* ... */ }
-}
-
 public Book findBook(HttpServletRequest req, Author author) throws JXPathException {
   String name = request.getParameter("name"); 
 

--- a/rules/S2091/java/how-to-fix-it/apache-commons.adoc
+++ b/rules/S2091/java/how-to-fix-it/apache-commons.adoc
@@ -1,4 +1,4 @@
-== How to fix it in Java SE
+== How to fix it in Apache Commons
 
 === Code examples
 

--- a/rules/S2091/java/rule.adoc
+++ b/rules/S2091/java/rule.adoc
@@ -8,6 +8,8 @@ include::../impact.adoc[]
 
 include::how-to-fix-it/java-se.adoc[]
 
+include::how-to-fix-it/apache-commons.adoc[]
+
 == Resources
 
 include::../common/resources/articles.adoc[]


### PR DESCRIPTION
Motivated by [APPSEC-203](https://sonarsource.atlassian.net/browse/APPSEC-203) and CVE-2022-41852.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)



[APPSEC-203]: https://sonarsource-sandbox-608.atlassian.net/browse/APPSEC-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ