### PR TITLE
Modify rule S2551: clarify example used in the description

### DIFF
--- a/rules/S2551/csharp/rule.adoc
+++ b/rules/S2551/csharp/rule.adoc
@@ -2,7 +2,7 @@ include::../why-dotnet.adoc[]
 
 For example, a `string` should never be used for locking. When a `string` is https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime, it can be shared by multiple threads, breaking the locking mechanism.
 
-Instead, a dedicated private `object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks or lock contention.
+Instead, a dedicated private `object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks and lock contention.
 
 The following objects are considered as shared resources:
 

--- a/rules/S2551/csharp/rule.adoc
+++ b/rules/S2551/csharp/rule.adoc
@@ -1,5 +1,9 @@
 include::../why-dotnet.adoc[]
 
+For example, a `string` should never be used for locking. When a `string` is https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime, it can be shared by multiple threads, breaking the locking mechanism.
+
+Instead, a dedicated private `object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks or lock contention.
+
 The following objects are considered as shared resources:
 
 * a reference to https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/this[this]: if the instance is publicly accessibly, the lock might be shared

--- a/rules/S2551/vbnet/rule.adoc
+++ b/rules/S2551/vbnet/rule.adoc
@@ -1,5 +1,9 @@
 include::../why-dotnet.adoc[]
 
+For example, a `String` should never be used for locking. When a `String` is https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime, it can be shared by multiple threads, breaking the locking mechanism.
+
+Instead, a dedicated private `Object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks or lock contention.
+
 The following objects are considered as shared resources:
 
 * a reference to https://learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass#me[Me]: if the instance is publicly accessible, the lock might be shared

--- a/rules/S2551/vbnet/rule.adoc
+++ b/rules/S2551/vbnet/rule.adoc
@@ -2,7 +2,7 @@ include::../why-dotnet.adoc[]
 
 For example, a `String` should never be used for locking. When a `String` is https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime, it can be shared by multiple threads, breaking the locking mechanism.
 
-Instead, a dedicated private `Object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks or lock contention.
+Instead, a dedicated private `Object` instance should be used for each shared resource. This minimizes access to the lock instance, avoiding deadlocks and lock contention.
 
 The following objects are considered as shared resources:
 

--- a/rules/S2551/why-dotnet.adoc
+++ b/rules/S2551/why-dotnet.adoc
@@ -1,9 +1,5 @@
 == Why is this an issue?
 
-A shared resource refers to a resource or data that can be accessed or modified by multiple https://en.wikipedia.org/wiki/Thread_(computing)[threads] or concurrent parts of a program. It could be any piece of data, object, file, database connection, or system resource that needs to be accessed or manipulated by multiple parts of a program concurrently.
+A shared resource refers to a resource or data that can be accessed or modified by multiple https://en.wikipedia.org/wiki/Thread_(computing)[threads] or concurrent parts of a program. It could be any piece of data, object, file, database connection, or system resource that needs to be accessed or manipulated by multiple parts of a program at the same time.
 
-Shared resources should not be used for https://en.wikipedia.org/wiki/Lock_(computer_science)[locking] as it increases the chance of https://en.wikipedia.org/wiki/Deadlock[deadlocks]. Any other thread could acquire (or attempt to acquire) the same lock while doing some operation, without knowing that the resource is meant to be used for locking purposes.
-
-One example of this is a `String` https://en.wikipedia.org/wiki/Interning_(computer_science)[interned] by the runtime. This means that each `String` instance is immutable and stored, and then reused everywhere it is referenced.
-
-Instead, a dedicated private `object` instance should be used for each shared resource. Making the lock-specific object `private` guarantees that the access to it is as minimal as possible, in order to avoid deadlocks or lock contention.
+Shared resources should not be used for https://en.wikipedia.org/wiki/Lock_(computer_science)[locking] because it increases the chance of https://en.wikipedia.org/wiki/Deadlock[deadlocks]. Any other thread could acquire (or attempt to acquire) the same lock while doing some operation, without knowing that the resource is meant to be used for locking purposes.


### PR DESCRIPTION
Changes suggested by the Docs Squad:
- the example used to illustrate the rule did not consider if the case was in C# or VB
- In addition, the description was confusing so was simplified to make the case easier to understand.