### PR TITLE
Modify rule S2631: Document additional mitigations for C#

### DIFF
--- a/rules/S2631/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S2631/csharp/how-to-fix-it/dotnet.adoc
@@ -15,7 +15,19 @@ public class ExampleController : Controller
     public IActionResult Validate(string regex, string input)
     {
         bool match = Regex.IsMatch(input, regex);
+        return Json(match);
+    }
+}
+----
 
+[source,csharp,diff-id=2,diff-type=noncompliant]
+----
+public class ExampleController : Controller
+{
+    public IActionResult Validate(string regex, string input)
+    {
+        Regex re = new Regex(regex, RegexOptions.None);
+        bool match = re.IsMatch(input);
         return Json(match);
     }
 }
@@ -30,7 +42,19 @@ public class ExampleController : Controller
     public IActionResult Validate(string regex, string input)
     {
         bool match = Regex.IsMatch(input, Regex.Escape(regex));
+        return Json(match);
+    }
+}
+----
 
+[source,csharp,diff-id=2,diff-type=compliant]
+----
+public class ExampleController : Controller
+{
+    public IActionResult Validate(string regex, string input)
+    {
+        Regex re = new Regex(regex, RegexOptions.None, TimeSpan.FromMilliseconds(100));
+        bool match = re.IsMatch(input);
         return Json(match);
     }
 }
@@ -40,6 +64,11 @@ public class ExampleController : Controller
 
 include::../../common/fix/validation.adoc[]
 
-In the compliant solution example, `Regex.Escape` escapes metacharacters and escape sequences that
-could have broken the initially intended logic.
+In the first compliant solution example, `Regex.Escape` escapes metacharacters and escape sequences
+that could have broken the initially intended logic.
 
+In the second compliant solution example, a match timeout of 100 milliseconds is applied to the
+regular expression. An exception will by thrown if the timeout is exceeded.
+
+Starting with .NET 7, `RegexOptions.NonBacktracking` will cause matching to be performed without
+backtracking. This prevents the performance issues that backtracking can introduce.


### PR DESCRIPTION
S2631 did not properly document all of the compliant fixes available for C#. An additional fix will be added with [SONARSEC-4799](https://sonarsource.atlassian.net/browse/SONARSEC-4799) so this is a good opportunity to ensure that the documentation is up to date.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)



[SONARSEC-4799]: https://sonarsource.atlassian.net/browse/SONARSEC-4799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ