### PR TITLE
Avoid hitting "Next" downtime by postponing the job later in the night

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -1,7 +1,7 @@
 name: Update rule coverage
 on:
   schedule:
-    - cron: '17 0 * * *'
+    - cron: '17 2 * * *'
 
 jobs:
   update_coverage:


### PR DESCRIPTION
The frontend SQ analysis frequently fails during the night likely because it runs soon after SQ is redeployed. Move the update_coverage job 2h later to avoid that.

