### PR TITLE
Modify rule S4428: improve sentence structure

### DIFF
--- a/rules/S4428/description.adoc
+++ b/rules/S4428/description.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
 To customize the default behavior for an export in the https://learn.microsoft.com/en-us/dotnet/framework/mef/[Managed Extensibility Framework] (MEF), applying the https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.partcreationpolicyattribute[`PartCreationPolicyAttribute`] is necessary.
-For the https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.partcreationpolicyattribute[`PartCreationPolicyAttribute`] to be meaningful in the context of an export, it is required to also annotate the class with the https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.exportattribute[`ExportAttribute`].
+For the https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.partcreationpolicyattribute[`PartCreationPolicyAttribute`] to be meaningful in the context of an export, the class must also be annotated with the https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.composition.exportattribute[`ExportAttribute`].
 
 This rule raises an issue when a class is annotated with the `PartCreationPolicyAttribute` but not with the `ExportAttribute`.


### PR DESCRIPTION
- place the noun first to clarify the required action

