### PR TITLE
Modify S2955 C#: Fix compliant solution

### DIFF
--- a/rules/S2955/csharp/rule.adoc
+++ b/rules/S2955/csharp/rule.adoc
@@ -30,7 +30,7 @@ bool IsDefault<T>(T value)
 ----
 bool IsDefault<T>(T value)
 {
-  if(EqualityComparer<T>.Default.Equals(value, default(T)))
+  if (EqualityComparer<T>.Default.Equals(value, default(T)))
   {
     // ...
   }

--- a/rules/S2955/csharp/rule.adoc
+++ b/rules/S2955/csharp/rule.adoc
@@ -30,7 +30,7 @@ bool IsDefault<T>(T value)
 ----
 bool IsDefault<T>(T value)
 {
-  if(object.Equals(value, default(T)))
+  if(EqualityComparer<T>.Default.Equals(value, default(T)))
   {
     // ...
   }


### PR DESCRIPTION
Provide a better solution, that does not box value types to `object`.
For more details, see [this thread](https://github.com/SonarSource/sonar-dotnet/issues/8933#issuecomment-2004644300).