### PR TITLE
Modify Rule S1144: Add exception to C# RSPEC

### DIFF
--- a/rules/S1144/csharp/rule.adoc
+++ b/rules/S1144/csharp/rule.adoc
@@ -46,6 +46,7 @@ This rule doesn't raise issues on:
 * the `Main` method of the application
 * methods with event handler signature `void Foo(object, EventArgs)` that are declared in partial class
 * empty serialization constructor on type with https://learn.microsoft.com/en-us/dotnet/api/system.serializableattribute[System.SerializableAttribute] attribute.
+* field and property members of types marked with https://learn.microsoft.com/en-us/dotnet/api/system.serializableattribute[System.SerializableAttribute] attribute
 * internal members in assemblies that have a https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute[System.Runtime.CompilerServices.InternalsVisibleToAttribute] attribute.
 
 == Resources


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

