### PR TITLE
Modify rule S1289 (`COBOL.UnusedDataItem`): Ignore `EXTERNAL` data items

### DIFF
--- a/rules/S1289/cobol/rule.adoc
+++ b/rules/S1289/cobol/rule.adoc
@@ -30,6 +30,8 @@ MOVE "John" TO FIRST_NAME.
 
 ``++FILLER++`` top level data items and top level data items which have sub data items with a ``++VALUE++`` clause are not checked by this rule.
 
+``++EXTERNAL++`` data items are not checked by this rule.
+
 ifdef::env-github,rspecator-view[]
 
 '''


### PR DESCRIPTION
Companion PR for ticket [COBOL-1701](https://sonarsource.atlassian.net/browse/SONARCOBOL-1701): data items marked as `EXTERNAL` should not be reported as "unused data item".

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

