### PR TITLE
Modify rule S6931: Deprecate VB for 

### DIFF
--- a/rules/S6931/vbnet/metadata.json
+++ b/rules/S6931/vbnet/metadata.json
@@ -1,2 +1,4 @@
 {
+    "defaultQualityProfiles": [],
+    "status": "deprecated"
 }


### PR DESCRIPTION
Deprecates VB for S6931.

Hint: https://github.com/SonarSource/rspec/tree/master/rules/S6934 does not implement VB,so we do not need to do any changes there.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

