### PR TITLE
Modify rule S2094: Add an exception

### DIFF
--- a/rules/S2094/csharp/rule.adoc
+++ b/rules/S2094/csharp/rule.adoc
@@ -22,11 +22,7 @@ public interface IEmpty
 
 === Exceptions
 
-Partial classes are ignored entirely, as they are often used with Source Generators.
-Subclasses of System.Exception are ignored, as even an empty Exception class can provide useful information by its type name alone.
-Subclasses of System.Attribute are ignored, as well as classes which are annotated with attributes.
-Subclasses of generic classes are ignored, as even when empty they can be used for type specialization.
-Subclasses of certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also ignored.
+include::../exceptions-dotnet.adoc[]
 
 [source,csharp]
 ----

--- a/rules/S2094/exceptions-dotnet.adoc
+++ b/rules/S2094/exceptions-dotnet.adoc
@@ -1,0 +1,13 @@
+﻿Partial classes are ignored entirely, as source generators often use them.
+
+Classes with names ending in `Command`, `Message`, or `Event` are ignored as messaging libraries often use them.
+
+Subclasses of `System.Exception` are ignored; even an empty Exception class can provide helpful information by its type name alone.
+
+Subclasses of `System.Attribute` and classes annotated with attributes are ignored.
+
+Subclasses of generic classes are ignored, as they can be used for type specialization even when empty.
+
+Subclasses of certain framework types — like the `PageModel` class used in ASP.NET Core Razor Pages — are ignored.
+
+Subclass of a class with non-public default constructors are ignored, as they widen the constructor accessibility.

--- a/rules/S2094/exceptions-dotnet.adoc
+++ b/rules/S2094/exceptions-dotnet.adoc
@@ -1,13 +1,7 @@
-﻿Partial classes are ignored entirely, as source generators often use them.
-
-Classes with names ending in `Command`, `Message`, or `Event` are ignored as messaging libraries often use them.
-
-Subclasses of `System.Exception` are ignored; even an empty Exception class can provide helpful information by its type name alone.
-
-Subclasses of `System.Attribute` and classes annotated with attributes are ignored.
-
-Subclasses of generic classes are ignored, as they can be used for type specialization even when empty.
-
-Subclasses of certain framework types — like the `PageModel` class used in ASP.NET Core Razor Pages — are ignored.
-
-Subclass of a class with non-public default constructors are ignored, as they widen the constructor accessibility.
+﻿- Partial classes are ignored entirely, as source generators often use them.
+- Classes with names ending in `Command`, `Message`, or `Event` are ignored as messaging libraries often use them.
+- Subclasses of `System.Exception` are ignored; even an empty Exception class can provide helpful information by its type name alone.
+- Subclasses of `System.Attribute` and classes annotated with attributes are ignored.
+- Subclasses of generic classes are ignored, as they can be used for type specialization even when empty.
+- Subclasses of certain framework types — like the `PageModel` class used in ASP.NET Core Razor Pages — are ignored.
+- Subclass of a class with non-public default constructors are ignored, as they widen the constructor accessibility.

--- a/rules/S2094/vbnet/rule.adoc
+++ b/rules/S2094/vbnet/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-There is no good excuse for an empty class. If it's being used simply as a common extension point, it should be replaced with an ``++Interface++``. If it was stubbed in as a placeholder for future development it should be fleshed-out. In any other case, it should be eliminated.
+include::../description.adoc[]
 
 === Noncompliant code example
 
@@ -22,11 +22,8 @@ End Interface
 
 === Exceptions
 
-Partial classes are ignored entirely, as they are often used with Source Generators.
-Subclasses of System.Exception are ignored, as even an empty Exception class can provide useful information by its type name alone.
-Subclasses of System.Attribute are ignored, as well as classes which are annotated with attributes.
-Subclasses of generic classes are ignored, as even when empty they can be used for type specialization.
-Subclasses of certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also ignored.
+include::../exceptions-dotnet.adoc[]
+
 [source,vbnet]
 ----
 Imports Microsoft.AspNetCore.Mvc.RazorPages


### PR DESCRIPTION
Implementation tickets:
[Implicit parameterless constructor widens the scope of the base class constructor](https://github.com/SonarSource/sonar-dotnet/issues/7591)
[Should not raise for messages](https://github.com/SonarSource/sonar-dotnet/issues/9063)

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

