### PR TITLE
Modify rule S6962: Fix rule link

### DIFF
--- a/rules/S6962/csharp/rule.adoc
+++ b/rules/S6962/csharp/rule.adoc
@@ -79,7 +79,7 @@ public class FooController : Controller
 
 === Documentation
 
-* https://rules.sonarsource.com/csharp/RSPEC-6420/[S6420 - Client instances should not be recreated on each Azure Function invocation]
+* S6420 - Client instances should not be recreated on each Azure Function invocation
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.net.http.ihttpclientfactory[IHttpClientFactory Interface]
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient[HttpClient Class]
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory[IHttpClientFactory with .NET]


### PR DESCRIPTION
Adding a link to a rule causes the creation of nested `a` tags:
```html
<a href="https://rules.sonarsource.com/csharp/RSPEC-6420/"><a href='/sonarqube/coding_rules#rule_key=csharpsquid:S6420'>S6420</a> - Client instances should not be recreated on each Azure\n  Function invocation</a>
```

This causes trouble e.g. in SonarLint for Visual Studio. See the discussion here:
https://sonarsource.slack.com/archives/C012KBFFYD6/p1715177821573109?thread_ts=1715166368.425089&cid=C012KBFFYD6

See also SonarSource/sonarlint-visualstudio/issues/5413

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

