### PR TITLE
Resolve SONARHTML-231 - Deprecate S1085:html

### DIFF
--- a/rules/S1085/html/metadata.json
+++ b/rules/S1085/html/metadata.json
@@ -22,8 +22,6 @@
   "ruleSpecification": "RSPEC-1085",
   "sqKey": "TableWithoutCaptionCheck",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1085/html/metadata.json
+++ b/rules/S1085/html/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "\"<table>\" tags should have a description",
   "type": "BUG",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"


### PR DESCRIPTION
Relates to https://sonarsource.atlassian.net/browse/SONARHTML-231

