### PR TITLE
Modify rule S927: Update rule description

### DIFF
--- a/rules/S927/why-dotnet.adoc
+++ b/rules/S927/why-dotnet.adoc
@@ -2,10 +2,10 @@
 
 Parameters are part of the {methodSignatureLine}[method signature] and its identity. 
 
-Implementing a method from an interface, a base class, or a partial method and changing one of its parameters' names will confuse and impact its readability.
+Implementing a method from an interface, a base class, or a partial method and changing one of its parameters' names will confuse and impact the method's readability.
 
 include::{noncompliantCode}[]
 
-To avoid any ambiguity in the code, parameters' names should match the initial declaration, whether its initial declaration is from an interface, a base class, or a partial method.
+To avoid any ambiguity in the code, a parameter's name should match the initial declaration, whether its initial declaration is from an interface, a base class, or a partial method.
 
 include::{compliantCode}[]


### PR DESCRIPTION
Suggested changes by the Docs Squad:
- specify pronoun to clarify what "it" is
- fix plural possessives
