### PR TITLE
Modify rule S6937: Extend support to other statements

### DIFF
--- a/rules/S6937/jcl/metadata.json
+++ b/rules/S6937/jcl/metadata.json
@@ -8,7 +8,7 @@
   },
   "tags": [
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6937",
   "sqKey": "S6937",
   "scope": "All",
@@ -18,6 +18,6 @@
     "impacts": {
       "RELIABILITY": "HIGH"
     },
-    "attribute": "CONVENTIONAL"
+    "attribute": "LOGICAL"
   }
 }

--- a/rules/S6937/jcl/rule.adoc
+++ b/rules/S6937/jcl/rule.adoc
@@ -1,9 +1,8 @@
 == Why is this an issue?
 
-In JCL, some statement require to have a label or name defined, otherwise it will trigger a JCL error.
+In JCL, some statements require to have a label or name defined, otherwise it will trigger a JCL error.
 The statements that require a name/label are:
 * CNTL
-* ENDCNTL
 * JOB
 * NOTIFY
 * OUTPUT
@@ -38,7 +37,6 @@ The statements that require a name/label are:
 === Documentation
 
 * https://www.ibm.com/docs/en/zos/3.1.0?topic=description-label-field[IBM Reference - CNTL Label field]
-* https://www.ibm.com/docs/en/zos/3.1.0?topic=d-label-field[IBM Reference - ENDCNTL Label field]
 * https://www.ibm.com/docs/en/zos/3.1.0?topic=d-name-field-5[IBM Reference - JOB Name field]
 * https://www.ibm.com/docs/en/zos/3.1.0?topic=statement-label-field[IBM Reference - NOTIFY Label field]
 * https://www.ibm.com/docs/en/zos/3.1.0?topic=d-name-field-6[IBM Reference - OUTPUT Name field]

--- a/rules/S6937/jcl/rule.adoc
+++ b/rules/S6937/jcl/rule.adoc
@@ -1,8 +1,13 @@
-In-stream procedures should always have a name.
-
 == Why is this an issue?
 
-In JCL, it is expected for a PROC statement inside of a job stream to have a name.
+In JCL, some statement require to have a label or name defined, otherwise it will trigger a JCL error.
+The statements that require a name/label are:
+* CNTL
+* ENDCNTL
+* JOB
+* NOTIFY
+* OUTPUT
+* in-stream PROC
 
 == How to fix it
 

--- a/rules/S6937/jcl/rule.adoc
+++ b/rules/S6937/jcl/rule.adoc
@@ -37,4 +37,9 @@ The statements that require a name/label are:
 
 === Documentation
 
+* https://www.ibm.com/docs/en/zos/3.1.0?topic=description-label-field[IBM Reference - CNTL Label field]
+* https://www.ibm.com/docs/en/zos/3.1.0?topic=d-label-field[IBM Reference - ENDCNTL Label field]
+* https://www.ibm.com/docs/en/zos/3.1.0?topic=d-name-field-5[IBM Reference - JOB Name field]
+* https://www.ibm.com/docs/en/zos/3.1.0?topic=statement-label-field[IBM Reference - NOTIFY Label field]
+* https://www.ibm.com/docs/en/zos/3.1.0?topic=d-name-field-6[IBM Reference - OUTPUT Name field]
 * https://www.ibm.com/docs/en/zos/3.1.0?topic=d-name-field-8[IBM reference - PROC statement - Name field]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

