### PR TITLE
CPP-4910 Fix links to C++ Core Guideline with double dashes

### DIFF
--- a/rules/S1236/cfamily/rule.adoc
+++ b/rules/S1236/cfamily/rule.adoc
@@ -39,5 +39,5 @@ public:
 == Resources
 
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c60-make-copy-assignment-non-virtual-take-the-parameter-by-const-and-return-by-non-const[C.60: Make copy assignment non-`virtual`, take the parameter by `const&`, and return by non-`const&`]
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c63-make-move-assignment-non-virtual-take-the-parameter-by--and-return-by-non-const[C.63: Make move assignment non-`virtual`, take the parameter by `&&`, and return by non-`const&`]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c63-make-move-assignment-non-virtual-take-the-parameter-by\--and-return-by-non-const[C.63: Make move assignment non-`virtual`, take the parameter by `&&`, and return by non-`const&`]
 

--- a/rules/S3657/cfamily/rule.adoc
+++ b/rules/S3657/cfamily/rule.adoc
@@ -1,12 +1,12 @@
 == Why is this an issue?
 
-{cpp} does not support polymorphic copy or move assignment operators. For example, the signature of a copy assignment operator on a "Base" class would be ``++Base& operator=(const Base& other)++``. 
+{cpp} does not support polymorphic copy or move assignment operators. For example, the signature of a copy assignment operator on a "Base" class would be ``++Base& operator=(const Base& other)++``.
 
 
 And on a "Derived" class that extends "Base", it would be ``++Derived& operator=(const Derived& other)++``.
 
 
-Because these are two entirely different method signatures, the second method does not override the first, and adding ``++virtual++`` to the "Base" signature does not change which method is called. 
+Because these are two entirely different method signatures, the second method does not override the first, and adding ``++virtual++`` to the "Base" signature does not change which method is called.
 
 
 It is possible to add an ``++operator=++`` override in a derived class, but doing so is an indication that you may need to reexamine your application architecture.
@@ -47,7 +47,7 @@ public:
 == Resources
 
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c60-make-copy-assignment-non-virtual-take-the-parameter-by-const-and-return-by-non-const[C.60: Make copy assignment non-`virtual`, take the parameter by `const&`, and return by non-`const&`]
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c63-make-move-assignment-non-virtual-take-the-parameter-by--and-return-by-non-const[C.63: Make move assignment non-`virtual`, take the parameter by `&&`, and return by non-`const&`]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c63-make-move-assignment-non-virtual-take-the-parameter-by\--and-return-by-non-const[C.63: Make move assignment non-`virtual`, take the parameter by `&&`, and return by non-`const&`]
 
 
 ifdef::env-github,rspecator-view[]
@@ -73,7 +73,7 @@ Remove this "virtual" specifier; polymorphism should not be used with assignment
 === relates to: S1023
 
 === on 27 Jun 2016, 21:46:17 Ann Campbell wrote:
-\[~alban.auzeill] I've made some edits, but I'm not done. I'm stuck on 
+\[~alban.auzeill] I've made some edits, but I'm not done. I'm stuck on
 
 
 ____

--- a/rules/S3692/cfamily/rule.adoc
+++ b/rules/S3692/cfamily/rule.adoc
@@ -30,7 +30,7 @@ struct Foo {
 
 == Resources
 
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c87-beware-of--on-base-classes[C.87: Beware of `==` on base classes]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c87-beware-of\--on-base-classes[C.87: Beware of `==` on base classes]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5019/cfamily/rule.adoc
+++ b/rules/S5019/cfamily/rule.adoc
@@ -55,7 +55,7 @@ class A {
 
 == Resources
 
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#f54-when-writing-a-lambda-that-captures-this-or-any-class-data-member-dont-use--default-capture[F.54: When writing a lambda that captures `this` or any class data member, don't use ``++[=]++`` default capture]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#f54-when-writing-a-lambda-that-captures-this-or-any-class-data-member-dont-use\--default-capture[F.54: When writing a lambda that captures `this` or any class data member, don't use ``++[=]++`` default capture]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5829/cfamily/rule.adoc
+++ b/rules/S5829/cfamily/rule.adoc
@@ -62,18 +62,18 @@ struct B {
 
 [source,cpp]
 ----
-struct A { 
-  A(int i, int j, int z) { 
-    ... 
-  } 
+struct A {
+  A(int i, int j, int z) {
+    ...
+  }
 };
 
-void f() { 
-  A a{1,2,3}; 
+void f() {
+  A a{1,2,3};
 }
 
-struct B { 
-  A a{1, 2, 3}; 
+struct B {
+  A a{1, 2, 3};
 };
 ----
 
@@ -91,7 +91,7 @@ vector<int> v1(5, 10); //  5 copies of the value 10
 
 [source,cpp]
 ----
-auto i1 {1}; // int with the value 1 
+auto i1 {1}; // int with the value 1
 auto i2 = {1}; //  std::initializer_list<int> with an element equal to 1
 ----
 
@@ -112,7 +112,7 @@ vector<int> v = { 1, 2, 4 };
 
 == Resources
 
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#es23-prefer-the--initializer-syntax[ES.23: Prefer the `{}`-initializer syntax]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#es23-prefer-the\--initializer-syntax[ES.23: Prefer the `{}`-initializer syntax]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S867/cfamily/rule.adoc
+++ b/rules/S867/cfamily/rule.adoc
@@ -15,7 +15,7 @@ Moreover, a logical operation with integer types might also be a confusion with 
 Converting a pointer to ``++bool++`` to check if it is null is idiomatic and is allowed by this rule. We also allow the use of any user-defined type convertible to bool (for instance ``++std::ostream++``), since they were specifically designed to be used in such situations. What this rule really detects is the use or arithmetic types (``++int++``, ``++long++``...) and of enum types.
 
 
-On the other hand, arithmetic operations are defined with booleans, but usually make little sense (think of adding two booleans). Booleans should not be used in an arithmetic context. 
+On the other hand, arithmetic operations are defined with booleans, but usually make little sense (think of adding two booleans). Booleans should not be used in an arithmetic context.
 
 
 Finally, comparing a boolean with the literals ``++true++`` or ``++false++`` is unnecessarily verbose, and should be avoided.
@@ -30,7 +30,7 @@ if ( ( a < b ) && ( c + d ) ) // Noncompliant
 if ( u8_a && ( c + d ) ) // Noncompliant
 if ( !0 ) // Noncompliant, always true
 if ( !ptr ) // Compliant
-if ( ( a < b ) && ( c < d ) ) // Compliant 
+if ( ( a < b ) && ( c < d ) ) // Compliant
 if ( !false ) // Compliant
 if (!!a) // Compliant by exception
 if ( ( a < b ) == true) // Noncompliant
@@ -59,7 +59,7 @@ Some people use ``++!!++`` as a shortcut to cast an integer to bool. This usage 
 * MISRA C:2004, 12.6 - The operands of logical operators (&&, || and !) should be effectively Boolean. Expressions that are effectively Boolean should not be used as operands to operators other than (&&, || and !).
 * MISRA {cpp}:2008, 5-3-1 - Each operand of the ! operator, the logical && or the logical || operators shall have type bool.
 * https://wiki.sei.cmu.edu/confluence/display/c/EXP13-C.+Treat+relational+and+equality+operators+as+if+they+were+nonassociative[CERT, EXP13-C.] - Treat relational and equality operators as if they were nonassociative
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#es87-dont-add-redundant--or--to-conditions[ES.87: Don't add redundant `==` or `!=` to conditions]
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#es87-dont-add-redundant\--or\--to-conditions[ES.87: Don't add redundant `==` or `!=` to conditions]
 
 ifdef::env-github,rspecator-view[]
 
@@ -83,7 +83,7 @@ ifdef::env-github,rspecator-view[]
 === is related to: S5359
 
 === on 21 Oct 2014, 20:22:30 Ann Campbell wrote:
-\[~samuel.mercier] please use standard section headings. 
+\[~samuel.mercier] please use standard section headings.
 
 I would associate this to Reliability
 

--- a/rules/S877/cfamily/rule.adoc
+++ b/rules/S877/cfamily/rule.adoc
@@ -32,8 +32,8 @@ void f2 ( A & a )
 
 == Resources
 
-* MISRA {cpp} 2008, 5-3-3 - The unary & operator shall not be overloaded. 
-* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c166-overload-unary--only-as-part-of-a-system-of-smart-pointers-and-references[C.166: Overload unary `&` only as part of a system of smart pointers and references]
+* MISRA {cpp} 2008, 5-3-3 - The unary & operator shall not be overloaded.
+* {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c166-overload-unary\--only-as-part-of-a-system-of-smart-pointers-and-references[C.166: Overload unary `&` only as part of a system of smart pointers and references]
 
 
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

