### PR TITLE
SONARIAC-1228 S6870: Should not raise with LimitRange in the same namespace setting Storage Limits

### DIFF
--- a/rules/S6870/kubernetes/rule.adoc
+++ b/rules/S6870/kubernetes/rule.adoc
@@ -47,6 +47,21 @@ spec:
           mountPath: "/tmp"
 ----
 
+[source,yaml,diff-id=2,diff-type=noncompliant]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+spec:
+  containers:
+    - name: web # Noncompliant
+      image: nginx
+      volumeMounts:
+        - name: ephemeral
+          mountPath: "/tmp"
+----
+
 ==== Compliant solution
 
 [source,yaml,diff-id=1,diff-type=compliant]
@@ -67,11 +82,38 @@ spec:
           mountPath: "/tmp"
 ----
 
+[source,yaml,diff-id=2,diff-type=compliant]
+----
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: storage-limit-range
+  namespace: namespace-with-limit-range
+spec:
+  limits:
+  - default:
+      ephemeral-storage: "10Mi"
+    type: Container
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  namespace: namespace-with-limit-range
+spec:
+  containers:
+    - name: web
+      image: nginx
+      volumeMounts:
+        - name: ephemeral
+          mountPath: "/tmp"
+----
+
 === How does this work?
 
 A limit can be set through the property `resources.limits.ephemeral-storage` of
 a container. Alternatively, a default limit for a namespace can be set with
-`LimitRange`.
+`LimitRange` through `spec.limits[].default.ephemeral-storage`.
 
 == Resources
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

