### PR TITLE
Modify rule S6945: fix typo in title

### DIFF
--- a/rules/S6945/jcl/metadata.json
+++ b/rules/S6945/jcl/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "COND code should be should be set after a certain step",
+  "title": "COND code should be set after a certain step",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

