### PR TITLE
Modiful rules S5281,S2275: Mention the safer std::print alternative in the RSPEC (CPP-5027)

### DIFF
--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-Because ``++printf++`` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that lead to unexpected behavior or runtime errors. This rule statically validates the good behavior of ``++printf++`` formats.
+Because `printf` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that lead to unexpected behavior or runtime errors. This rule statically validates the good behavior of `printf` formats.
 
 The related rule S3457 is about errors that produce an unexpected string, while this rule is about errors that will create undefined behavior.
 

--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -43,6 +43,7 @@ This rule will only work if the format string is provided as a string literal.
 
 * S3457 - Format strings should be used correctly
 * S5281 - Argument of "printf" should be a format string
+* S6494 - {cpp} formatting functions should be used instead of C printf-like functions
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -37,7 +37,7 @@ This rule will only work if the format string is provided as a string literal.
 
 == Resources
 
-=== Standard
+=== Standards
 
 * CERT - https://www.securecoding.cert.org/confluence/x/wQA1[FIO47-C. Use valid format strings]
 

--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -4,6 +4,8 @@ Because ``++printf++`` format strings are interpreted at runtime rather than val
 
 The related rule S3457 is about errors that produce an unexpected string, while this rule is about errors that will create undefined behavior.
 
+Starting with {cpp}23, `std::print` should be preferred: its arguments are validated at compile-time, making it more secure.
+
 === Noncompliant code example
 
 [source,cpp]

--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -42,6 +42,7 @@ This rule will only work if the format string is provided as a string literal.
 === Related rules
 
 * S3457 - Format strings should be used correctly
+* S5281 - Argument of "printf" should be a format string
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S2275/cfamily/rule.adoc
+++ b/rules/S2275/cfamily/rule.adoc
@@ -1,7 +1,6 @@
 == Why is this an issue?
 
-Because ``++printf++`` format strings are interpreted at runtime, rather than validated by the compiler, they can contain errors that lead to unexpected behavior or runtime errors. This rule statically validates the good behavior of ``++printf++`` formats.
-
+Because ``++printf++`` format strings are interpreted at runtime rather than validated by the compiler, they can contain errors that lead to unexpected behavior or runtime errors. This rule statically validates the good behavior of ``++printf++`` formats.
 
 The related rule S3457 is about errors that produce an unexpected string, while this rule is about errors that will create undefined behavior.
 
@@ -36,7 +35,13 @@ This rule will only work if the format string is provided as a string literal.
 
 == Resources
 
-* https://www.securecoding.cert.org/confluence/x/wQA1[CERT, FIO47-C.] - Use valid format strings
+=== Standard
+
+* CERT - https://www.securecoding.cert.org/confluence/x/wQA1[FIO47-C. Use valid format strings]
+
+=== Related rules
+
+* S3457 - Format strings should be used correctly
 
 ifdef::env-github,rspecator-view[]
 

--- a/rules/S5281/cfamily/rule.adoc
+++ b/rules/S5281/cfamily/rule.adoc
@@ -39,6 +39,7 @@ void f(char* userInput) {
 === Related rules
 
 * S2275 - Printf-style format strings should not lead to unexpected behavior at runtime
+* S6494 - {cpp} formatting functions should be used instead of C printf-like functions
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5281/cfamily/rule.adoc
+++ b/rules/S5281/cfamily/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-It is a security vulnerability to call ``++printf++`` with a unique string argument that is not a string literal. Indeed, if this argument comes from a user input, this user can:
+It is a security vulnerability to call `printf` with a unique string argument that is not a string literal. Indeed, if this argument comes from a user input, this user can:
 
 * make the program crash by executing code equivalent to: ``++printf("%s%s%s%s%s%s%s%s")++``
 * view the stack or memory at any location by executing code equivalent to: ``++printf("%08x %08x %08x %08x %08x\n")++``

--- a/rules/S5281/cfamily/rule.adoc
+++ b/rules/S5281/cfamily/rule.adoc
@@ -5,6 +5,7 @@ It is a security vulnerability to call ``++printf++`` with a unique string argum
 * make the program crash by executing code equivalent to: ``++printf("%s%s%s%s%s%s%s%s")++``
 * view the stack or memory at any location by executing code equivalent to: ``++printf("%08x %08x %08x %08x %08x\n")++``
 
+Starting with {cpp}23, `std::print` should be preferred: its arguments are validated at compile-time, making it more secure.
 
 === Noncompliant code example
 

--- a/rules/S5281/cfamily/rule.adoc
+++ b/rules/S5281/cfamily/rule.adoc
@@ -1,9 +1,9 @@
 == Why is this an issue?
 
-It is a security vulnerability to call ``++printf++`` with a unique string argument which is not a string literal. Indeed, if this argument comes from a user input, this user can :
+It is a security vulnerability to call ``++printf++`` with a unique string argument that is not a string literal. Indeed, if this argument comes from a user input, this user can:
 
-* make the program crash, by executing code equivalent to: ``++printf("%s%s%s%s%s%s%s%s")++``
-* view the stack or a memory at any location, by executing code equivalent to: ``++printf("%08x %08x %08x %08x %08x\n")++``
+* make the program crash by executing code equivalent to: ``++printf("%s%s%s%s%s%s%s%s")++``
+* view the stack or memory at any location by executing code equivalent to: ``++printf("%08x %08x %08x %08x %08x\n")++``
 
 
 === Noncompliant code example
@@ -28,7 +28,13 @@ void f(char* userInput) {
 
 == Resources
 
-* https://owasp.org/www-community/attacks/Format_string_attack[Owasp: format string attack]
+=== Documentation
+
+* {cpp} reference - https://en.cppreference.com/w/cpp/io/c/fprintf[`printf`]
+
+=== Standards
+
+* OWASP - https://owasp.org/www-community/attacks/Format_string_attack[Format string attack]
 
 
 ifdef::env-github,rspecator-view[]

--- a/rules/S5281/cfamily/rule.adoc
+++ b/rules/S5281/cfamily/rule.adoc
@@ -36,6 +36,10 @@ void f(char* userInput) {
 
 * OWASP - https://owasp.org/www-community/attacks/Format_string_attack[Format string attack]
 
+=== Related rules
+
+* S2275 - Printf-style format strings should not lead to unexpected behavior at runtime
+
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
`validate_links` fails for unrelated reasons.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

