### PR TITLE
APPSEC-1479: S6910 Adjustment to make RSPEC consistent with Sonar Text

### DIFF
--- a/rules/S6910/secrets/rule.adoc
+++ b/rules/S6910/secrets/rule.adoc
@@ -29,7 +29,7 @@ include::../../../shared_content/secrets/fix/vault.adoc[]
 
 === Code examples
 
-:example_secret: 0a9e83b47-938b-aed2-239a-29e8b3a90a83
+:example_secret: 89d36b44-4c54-4623-91d9-b61f29b702f8
 :example_name: X-Postmark-Server-Token
 :example_env: POSTMARK_SERVER_TOKEN
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

