### PR TITLE
Fix S4027 C#: BinaryFormatter. Serialization constructors are obsolete and should not be required

### DIFF
--- a/rules/S4027/csharp/rspecator.adoc
+++ b/rules/S4027/csharp/rspecator.adoc
@@ -1,0 +1,15 @@
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+Implement the missing constructors for this exception.
+
+=== Highlighting
+
+Exception class declaration
+
+endif::env-github,rspecator-view[]

--- a/rules/S4027/csharp/rule.adoc
+++ b/rules/S4027/csharp/rule.adoc
@@ -16,15 +16,10 @@ The absence of these constructors can complicate exception handling and limit th
 
 [source,csharp,diff-id=1,diff-type=noncompliant]
 ----
-using System;
-
-namespace MyLibrary
+public class MyException : Exception // Noncompliant: several constructors are missing
 {
-  public class MyException : Exception // Noncompliant: several constructors are missing
+  public MyException()
   {
-    public MyException()
-    {
-    }
   }
 }
 ----
@@ -33,26 +28,20 @@ namespace MyLibrary
 
 [source,csharp,diff-id=1,diff-type=compliant]
 ----
-using System;
-using System.Runtime.Serialization;
-
-namespace MyLibrary
+public class MyException : Exception
 {
-  public class MyException : Exception
+  public MyException()
   {
-      public MyException()
-      {
-      }
+  }
 
-      public MyException(string message)
-          :base(message)
-      {
-      }
+  public MyException(string message)
+    :base(message)
+  {
+  }
 
-      public MyException(string message, Exception innerException)
-          : base(message, innerException)
-      {
-      }
+  public MyException(string message, Exception innerException)
+    : base(message, innerException)
+  {
   }
 }
 ----

--- a/rules/S4027/csharp/rule.adoc
+++ b/rules/S4027/csharp/rule.adoc
@@ -2,20 +2,19 @@
 
 Exceptions types should provide the following constructors:
 
-* ``++public MyException()++``
-* ``++public MyException(string)++``
-* ``++public MyException(string, Exception)++``
-* ``++protected++`` or ``++private MyException(SerializationInfo, StreamingContext)++``
+* `public MyException()`
+* `public MyException(string)`
+* `public MyException(string, Exception)`
 
-That fourth constructor should be ``++protected++`` in unsealed classes, and ``++private++`` in sealed classes.
+The absence of these constructors can complicate exception handling and limit the information that can be provided when an exception is thrown.
 
+== How to fix it
 
-Not having this full set of constructors can make it difficult to handle exceptions.
+=== Code examples
 
+==== Noncompliant code example
 
-=== Noncompliant code example
-
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 using System;
 
@@ -30,10 +29,9 @@ namespace MyLibrary
 }
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 using System;
 using System.Runtime.Serialization;
@@ -55,30 +53,16 @@ namespace MyLibrary
           : base(message, innerException)
       {
       }
-
-      protected MyException(SerializationInfo info, StreamingContext context)
-          : base(info, context)
-      {
-      }
   }
 }
 ----
 
+== Resources
 
-ifdef::env-github,rspecator-view[]
+=== Documentation
 
-'''
-== Implementation Specification
-(visible only on this page)
+* https://learn.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions[How to create user-defined exceptions]
+* https://learn.microsoft.com/en-us/dotnet/api/system.exception[Exception Class]
+* https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/creating-and-throwing-exceptions#define-exception-classes[Define exception classes]
 
-=== Message
-
-Implement the missing constructors for this exception.
-
-
-=== Highlighting
-
-Exception class declaration
-
-
-endif::env-github,rspecator-view[]
+include::./rspecator.adoc[]

--- a/rules/S4027/csharp/rule.adoc
+++ b/rules/S4027/csharp/rule.adoc
@@ -20,7 +20,7 @@ using System;
 
 namespace MyLibrary
 {
-  public class MyException // Noncompliant: several constructors are missing
+  public class MyException : Exception // Noncompliant: several constructors are missing
   {
     public MyException()
     {
@@ -61,8 +61,8 @@ namespace MyLibrary
 
 === Documentation
 
-* https://learn.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions[How to create user-defined exceptions]
-* https://learn.microsoft.com/en-us/dotnet/api/system.exception[Exception Class]
-* https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/creating-and-throwing-exceptions#define-exception-classes[Define exception classes]
+* Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions[How to create user-defined exceptions]
+* Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/api/system.exception[Exception Class]
+* Microsoft Learn: https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/creating-and-throwing-exceptions#define-exception-classes[Define exception classes]
 
 include::./rspecator.adoc[]


### PR DESCRIPTION
Description
In .Net 8 "All externally visible (public or protected) serialization ctors: .ctor(SerializationInfo, StreamingContext)." are marked as obsolete ([Source](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md#new-obsoletions-in-net-8)).

We need to remove the serialization constructor from the list of required constructors for exceptions.