### PR TITLE
Modify rule S5769: Remove dead link

### DIFF
--- a/rules/S5769/abap/rule.adoc
+++ b/rules/S5769/abap/rule.adoc
@@ -28,11 +28,6 @@ LOOP AT i_bseg ASSIGNING <fs_bseg>.
 ENDLOOP.
 ----
 
-
-== Resources
-
-* https://zevolving.com/use-of-field-symbols-vs-work-area/[Use of Field-symbols vs Work area]
-
 ifdef::env-github,rspecator-view[]
 
 '''


### PR DESCRIPTION
I believe it's Ok to simply remove it. I didn't find an alternative and the link is not on the wayback machine https://wayback-api.archive.org/web/20240000000000*/https://zevolving.com/use-of-field-symbols-vs-work-area 
