### PR TITLE
Modify rule S103: Remove from default profile for PHP

### DIFF
--- a/rules/S103/php/metadata.json
+++ b/rules/S103/php/metadata.json
@@ -1,5 +1,3 @@
 {
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

## Summary

This PR addresses https://sonarsource.atlassian.net/browse/SONARPHP-1492 following a dogfood request https://discuss.sonarsource.com/t/php-rule-s103-lines-too-long-is-enabled-by-default/17909