### PR TITLE
Modify rule S3624: fix error in documentation visibility

### DIFF
--- a/rules/S3624/cfamily/rule.adoc
+++ b/rules/S3624/cfamily/rule.adoc
@@ -152,8 +152,6 @@ public:
 
 * MISRA {cpp}23 15.0.1 - "Special member functions" shall be provided appropriately
 
-ifdef::env-github,rspecator-view[]
-
 === External coding guidelines
 
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c20-if-you-can-avoid-defining-default-operations-do[C.20: If you can avoid defining default operations, do]
@@ -161,6 +159,8 @@ ifdef::env-github,rspecator-view[]
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all[C.21: If you define or =delete any copy, move, or destructor function, define or =delete them all]
 
 * {cpp} Core Guidelines - https://github.com/isocpp/CppCoreGuidelines/blob/e49158a/CppCoreGuidelines.md#c22-make-default-operations-consistent[C.22: Make default operations consistent]
+
+ifdef::env-github,rspecator-view[]
 
 == Comments And Links
 (visible only on this page)


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

