### PR TITLE
Fix typo in S1125 description

### DIFF
--- a/rules/S1125/apex/rule.adoc
+++ b/rules/S1125/apex/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/csharp/rule.adoc
+++ b/rules/S1125/csharp/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/description.adoc
+++ b/rules/S1125/description.adoc
@@ -3,6 +3,6 @@ They can be combined with logical operators (`{ops}`) to produce logical express
 However, comparing a boolean literal to a variable or expression that evaluates to a boolean value is unnecessary and can make the code harder to read and understand.
 The more complex a boolean expression is, the harder it will be for developers to understand its meaning and expected behavior, and it will favour the introduction of new bugs.
 
-== How to tix it
+== How to fix it
 
 Remove redundant boolean literals from expressions to improve readability and make the code more maintainable.

--- a/rules/S1125/description.adoc
+++ b/rules/S1125/description.adoc
@@ -3,6 +3,13 @@ They can be combined with logical operators (`{ops}`) to produce logical express
 However, comparing a boolean literal to a variable or expression that evaluates to a boolean value is unnecessary and can make the code harder to read and understand.
 The more complex a boolean expression is, the harder it will be for developers to understand its meaning and expected behavior, and it will favour the introduction of new bugs.
 
+ifdef::exceptions[]
+=== Exceptions
+
+{exceptions}
+
+endif::[]
+
 == How to fix it
 
 Remove redundant boolean literals from expressions to improve readability and make the code more maintainable.

--- a/rules/S1125/description.adoc
+++ b/rules/S1125/description.adoc
@@ -2,14 +2,3 @@ A boolean literal can be represented in two different ways: `{true}` or `{false}
 They can be combined with logical operators (`{ops}`) to produce logical expressions that represent truth values.
 However, comparing a boolean literal to a variable or expression that evaluates to a boolean value is unnecessary and can make the code harder to read and understand.
 The more complex a boolean expression is, the harder it will be for developers to understand its meaning and expected behavior, and it will favour the introduction of new bugs.
-
-ifdef::exceptions[]
-=== Exceptions
-
-{exceptions}
-
-endif::[]
-
-== How to fix it
-
-Remove redundant boolean literals from expressions to improve readability and make the code more maintainable.

--- a/rules/S1125/go/rule.adoc
+++ b/rules/S1125/go/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/how-to-fix-it.adoc
+++ b/rules/S1125/how-to-fix-it.adoc
@@ -1,0 +1,1 @@
+Remove redundant boolean literals from expressions to improve readability and make the code more maintainable.

--- a/rules/S1125/javascript/rule.adoc
+++ b/rules/S1125/javascript/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 [source,javascript,diff-id=1,diff-type=noncompliant]
 ----
 if (someValue == true) { /* ... */ } // Noncompliant: Redundant comparison

--- a/rules/S1125/kotlin/rule.adoc
+++ b/rules/S1125/kotlin/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/php/rule.adoc
+++ b/rules/S1125/php/rule.adoc
@@ -1,10 +1,17 @@
 :true: true
 :false: false
 :ops: !, &&, ||, ==, !=
-:exceptions: The use of literal booleans in comparisons which use identity operators (`===` and `!==`) are ignored.
 == Why is this an issue?
 
 include::../description.adoc[]
+
+=== Exceptions
+
+The use of literal booleans in comparisons which use identity operators (`===` and `!==`) are ignored.
+
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
 
 === Code examples
 

--- a/rules/S1125/php/rule.adoc
+++ b/rules/S1125/php/rule.adoc
@@ -1,6 +1,7 @@
 :true: true
 :false: false
 :ops: !, &&, ||, ==, !=
+:exceptions: The use of literal booleans in comparisons which use identity operators (`===` and `!==`) are ignored.
 == Why is this an issue?
 
 include::../description.adoc[]
@@ -26,10 +27,6 @@ if (!$booleanVariable) { /* ... */ }
 if ($booleanVariable) { /* ... */ }       
 doSomething(true);
 ----
-
-=== Exceptions
-
-The use of literal booleans in comparisons which use identity operators (``++===++`` and ``++!==++``) are ignored.
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S1125/plsql/rule.adoc
+++ b/rules/S1125/plsql/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/rule.adoc
+++ b/rules/S1125/rule.adoc
@@ -2,6 +2,10 @@
 
 include::description.adoc[]
 
+== How to fix it
+
+include::how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/scala/rule.adoc
+++ b/rules/S1125/scala/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/vb6/rule.adoc
+++ b/rules/S1125/vb6/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example

--- a/rules/S1125/vbnet/rule.adoc
+++ b/rules/S1125/vbnet/rule.adoc
@@ -5,6 +5,10 @@
 
 include::../description.adoc[]
 
+== How to fix it
+
+include::../how-to-fix-it.adoc[]
+
 === Code examples
 
 ==== Noncompliant code example


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

