### PR TITLE
Modify rule S6865: Updated example, message and removed configuration part for now

### DIFF
--- a/rules/S6865/kubernetes/rule.adoc
+++ b/rules/S6865/kubernetes/rule.adoc
@@ -34,8 +34,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: example-pod
-spec:
-  containers: # Noncompliant
+spec: # Noncompliant
+  containers:
   - name: example-pod
     image: nginx:1.25.3
 ----
@@ -54,28 +54,6 @@ spec:
     image: nginx:1.25.3
   automountServiceAccountToken: false
 
-----
-
-The same can be achieved by setting `automountServiceAccountToken: false` in the service account's configuration:
-
-[source,yaml]
-----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: example-service-account
-  namespace: default
-automountServiceAccountToken: false
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: example-pod
-spec:
-  containers:
-  - name: example-pod
-    image: nginx:1.25.3
-  serviceAccountName: example-service-account
 ----
 
 === How does this work?
@@ -108,7 +86,7 @@ ifdef::env-github,rspecator-view[]
 
 === Message
 
-Set automountServiceAccountToken to false for this container.
+Set automountServiceAccountToken to false for this specification of kind `kind=Pod|Deployment...`.
 
 
 === Highlighting

--- a/rules/S6865/kubernetes/rule.adoc
+++ b/rules/S6865/kubernetes/rule.adoc
@@ -58,7 +58,7 @@ spec:
 
 === How does this work?
 
-The automounting of service account tokens can be disabled by setting `automountServiceAccountToken: false` in the pod's specification or in the service account's configuration.
+The automounting of service account tokens can be disabled by setting `automountServiceAccountToken: false` in the pod's specification. Additionally, it can be disabled in the configuration of an accompanied service account.
 
 
 // === Pitfalls


### PR DESCRIPTION
Removed the example for **service account's configuration** part, as this is not yet supported
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

