### PR TITLE
SONARIAC-1429 S1192: String literals should be raised less often

### DIFF
--- a/rules/S1192/azureresourcemanager/exceptions-arm.adoc
+++ b/rules/S1192/azureresourcemanager/exceptions-arm.adoc
@@ -3,3 +3,7 @@ The following are ignored:
 * literals with fewer than 5 characters
 * literals with only letters, numbers, underscores, hyphens and periods
 * `apiVersion` property of a resource (see rule S6874)
+* `type` in sub-templates
+* `$schema` property
+* version numbers like `1.0.0` or `1-0-0`
+* escaped function calls like `[[variables('variableName')]`

--- a/rules/S1192/azureresourcemanager/rule.adoc
+++ b/rules/S1192/azureresourcemanager/rule.adoc
@@ -14,7 +14,7 @@ include::howtofix-arm.adoc[]
 
 ==== Noncompliant code example
 
-With the default threshold of 3:
+With the default threshold of 5:
 
 [source,json,diff-id=1,diff-type=noncompliant]
 ----
@@ -29,7 +29,9 @@ With the default threshold of 3:
       "name": "appSuperStorage",
       "tags": {
         "displayName": "appSuperStorage",
-        "shortName" : "appSuperStorage"
+        "shortName" : "appSuperStorage",
+        "someName": "appSuperStorage",
+        "yetAnotherName": "appSuperStorage"
       }
     }
   ]
@@ -53,7 +55,9 @@ With the default threshold of 3:
       "name": "[variables('storageAccountName')]",
       "tags": {
         "displayName": "[variables('storageAccountName')]",
-        "shortName" : "[variables('storageAccountName')]"
+        "shortName" : "[variables('storageAccountName')]",
+        "someName": "[variables('storageAccountName')]",
+        "yetAnotherName": "[variables('storageAccountName')]"
       }
     }
   ]
@@ -68,15 +72,17 @@ include::howtofix-arm.adoc[]
 
 ==== Noncompliant code example
 
-With the default threshold of 3:
+With the default threshold of 5:
 
 [source,bicep,diff-id=2,diff-type=noncompliant]
 ----
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
-  name: 'appSuperStorage'          // Noncompliant
+  name: 'appSuperStorage'             // Noncompliant
   tags: {
-    displayName: 'appSuperStorage' // Noncompliant
-    shortName: 'appSuperStorage'   // Noncompliant
+    displayName: 'appSuperStorage'    // Noncompliant
+    shortName: 'appSuperStorage'      // Noncompliant
+    someName: 'appSuperStorage'       // Noncompliant
+    yetAnotherName: 'appSuperStorage' // Noncompliant
   }
 }
 ----
@@ -92,6 +98,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
   tags: {
     displayName: storageAccountName
     shortName: storageAccountName
+    someName: storageAccountName
+    yetAnotherName: storageAccountName
   }
 }
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

