### PR TITLE
Benchmarks Guide: Update statistical term links

### DIFF
--- a/docs/benchmarks.adoc
+++ b/docs/benchmarks.adoc
@@ -11,7 +11,7 @@ The format of the benchmarks section is as follows:
 == Benchmark table
 
 - Do not use abbreviations for statistical terms, not everyone is familiar with them.
-- At the `Benchmarks` section, add a subsection called `Glossary` right after the benchmark table and add links to Wikipedia to explain statistical terms used at the header of each column:
+- In the `Benchmarks` section, add a subsection called `Glossary` right after the benchmark table and add links to Wikipedia to explain statistical terms used in the header of each column:
 
 ==== Glossary
 
@@ -19,7 +19,7 @@ The format of the benchmarks section is as follows:
 * https://en.wikipedia.org/wiki/Standard_deviation[Standard Deviation]
 * https://en.wikipedia.org/wiki/Memory_management[Allocated]
 
-Ideally, the columns should look like the following example:
+Ideally, the columns should look like in the following example:
 
 |===
 | <What is being measured> | Mean | Standard Deviation | Allocated

--- a/docs/benchmarks.adoc
+++ b/docs/benchmarks.adoc
@@ -11,12 +11,18 @@ The format of the benchmarks section is as follows:
 == Benchmark table
 
 - Do not use abbreviations for statistical terms, not everyone is familiar with them.
-- Add links to Wikipedia to explain statistical terms at the header of each column.
+- At the `Benchmarks` section, add a subsection called `Glossary` right after the benchmark table and add links to Wikipedia to explain statistical terms used at the header of each column:
+
+==== Glossary
+
+* https://en.wikipedia.org/wiki/Arithmetic_mean[Mean]
+* https://en.wikipedia.org/wiki/Standard_deviation[Standard Deviation]
+* https://en.wikipedia.org/wiki/Memory_management[Allocated]
 
 Ideally, the columns should look like the following example:
 
 |===
-| <What is being measured> | https://en.wikipedia.org/wiki/Arithmetic_mean[Mean] | https://en.wikipedia.org/wiki/Standard_deviation[Standard Deviation] | https://en.wikipedia.org/wiki/Memory_management[Allocated]
+| <What is being measured> | Mean | Standard Deviation | Allocated
 | <This> | 5.042 ms | 0.1049 ms | 125 KB
 | <That> | 2.691 ms | 0.0334 ms | 85.94 KB
 |===


### PR DESCRIPTION
I am not sure links on table headers will work across all variants of rspec (SL, SQ, SC, rules.sonarsource...), so instead I suggest we use a glossary (which was also suggested as a solution in discussions with the documentation team).