### PR TITLE
Modify rule S2589,S3516,S3626: Remove them from CFamily (CPP-5165)

### DIFF
--- a/rules/S1854/cfamily/rule.adoc
+++ b/rules/S1854/cfamily/rule.adoc
@@ -182,9 +182,6 @@ void caller() {
 
 * S1763 - All code should be reachable
 * S2583 - Conditionally executed code should be reachable
-* S2589 - Boolean expressions should not be gratuitous
-* S3516 - Methods returns should not be invariant
-* S3626 - Jump statements should not be redundant
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2589/cfamily/metadata.json
+++ b/rules/S2589/cfamily/metadata.json
@@ -1,4 +1,5 @@
 {
+  "status": "closed",
   "tags": [
     "cwe",
     "based-on-misra",

--- a/rules/S2589/cfamily/metadata.json
+++ b/rules/S2589/cfamily/metadata.json
@@ -8,9 +8,7 @@
     "redundant",
     "misra-c2012"
   ],
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "securityStandards": {
     "CERT": [
       "MSC12-C."

--- a/rules/S2589/comments-and-links.adoc
+++ b/rules/S2589/comments-and-links.adoc
@@ -9,3 +9,6 @@ Question : should we consider this RSPEC as being fully a subset of RSPEC-2583 ?
 
 === on 29 Feb 2016, 08:37:04 Pierre-Yves Nicolas wrote:
 \[~freddy.mallet] I don't really see why this RSPEC is "fully a subset of RSPEC-2583". Maybe that makes sense if it is implemented through symbolic execution with short-circuit logical operators, but then it all depends on the order of sub-conditions. Please consider ``++IF X > 1 AND X = 5++``: I think that this code would raise an issue for the current description of this RSPEC, but not for RSPEC-2583.
+
+=== on 26 Mar 2024, 08:15:00 Philipp Dominik Schubert wrote:
+We created a circle to discuss CFamily's rules on dead code and decided to disable this rule in the CFamily analyzer since we believe it provides relatively low value and is not even implemented in CFamily's analyzer (cf. https://sonarsource.atlassian.net/browse/CPP-5165).

--- a/rules/S3516/cfamily/metadata.json
+++ b/rules/S3516/cfamily/metadata.json
@@ -1,4 +1,5 @@
 {
+  "status": "closed",
   "code": {
     "impacts": {
       "MAINTAINABILITY": "MEDIUM"

--- a/rules/S3516/cfamily/metadata.json
+++ b/rules/S3516/cfamily/metadata.json
@@ -6,7 +6,5 @@
     "attribute": "LOGICAL"
   },
   "defaultSeverity": "Major",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }

--- a/rules/S3516/comments-and-links.adoc
+++ b/rules/S3516/comments-and-links.adoc
@@ -1,2 +1,4 @@
 === relates to: S3400
 
+=== on 26 Mar 2024, 08:15:00 Philipp Dominik Schubert wrote:
+We created a circle to discuss CFamily's rules on dead code and decided to disable this rule in the CFamily analyzer since we believe it provides relatively low value and is not even implemented in CFamily's analyzer (cf. https://sonarsource.atlassian.net/browse/CPP-5165).

--- a/rules/S3626/cfamily/metadata.json
+++ b/rules/S3626/cfamily/metadata.json
@@ -1,5 +1,3 @@
 {
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }

--- a/rules/S3626/cfamily/metadata.json
+++ b/rules/S3626/cfamily/metadata.json
@@ -1,3 +1,4 @@
 {
+  "status": "closed",
   "defaultQualityProfiles": []
 }

--- a/rules/S3626/comments-and-links.adoc
+++ b/rules/S3626/comments-and-links.adoc
@@ -11,3 +11,5 @@ Note that there is a potential overlap of this rule with RSPEC-1751: uncondition
 === on 2 Jun 2016, 14:05:22 Ann Campbell wrote:
 looks fine [~tamas.vajk]
 
+=== on 26 Mar 2024, 08:15:00 Philipp Dominik Schubert wrote:
+We created a circle to discuss CFamily's rules on dead code and decided to disable this rule in the CFamily analyzer since we believe it provides relatively low value and is not even implemented in CFamily's analyzer (cf. https://sonarsource.atlassian.net/browse/CPP-5165).


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

