### PR TITLE
CPP-5375 S6459 Add exception for `std::convertible_to` concept

### DIFF
--- a/rules/S6459/cfamily/rule.adoc
+++ b/rules/S6459/cfamily/rule.adoc
@@ -40,7 +40,8 @@ The rule raises an issue when a forwarding reference parameter is constrained by
 
 === Exceptions
 
-The rule does not raise an issue for the `std::ranges::range` concept and its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`) which are designed to handle forwarding reference parameters.
+The rule does not raise an issue for the concepts `std::convertible_to` and `std::ranges::range` with its refinements (like `std::ranges::forward_range`, `std::ranges::bidirectional_range`),
+that handle forwarding reference parameters correctly.
 
 == How to fix it
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

