### PR TITLE
Deprecate rule S2647 (APPSEC-1639)

### DIFF
--- a/rules/S2647/metadata.json
+++ b/rules/S2647/metadata.json
@@ -7,14 +7,12 @@
     },
     "attribute": "TRUSTWORTHY"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "2h"
   },
-  "tags": [
-    "cwe"
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [],
     "legacyKeys": []
@@ -43,8 +41,6 @@
       "2.10.3"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
The AppSec squad has decided to deprecate this rule. Basic authentication is mostly dangerous when used with cleartext HTTP, and that's covered by rule S5332. The widespread adoption of HTTPS also makes this rule increasingly redundant.

More rationale are covered in [APPSEC-1639](https://sonarsource.atlassian.net/browse/APPSEC-1639).

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

