### PR TITLE
Mark S1086 HTML variant as deprecated

### DIFF
--- a/rules/S1086/html/metadata.json
+++ b/rules/S1086/html/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "Heading tags should be used consecutively from \"H1\" to \"H6\"",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"
@@ -21,8 +21,6 @@
   "ruleSpecification": "RSPEC-1086",
   "sqKey": "NonConsecutiveHeadingCheck",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
As required by SONARHTML-234

