### PR TITLE
Modify rule S1696: Fix link

### DIFF
--- a/rules/S1696/csharp/rule.adoc
+++ b/rules/S1696/csharp/rule.adoc
@@ -13,7 +13,7 @@ Instead of catching NullReferenceException, it's better to prevent it from happe
 
 [source,csharp,diff-id=1,diff-type=noncompliant]
 ----
-public int GetLengthPlusTwo(string str) 
+public int GetLengthPlusTwo(string str)
 {
     try
     {
@@ -46,6 +46,6 @@ public int GetLengthPlusTwo(string str)
 
 * CWE - https://cwe.mitre.org/data/definitions/395[CWE-395 - Use of NullPointerException Catch to Detect NULL Pointer Dereference]
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception[NullReferenceException class]
-* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-[Null-conditional operators ?. and ?[]]
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators\--and-[Null-conditional operators ?. and ?[\]]
 
 include::../rspecator.adoc[]


### PR DESCRIPTION
I was looking for double dashes in cfamily rules for CPP-4910 and randomly stumbled upon S1696 for C#.

The link has two issues:
 1. `--` is transformed into em-dash `—​`.
 2. `]` in the link text was interpreted as the closing bracket instead of a regular text character.

In both cases, the fix is to escape such character.

FWIW, I did not attempt to search for other broken links in C#.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

