### PR TITLE
Modify rule S3927: Update rule description

### DIFF
--- a/rules/S3927/description.adoc
+++ b/rules/S3927/description.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to automated serialization and/or deserialization events.
+Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to automated serialization and deserialization events.
 
 A method is designated a serialization event handler by applying one of the following serialization event attributes:
 

--- a/rules/S3927/description.adoc
+++ b/rules/S3927/description.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to the automated de/serialization.
+Serialization event handlers that don't have the correct signature will not be called, bypassing augmentations to automated serialization and/or deserialization events.
 
 A method is designated a serialization event handler by applying one of the following serialization event attributes:
 


### PR DESCRIPTION
Changes suggested by the Docs Squad:
- use full word in place of short-hand text

