### PR TITLE
Deprecate S6803

### DIFF
--- a/rules/S6803/csharp/metadata.json
+++ b/rules/S6803/csharp/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "Parameters with SupplyParameterFromQuery attribute should be used only in routable components",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"

--- a/rules/S6803/csharp/metadata.json
+++ b/rules/S6803/csharp/metadata.json
@@ -13,7 +13,7 @@
   "ruleSpecification": "RSPEC-6803",
   "sqKey": "S6803",
   "scope": "All",
-  "defaultQualityProfiles": ["Sonar way"],
+  "defaultQualityProfiles": [],
   "quickfix": "infeasible",
   "code": {
     "impacts": {

--- a/rules/S6803/csharp/rule.adoc
+++ b/rules/S6803/csharp/rule.adoc
@@ -1,4 +1,5 @@
-<p>This rule is deprecated, and will eventually be removed.</p>
+*This rule is deprecated, and will eventually be removed.*
+
 Component parameters can only receive query parameter values in routable components with an @page directive.
 
 == Why is this an issue?

--- a/rules/S6803/csharp/rule.adoc
+++ b/rules/S6803/csharp/rule.adoc
@@ -1,3 +1,4 @@
+<p>This rule is deprecated, and will eventually be removed.</p>
 Component parameters can only receive query parameter values in routable components with an @page directive.
 
 == Why is this an issue?


### PR DESCRIPTION
After discussing the impact of this rule we decided to deprecate it.

- The rule applies < .NET8
- It has a very low impact
- It applies only to sealed components

