### PR TITLE
Deprecate rule S5743 (APPSEC-1410)

### DIFF
--- a/rules/S5743/javascript/metadata.json
+++ b/rules/S5743/javascript/metadata.json
@@ -1,9 +1,1 @@
-{
-  "tags": [
-    "privacy",
-    "express.js"
-  ],
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
-}
+{}

--- a/rules/S5743/metadata.json
+++ b/rules/S5743/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Allowing browsers to perform DNS prefetching  is security-sensitive",
+  "title": "Allowing browsers to perform DNS prefetching is security-sensitive",
   "type": "SECURITY_HOTSPOT",
   "code": {
     "impacts": {
@@ -7,21 +7,15 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-    "privacy"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-5743",
@@ -41,7 +35,5 @@
       "2.2"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
This rule checks for the [X-DNS-Prefetch-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control) header, which is non-standard and not on a standards track. It is recommended to not be used on production sites facing the Web, so we should also not recommend it.

As we are currently looking to remove unwanted hotspots as part of our ongoing sprint, we are now deprecating this rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

