### PR TITLE
Modify rule S2094: add exception for classes ending with Query

### DIFF
--- a/rules/S2094/exceptions-dotnet.adoc
+++ b/rules/S2094/exceptions-dotnet.adoc
@@ -1,5 +1,5 @@
 ﻿- Partial classes are ignored entirely, as source generators often use them.
-- Classes with names ending in `Command`, `Message`, or `Event` are ignored as messaging libraries often use them.
+- Classes with names ending in `Command`, `Message`, `Event` or `Query` are ignored as messaging libraries often use them.
 - Subclasses of `System.Exception` are ignored; even an empty Exception class can provide helpful information by its type name alone.
 - Subclasses of `System.Attribute` and classes annotated with attributes are ignored.
 - Subclasses of generic classes are ignored, as they can be used for type specialization even when empty.

--- a/rules/S2094/exceptions-dotnet.adoc
+++ b/rules/S2094/exceptions-dotnet.adoc
@@ -1,5 +1,5 @@
 ﻿- Partial classes are ignored entirely, as source generators often use them.
-- Classes with names ending in `Command`, `Message`, `Event` or `Query` are ignored as messaging libraries often use them.
+- Classes with names ending in `Command`, `Message`, `Event`, or `Query` are ignored as messaging libraries often use them.
 - Subclasses of `System.Exception` are ignored; even an empty Exception class can provide helpful information by its type name alone.
 - Subclasses of `System.Attribute` and classes annotated with attributes are ignored.
 - Subclasses of generic classes are ignored, as they can be used for type specialization even when empty.


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

