### PR TITLE
Modify rule S4123: remove hint about JSdoc and add it to exception

### DIFF
--- a/rules/S4123/javascript/rule.adoc
+++ b/rules/S4123/javascript/rule.adoc
@@ -40,21 +40,25 @@ function foo() {
   return Promise.resolve(42);
 }
 async function bar() {
-  await foo();
+  await foo(); // Compliant
 }
 ----
 
 === Exceptions
 
-The rule does not raise issues if you are awaiting a function whose definition contains JSDoc. This is due to JSDoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:
+The rule does not raise issues if you are awaiting a function whose definition contains JSdoc with `@returns` or `@return` tags. This is due to JSdoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:
 
 [source,js]
 ----
+async function foo () {
+  await bar(); // Compliant
+}
+
 /**
- * @return {number} // this should be {Promise<number>}
+ * @return {number}
  */
-async function foo() {
-  await Promise.resolve(42)
+async function bar () {
+  return 42;
 }
 ----
 

--- a/rules/S4123/javascript/rule.adoc
+++ b/rules/S4123/javascript/rule.adoc
@@ -46,7 +46,7 @@ async function bar() {
 
 === Exceptions
 
-The rule does not raise issues if you are awaiting a function whose definition contains JSdoc. This is due to JSdoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:
+The rule does not raise issues if you are awaiting a function whose definition contains JSDoc. This is due to JSDoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:
 
 [source,js]
 ----

--- a/rules/S4123/javascript/rule.adoc
+++ b/rules/S4123/javascript/rule.adoc
@@ -20,39 +20,9 @@ const x = Promise.resolve(42);
 await x;
 ----
 
-When running on JavaScript code, the JSdoc is prioritized over the type inference, so make sure that they are correct, using a `Promise<T>` type when needed.
-
-[source,js,diff-id=2,diff-type=noncompliant]
-----
-/**
- * @return {number}
- */
-async function foo() {
-  return await Promise.resolve(42);
-}
-async function bar() {
-  await foo(); // Noncompliant
-}
-----
-
-Either remove the JSdoc or fix it to correct the issue.
-
-[source,js,diff-id=2,diff-type=compliant]
-----
-/**
- * @return {Promise<number>}
- */
-async function foo() {
-  return await Promise.resolve(42);
-}
-async function bar() {
-  await foo();
-}
-----
-
 When calling a function that returns a promise as the last expression, you might forget to return it, especially if you refactored your code from a single-expression arrow function.
 
-[source,js,diff-id=3,diff-type=noncompliant]
+[source,js,diff-id=2,diff-type=noncompliant]
 ----
 function foo() {
   Promise.resolve(42);
@@ -64,13 +34,27 @@ async function bar() {
 
 Make sure that you return the promise.
 
-[source,js,diff-id=3,diff-type=compliant]
+[source,js,diff-id=2,diff-type=compliant]
 ----
 function foo() {
   return Promise.resolve(42);
 }
 async function bar() {
   await foo();
+}
+----
+
+=== Exceptions
+
+The rule does not raise issues if you are awaiting a function whose definition contains JSdoc. This is due to JSdoc often mistakenly declaring a returning type without mentioning that it is resolved by a promise. For example:
+
+[source,js]
+----
+/**
+ * @return {number} // this should be {Promise<number>}
+ */
+async function foo() {
+  await Promise.resolve(42)
 }
 ----
 


### PR DESCRIPTION
@yassin-kammoun-sonarsource 
The diff might be confusing. In that case, have a look at the result: https://github.com/SonarSource/rspec/blob/modify-S4123-jsdoc-exception/rules/S4123/javascript/rule.adoc

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

