### PR TITLE
Delete rule S5750 (APPSEC-1411)

### DIFF
--- a/rules/S5750/javascript/metadata.json
+++ b/rules/S5750/javascript/metadata.json
@@ -1,10 +1,1 @@
-{
-  "tags": [
-    "cwe",
-    "privacy",
-    "express.js"
-  ],
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
-}
+{}

--- a/rules/S5750/metadata.json
+++ b/rules/S5750/metadata.json
@@ -7,7 +7,7 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"
@@ -17,12 +17,8 @@
     "privacy"
   ],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-5750",
@@ -49,7 +45,5 @@
       "8.2.1"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
This rule was decided not to be implemented back in 2020: SonarSource/SonarJS#1962.

As we are currently looking to remove unwanted hotspots as part of our ongoing sprint, we are deleting this rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

