### PR TITLE
Create specialized single-language rules

### DIFF
--- a/rspec-tools/rspec_template/single_language/secrets/metadata.json
+++ b/rspec-tools/rspec_template/single_language/secrets/metadata.json
@@ -1,0 +1,56 @@
+{
+  "title": "SECRET_TYPE should not be disclosed",
+  "type": "VULNERABILITY",
+  "code": {
+    "impacts": {
+      "SECURITY": "HIGH"
+    },
+    "attribute": "TRUSTWORTHY"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "30min"
+  },
+  "tags": [
+    "cwe",
+    "cert"
+  ],
+  "defaultSeverity": "Blocker",
+  "ruleSpecification": "RSPEC-${RSPEC_ID}",
+  "sqKey": "S${RSPEC_ID}",
+  "scope": "All",
+  "securityStandards": {
+    "CWE": [
+      798,
+      259
+    ],
+    "OWASP": [
+      "A3"
+    ],
+    "CERT": [
+      "MSC03-J."
+    ],
+    "OWASP Top 10 2021": [
+      "A7"
+    ],
+    "PCI DSS 3.2": [
+      "6.5.10"
+    ],
+    "PCI DSS 4.0": [
+      "6.2.4"
+    ],
+    "ASVS 4.0": [
+      "2.10.4",
+      "3.5.2",
+      "6.4.1"
+    ],
+    "STIG ASD 2023-06-08": [
+      "V-222642"
+    ]
+  },
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ],
+  "quickfix": "unknown"
+}

--- a/rspec-tools/rspec_template/single_language/secrets/rule.adoc
+++ b/rspec-tools/rspec_template/single_language/secrets/rule.adoc
@@ -1,0 +1,48 @@
+
+include::../../../shared_content/secrets/description.adoc[]
+
+== Why is this an issue?
+
+include::../../../shared_content/secrets/rationale.adoc[]
+
+=== What is the potential impact?
+
+// Optional: Give a general description of the secret and what it's used for.
+
+Below are some real-world scenarios that illustrate some impacts of an attacker
+exploiting the secret.
+
+// Set value that can be used to refer to the type of secret in, for example:
+// "An attacker can use this {secret_type} to ..."
+:secret_type: secret
+
+// Where possible, use predefined content for common impacts. This content can
+// be found in the folder "shared_content/secrets/impact".
+
+//include::../../../shared_content/secrets/impact/some_impact.adoc[]
+
+== How to fix it
+
+include::../../../shared_content/secrets/fix/revoke.adoc[]
+
+include::../../../shared_content/secrets/fix/vault.adoc[]
+
+=== Code examples
+
+:example_secret: example_secret_value
+:example_name: java-property-name
+:example_env: ENV_VAR_NAME
+
+include::../../../shared_content/secrets/examples.adoc[]
+
+//=== How does this work?
+
+//=== Pitfalls
+
+//=== Going the extra mile
+
+== Resources
+
+include::../../../shared_content/secrets/resources/standards.adoc[]
+
+//=== Benchmarks

--- a/rspec-tools/rspec_tools/create_rule.py
+++ b/rspec-tools/rspec_tools/create_rule.py
@@ -113,7 +113,9 @@ class RuleCreator:
 
   def _fill_single_lang_template_files(self, rule_dir: Path, rule_number: int, language: str):
     common_template = self.TEMPLATE_PATH / 'single_language' / 'common'
-    lang_specific_template = self.TEMPLATE_PATH / 'single_language' / 'language_specific'
+    lang_specific_template = self.TEMPLATE_PATH / 'single_language' / language
+    if not Path(lang_specific_template).exists():
+      lang_specific_template = self.TEMPLATE_PATH / 'single_language' / 'language_specific'
     copy_directory_content(common_template, rule_dir)
 
     lang_dir = rule_dir /language


### PR DESCRIPTION
This change allows single-language rules to use a specialized template when they're created.

The reason for this change is that the AppSec squad wants to improve the efficiency with which new `secrets` rules can be created. These rules only exist for a single language, `secrets`, and much of the rule content and metadata is similar/identical between rules.

The best way to realize this efficiency improvement for `secrets` rules is to have a specialized template that gets used when a new RSPEC is created. This template is used when a rule is created for a single language, and that language is `secrets`.

When a rule is created with a single language, the appropriate template folder is checked for a folder whose name matches the language. If such a folder is found, it will be used as the template for the language. If no such folder is found, the existing language-neutral template will be used instead.

I have chosen not to lock this feature down to just the `secrets` language. I can't think of any other languages that could make use of this language-specific template functionality right now, but it's possible that it will be useful for new languages in the future.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

