### PR TITLE
Modify rule S2178, S2551: Update rule description

### DIFF
--- a/rules/S2551/why-dotnet.adoc
+++ b/rules/S2551/why-dotnet.adoc
@@ -2,8 +2,8 @@
 
 A shared resource refers to a resource or data that can be accessed or modified by multiple https://en.wikipedia.org/wiki/Thread_(computing)[threads] or concurrent parts of a program. It could be any piece of data, object, file, database connection, or system resource that needs to be accessed or manipulated by multiple parts of a program concurrently.
 
-Shared resources should not be used for https://en.wikipedia.org/wiki/Lock_(computer_science)[locking] as it increases the chance of https://en.wikipedia.org/wiki/Deadlock[deadlocks]. Any other thread could acquire (or attempt to acquire) the same lock while doing some operation, without knowing that the resource is meant to be used for locking purposes.
+Shared resources should not be used for https://en.wikipedia.org/wiki/Lock_(computer_science)[locking] because it increases the chance of https://en.wikipedia.org/wiki/Deadlock[deadlocks]. Any other thread could acquire (or attempt to acquire) the same lock while doing some operation, without knowing that the resource is meant to be used for locking purposes.
 
-One example of this is a `String` https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime. This means that each `String` instance is immutable and stored, and then reused everywhere it is referenced.
+One example of a potential deadlock is a `String` data type https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime. Once a string is assigned to a `String` variable, it becomes immutable and stored to prevent changes or alterations; this is untenable for a functioning shared resource.
 
-Instead, a dedicated private `object` instance should be used for each shared resource. Making the lock-specific object `private` guarantees that the access to it is as minimal as possible, in order to avoid deadlocks or lock contention.
+Instead, a dedicated private `object` instance should be used for each shared resource. Making the lock-specific object `private` guarantees that access to it is possible and avoids deadlocks or lock contention.

--- a/rules/S3927/description.adoc
+++ b/rules/S3927/description.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to the automated de/serialization.
+Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to automated serialization and/or deserialization events.
 
 A method is designated a serialization event handler by applying one of the following serialization event attributes:
 


### PR DESCRIPTION
Changes suggested by the Docs Squad:

Modify rule S3927: Update rule description
- use full word in place of short-hand text

Modify rule S2551: Clarify the example given
- improve word choice to bring clarity to the illustration

