### PR TITLE
Modify rule S1948: Clarify the description (SONARJAVA-4814)

### DIFF
--- a/rules/S1948/java/rule.adoc
+++ b/rules/S1948/java/rule.adoc
@@ -11,9 +11,11 @@ In general, a `Serializable` class is expected to fulfil its contract and not ex
 
 This rule raises an issue on:
 
-* non-`Serializable` fields,
-* collection fields when they are not `private` (because they could be assigned non-`Serializable` values externally),
-* when a field is assigned a non-`Serializable` type within the class.
+* Non-`Serializable` fields.
+* When a field is assigned a non-`Serializable` type within the class.
+* Collection fields when they are not `private`.
+Values that are not serializable could be added to these collections externally.
+Due to type erasure, it cannot be guaranteed that the collection will only contain serializable objects at runtime despite being declared as a collection of serializable types.
 
 == How to fix it
 


### PR DESCRIPTION
SONARJAVA-4814 Improved S1948 RSPEC to better explain why public collections are a problem
