### PR TITLE
Modify rule S6169: minor rewordings

### DIFF
--- a/rules/S6169/cfamily/rule.adoc
+++ b/rules/S6169/cfamily/rule.adoc
@@ -194,10 +194,10 @@ void cpp03Code() {
 ----
 +
 Evaluating such variables at compile-time was already possible before `constexpr` was introduced to allow patterns like the above.
-It is recommended to mark such variables as `constexpr`.
+It is recommended to mark these variables as `constexpr`.
 
 Due to the above special rules, `std::is_constant_evaluated()` and `if consteval` are always `true` within such implicit constant initialization.
-This may lead to surprising and intuitive results, thus this rule raises issues in such cases:
+This may lead to surprising and unintuitive results, thus this rule raises issues in the following cases:
 
 [source,cpp]
 ----
@@ -207,7 +207,7 @@ void onlyRuntime() {
 }
 
 constexpr bool possiblyCompileTimeFunc() {
-  bool const ce = std::is_constant_evaluated(); // Noncompliant: always true, due implicit constant evaluation
+  bool const ce = std::is_constant_evaluated(); // Noncompliant: always true, due to implicit constant evaluation
   bool e = std::is_constant_evaluated();        // Compliant: depends on the call site
 }
 ----
@@ -343,8 +343,8 @@ Depending on the context, the issue may be fixed by:
 
 === Inside `if constexpr` condition
 
-Changing `if constexpr` into `if` leads to the condition is no longer always evaluated at compile-time,
-and now the result of `std::is_constant_evaluated()` depends on the call site.
+Changing `if constexpr` into `if` leads to the condition no longer being always evaluated at compile-time.
+The result of `std::is_constant_evaluated()` now depends on the call site.
 
 ==== Noncompliant code example
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

