### PR TITLE
CPP-5374 S1709 Introduce exception for "std::initializer_list" constructor

### DIFF
--- a/rules/S1709/cfamily/rule.adoc
+++ b/rules/S1709/cfamily/rule.adoc
@@ -61,6 +61,26 @@ int test(Bar& bar, Baz& baz) {
 
 === Exceptions
 
+The issue is not raised for constructor that have single parameter of `std::initializer_list` type -
+such constructors have special meaning and allows object to be constructed from brace delimited list of initializers.
+
+[source,cpp]
+----
+struct Container {
+  Container(std::initializer_list<int> elems); // Compliant
+};
+
+void handle(Container const& c);
+
+int test(Bar& bar, Baz& baz) {
+  Container c1{1, 2, 3};      // OK regardless if constructor is explicit or not
+  Container c2 = {1, 2, 3};   // Ill-formed if constructor would be explicit
+  handle({1, 2, 3});          // Ill-formed if constructor would be explicit
+  handle(Container{1, 2, 3}); // OK regardless if constructor is explicit or not
+}
+----
+
+
 {cpp}20 introduced conditional `explicit(expr)` that allows developers to make a constructor or conversion operator conditionally explicit depending on the value of `expr`.
 The new syntax allows a constructor or conversion operator declared with an `explicit(expr)` specifier to be implicit when `expr` evaluates to `false`.
 The issue is not raised in such situation.


### PR DESCRIPTION
…

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

