### PR TITLE
Modify rule S2871: Emphasize the necessity of using String.localeCompare to sort arrays of strings

### DIFF
--- a/rules/S2871/javascript/rule.adoc
+++ b/rules/S2871/javascript/rule.adoc
@@ -36,6 +36,22 @@ console.log([code1, code2, code3].sort()); // Noncompliant: ["éΔ", "eΔ", "é�
 console.log([code1, code2, code3].sort((a, b) => a.localeCompare(b))); // ["eΔ", "éΔ", "éΔ"]
 ----
 
+=== Exceptions
+
+The rule ignores arrays that only contain strings, or are declared as such.
+
+[source,javascript]
+----
+const names = ['foo', 'bar'];
+names.sort(); // Compliant
+----
+
+[source,javascript]
+----
+const names: string[] = [];
+names.sort(); // Compliant
+----
+
 == Resources
 === Documentation
 

--- a/rules/S2871/javascript/rule.adoc
+++ b/rules/S2871/javascript/rule.adoc
@@ -25,7 +25,7 @@ numbers.sort((a, b) => a - b);
 console.log(numbers); // Output: [1, 2, 5, 10, 30]
 ----
 
-Even to sort strings, the default sort order may give unexpected results. Not only does it not support localization, it also doesn't fully support Unicode, as it only considers UTF-16 code units. For example, in the code below, `"eΔ"` is surprisingly before and after `"éΔ"`.
+Even to sort strings, the default sort order may give unexpected results. Not only does it not support localization, it also doesn't fully support Unicode, as it only considers UTF-16 code units. For example, in the code below, `"eΔ"` is surprisingly before and after `"éΔ"`. To guarantee that the sorting is reliable and remains as such in the long run, it is necessary to provide a compare function that is both locale and Unicode aware - typically `String.localeCompare`.
 
 [source,javascript]
 ----
@@ -34,22 +34,6 @@ const code2 = '\u0065\u0301\u0394'; // "éΔ" using Unicode combining marks
 const code3 = '\u0065\u0394'; // "eΔ"
 console.log([code1, code2, code3].sort()); // Noncompliant: ["éΔ", "eΔ", "éΔ"], "eΔ" position is inconsistent
 console.log([code1, code2, code3].sort((a, b) => a.localeCompare(b))); // ["eΔ", "éΔ", "éΔ"]
-----
-
-=== Exceptions
-
-The rule ignores arrays that only contain strings, or are declared as such.
-
-[source,javascript]
-----
-const names = ['foo', 'bar'];
-names.sort(); // Compliant
-----
-
-[source,javascript]
-----
-const names: string[] = [];
-names.sort(); // Compliant
 ----
 
 == Resources


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

