### PR TITLE
S2951: Rename

### DIFF
--- a/rules/S2951/vbnet/metadata.json
+++ b/rules/S2951/vbnet/metadata.json
@@ -1,3 +1,3 @@
 {
-  "title": "VB.Net: \"Exit Select\" statements should not be used redundantly"
+  "title": "\"Exit Select\" statements should not be used redundantly"
 }


### PR DESCRIPTION
Rules should not be prefixed with their language name. We generally don't do that, as it doesn't make sense.