### PR TITLE
Deprecate rule S6245

### DIFF
--- a/rules/S6245/metadata.json
+++ b/rules/S6245/metadata.json
@@ -7,10 +7,8 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "deprecated",
   "tags": [
-    "aws",
-    "cwe"
   ],
   "extra": {
     "replacementRules": [
@@ -36,6 +34,5 @@
     ]
   },
   "defaultQualityProfiles": [
-    "Sonar way"
   ]
 }


### PR DESCRIPTION
S3 now encrypts by default. As we are currently looking to remove unwanted hotspots as part of our ongoing sprint, we are now deprecating this rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

