### PR TITLE
Modify rule S3416: remove from SonarWay

### DIFF
--- a/rules/S3416/csharp/metadata.json
+++ b/rules/S3416/csharp/metadata.json
@@ -1,4 +1,6 @@
 {
   "title": "Loggers should be named for their enclosing types",
-  "quickfix": "targeted"
+  "quickfix": "targeted",
+  "defaultQualityProfiles": [
+  ]
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

