### PR TITLE
Modify rule S1706:  Mention std::expected as an alternative to exceptions (CPP-5054)

### DIFF
--- a/rules/S1706/cfamily/rule.adoc
+++ b/rules/S1706/cfamily/rule.adoc
@@ -8,7 +8,7 @@ While exceptions are a common feature of modern languages, there are several rea
 * They may incur a small performance penalty.
 * The time required to handle an exception is not easy to assess, which makes them difficult to use for hard real-time applications. 
 
-If a project decides not to use exceptions, some other error-handling mechanisms must be used. One option is to immediately terminate the process when unrecoverable errors are detected. Another one is to use the return value of the functions to convey error information and explicitly check for this value at the call sites.
+If a project decides not to use exceptions, some other error-handling mechanisms must be used. One option is to immediately terminate the process when unrecoverable errors are detected. Another one is to use the return value of the functions to convey error information and explicitly check for this value at the call sites. This error information then has to be manually propagated up the call stack until reaching a point where recovery is possible.
 
 Starting with {cpp}23, the standard library provides the `std::expected` class that allows packing into a single object either the normal return value of a function when the execution succeeded or some error information when it failed. This type also simplifies checking for errors at the call site.
 

--- a/rules/S1706/cfamily/rule.adoc
+++ b/rules/S1706/cfamily/rule.adoc
@@ -8,28 +8,29 @@ While exceptions are a common feature of modern languages, there are several rea
 * They may incur a small performance penalty.
 * The time required to handle an exception is not easy to assess, which makes them difficult to use for hard real-time applications. 
 
-If a project decides not to use exceptions, some other error-handling mechanism needs to be used. One option is to immediately terminate the process when unrecoverable errors are detected. Another one is to use the return value of the functions to convey error information, and explicitly check for this value at the call sites.
+If a project decides not to use exceptions, some other error-handling mechanisms must be used. One option is to immediately terminate the process when unrecoverable errors are detected. Another one is to use the return value of the functions to convey error information and explicitly check for this value at the call sites.
 
 Starting with {cpp}23, the standard library provides the `std::expected` class that allows packing into a single object either the normal return value of a function when the execution succeeded or some error information when it failed. This type also simplifies checking for errors at the call site.
 
 This rule raises an issue when: 
 
-* an exception is ``++throw++``n
+* an exception is thrown
 * a ``++try++``-``++catch++`` block is used
 * an exception specification (``++throw(xxx)++``) is present.
 
-It applies both for {cpp} and Objective-C exception mechanisms.
+The rule applies both for {cpp} and Objective-C exception mechanisms.
 
 === Noncompliant code example
 
 [source,cpp]
 ----
-double myfunction(char param) throw (int); // Noncompliant
+enum class MyFunctionErrors{NotALetter, NotUppercase};
+double myfunction(char param) throw(MyFunctionErrors); // Noncompliant
 
-void f {
+void f() {
   try // Noncompliant
   {
-    do_something();
+    doSomething();
     throw std::runtime_error{"some error"}; // Noncompliant
   }
   catch (...)
@@ -44,11 +45,12 @@ void f {
 
 [source,cpp]
 ----
-std::expected<double, int> myfunction(char param); // Compliant
+enum class MyFunctionErrors{NotALetter, NotUppercase};
+std::expected<double, MyFunctionErrors> myfunction(char param); // Compliant
 void functionThatShallNotFail() noexcept; // Compliant
 
-bool f {
-  if (!do_something()); {
+bool f() {
+  if (!doSomething()); {
     // Handle the situation
     return false;
   }

--- a/rules/S1706/cfamily/rule.adoc
+++ b/rules/S1706/cfamily/rule.adoc
@@ -2,11 +2,15 @@
 
 While exceptions are a common feature of modern languages, there are several reasons to potentially avoid them:
 
-* They make the control flow of a program difficult to understand, because they introduce additional exit points.
-* The use of exceptions in new code can make that code difficult to integrate with existing, non-exception-safe code. 
+* They make the control flow of a program more difficult to understand because they introduce additional hidden exit points.
+* It is difficult to introduce them gradually in a codebase that was not designed with exceptions in mind.
 * They add to the size of each binary produced, thereby increasing both compile time and final executable size.
 * They may incur a small performance penalty.
 * The time required to handle an exception is not easy to assess, which makes them difficult to use for hard real-time applications. 
+
+If a project decides not to use exceptions, some other error-handling mechanism needs to be used. One option is to immediately terminate the process when unrecoverable errors are detected. Another one is to use the return value of the functions to convey error information, and explicitly check for this value at the call sites.
+
+Starting with {cpp}23, the standard library provides the `std::expected` class that allows packing into a single object either the normal return value of a function when the execution succeeded or some error information when it failed. This type also simplifies checking for errors at the call site.
 
 This rule raises an issue when: 
 
@@ -14,19 +18,19 @@ This rule raises an issue when:
 * a ``++try++``-``++catch++`` block is used
 * an exception specification (``++throw(xxx)++``) is present.
 
+It applies both for {cpp} and Objective-C exception mechanisms.
 
 === Noncompliant code example
-
-This {cpp} code example also applies to Objective-C.
 
 [source,cpp]
 ----
 double myfunction(char param) throw (int); // Noncompliant
+
 void f {
   try // Noncompliant
   {
     do_something();
-    throw 1; // Noncompliant
+    throw std::runtime_error{"some error"}; // Noncompliant
   }
   catch (...)
   {
@@ -40,7 +44,9 @@ void f {
 
 [source,cpp]
 ----
-double myfunction(char param) noexcept;
+std::expected<double, int> myfunction(char param); // Compliant
+void functionThatShallNotFail() noexcept; // Compliant
+
 bool f {
   if (!do_something()); {
     // Handle the situation
@@ -54,7 +60,7 @@ bool f {
 
 === Exceptions
 
-``++noexcept++`` specifications are ignored, because even if you choose not to use exceptions in your code, it's important to decorate as ``++noexcept++`` certain functions (for instance, move constructors that do not ``++throw++``). This decoration can be detected by type traits, and some meta-programming techniques rely on this information.
+``++noexcept++`` specifications are ignored because even if you choose not to use exceptions in your code, it's important to decorate as ``++noexcept++`` certain functions (for instance, move constructors that do not ``++throw++``, see S5018). This decoration can be detected by type traits, and some meta-programming techniques rely on this information.
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
Also improve the rule in many other places.
