### PR TITLE
Update S1144: Add exception for DynamicallyAccessedMembersAttribute

### DIFF
--- a/rules/S1144/csharp/rule.adoc
+++ b/rules/S1144/csharp/rule.adoc
@@ -48,6 +48,7 @@ This rule doesn't raise issues on:
 * empty serialization constructor on type with https://learn.microsoft.com/en-us/dotnet/api/system.serializableattribute[System.SerializableAttribute] attribute.
 * field and property members of types marked with https://learn.microsoft.com/en-us/dotnet/api/system.serializableattribute[System.SerializableAttribute] attribute
 * internal members in assemblies that have a https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute[System.Runtime.CompilerServices.InternalsVisibleToAttribute] attribute.
+* types and members decorated with the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute] attribute (available in .NET 5.0+) or a custom attribute named `DynamicallyAccessedMembersAttribute`.
 
 == Resources
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

