### PR TITLE
CPP-4968 S796 List all escape sequence from C99, C++11 and C++23

### DIFF
--- a/rules/S796/cfamily/rule.adoc
+++ b/rules/S796/cfamily/rule.adoc
@@ -1,6 +1,9 @@
 == Why is this an issue?
 
-The use of an undefined escape sequence leads to undefined behavior. The defined escape sequences (ISO/IEC 14882:2003 [1] §2.13.2) are: ``++\n++``, ``++\t++``, ``++\v++``, ``++\b++``, ``++\r++``, ``++\f++``, ``++\a++``, ``++\\++``, ``++?++``, ``++\'++``, ``++\"++``, ``++\<Octal Number>++``, and ``++\x<Hexadecimal Number>++``.
+The use of an undefined escape sequence leads to undefined behavior. 
+Escape sequences supported in each C and {cpp} standard are: `\n`, `\t`, `\v`, `\b`, `\r`, `\f`, `\a`, `\\`, `\?`, `\'`, `\"`, `\<Octal Number>`, and `\x<Hexadecimal Number>`.
+From C99 and {cpp}12 introduced escape sequence for Unicode characters in form: `\u<4 Hexadecimal Digits>` and `\U<8 Hexidecimal Digits>`.
+{cpp23} supported named escape sequences for Unicode characters in form `\N{<Name of Character>}` and a delimited version of escape sequences are supported: `\o{<Octal Number>}`, `\x{<Hexadecimal Number>}`, and `\u{<Hexadecimal Number>}`.
 
 
 === Noncompliant code example

--- a/rules/S796/cfamily/rule.adoc
+++ b/rules/S796/cfamily/rule.adoc
@@ -1,9 +1,12 @@
 == Why is this an issue?
 
 The use of an undefined escape sequence leads to undefined behavior. 
-Escape sequences supported in each C and {cpp} standard are: `\n`, `\t`, `\v`, `\b`, `\r`, `\f`, `\a`, `\\`, `\?`, `\'`, `\"`, `\<Octal Number>`, and `\x<Hexadecimal Number>`.
-From C99 and {cpp}12 introduced escape sequence for Unicode characters in form: `\u<4 Hexadecimal Digits>` and `\U<8 Hexidecimal Digits>`.
-{cpp23} supported named escape sequences for Unicode characters in form `\N{<Name of Character>}` and a delimited version of escape sequences are supported: `\o{<Octal Number>}`, `\x{<Hexadecimal Number>}`, and `\u{<Hexadecimal Number>}`.
+
+Escape sequences supported in every C and {cpp} standard are: `\n`, `\t`, `\v`, `\b`, `\r`, `\f`, `\a`, `\\`, `\?`, `\'`, `\"`, `\<Octal Number>`, and `\x<Hexadecimal Number>`.
+
+C99 and {cpp}11 introduced escape sequences for Unicode characters in the form: `\u<4 Hexadecimal Digits>` and `\U<8 Hexidecimal Digits>`.
+
+{cpp23} supports named escape sequences for Unicode characters in the form `\N{<Name of Character>}` and a delimited version of escape sequences is supported: `\o{<Octal Number>}`, `\x{<Hexadecimal Number>}`, and `\u{<Hexadecimal Number>}`.
 
 
 === Noncompliant code example


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

