### PR TITLE
Modify rule S5542: Change text for rule update

### DIFF
--- a/rules/S5542/common/fix/fix.adoc
+++ b/rules/S5542/common/fix/fix.adoc
@@ -4,7 +4,10 @@ considered strong by the cryptographic community.
 Appropriate choices are currently the following.
 
 
-==== For AES: Use Galois/Counter mode (GCM)
+==== For AES: use authenticated encryption modes
+
+The best-known authenticated encryption mode for AES is Galois/Counter mode
+(GCM).
 
 GCM mode combines encryption with authentication and integrity checks using a
 cryptographic hash function and provides both confidentiality and authenticity
@@ -16,11 +19,9 @@ Other similar modes are:
 * CWC: `Cipher Block Chaining with Message Authentication Code`
 * EAX: `Encrypt-and-Authenticate`
 * IAPM: `Integer Authenticated Parallelizable Mode`
-
 * OCB: `Offset Codebook Mode`
 
 It is also possible to use AES-CBC with HMAC for integrity checks. However, it
-
 is considered more straightforward to use AES-GCM directly instead.
 
 ==== For RSA: use the OAEP scheme

--- a/rules/S5542/rationale.adoc
+++ b/rules/S5542/rationale.adoc
@@ -10,16 +10,19 @@ When selecting encryption algorithms, tools, or combinations, you should also
 consider two things:
 
 1. No encryption is unbreakable.
-2. The strength of an encryption algorithm is usually measured by the effort required to crack it within a reasonable time frame.
-
+2. The strength of an encryption algorithm is usually measured by the effort
+   required to crack it within a reasonable time frame.
 
 For these reasons, as soon as cryptography is included in a project, it is
 important to choose encryption algorithms that are considered strong and secure
 by the cryptography community.
 
-For AES, the weakest modes are CBC (Cipher Block Chaining) and ECB (Electronic Codebook) 
-because they are either vulnerable to padding oracles or do
-not provide authentication mechanisms.
+For AES, the weakest mode is ECB (Electronic Codebook). Repeated blocks of data
+are encrypted to the same value, making them easy to identify and reducing the
+difficulty of recovering the original cleartext.
+
+Unauthenticated modes such as CBC (Cipher Block Chaining) may be used but are
+prone to attacks that manipulate the ciphertext. They must be used with caution.
 
 For RSA, the weakest algorithms are either using it without padding or
 using the PKCS1v1.5 padding scheme.


### PR DESCRIPTION
Rule S5542 will be modified so that it is no longer raised on CBC mode. A new rule will be introduced that triggers on the use of unauthenticated encryption modes, which will cover CBC.

See APPSEC-1560.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

