### PR TITLE
Modify rule S824: Clarify the most vexing parse (CPP-5122)

### DIFF
--- a/rules/S824/cfamily/rule.adoc
+++ b/rules/S824/cfamily/rule.adoc
@@ -8,15 +8,15 @@ Additionally, when a function is declared at block scope, the intent is often no
 ----
 void f() {
   int a;
-  int b();
+  string b();
   short c(short (a));
 }
 ----
 
 * `b` could be interpreted as:
 
-** A variable of type `int` with empty initialization or
-** A function with no argument and returning an `int`. 
+** A variable of type `string` with empty initialization or
+** A function with no argument and returning a `string`. 
 
 +
 The second interpretation is selected.
@@ -35,16 +35,18 @@ There are several ways to write the code differently so that `b` and `c` can onl
 ----
 void f() {
   int a;
-  int b {};
+  string b {};
   auto c = short (a);
 }
 ----
 
 By raising issues on local function declaration, this rule helps detect when a function is inadvertently declared.
 
+
+== How to fix it
 === Noncompliant code example
 
-[source,cpp]
+[source,cpp,diff-id=2,diff-type=noncompliant]
 ----
 class A {
 };
@@ -56,7 +58,18 @@ void fun() {
 }
 ----
 
+=== Compliant solution
+[source,cpp,diff-id=2,diff-type=compliant]
+----
+class A {
+};
 
+void nestedFun(); // Compliant, function declaration moved outside of fun
+
+void fun() {
+  A a;      // Compliant; declares an object
+}
+----
 == Resources
 === External coding guidelines
 

--- a/rules/S824/cfamily/rule.adoc
+++ b/rules/S824/cfamily/rule.adoc
@@ -1,10 +1,46 @@
 == Why is this an issue?
 
-A function declared at block scope will refer to a member of the enclosing namespace, and so the declaration should be explicitly placed at the namespace level.
+It is rarely useful to declare a function at block scope. Such a function will not get special access to any name in its enclosing scope, and therefore, it is equivalent but clearer to declare it instead in the enclosing namespace.
 
+Additionally, when a function is declared at block scope, the intent is often not to declare a function but instead to declare and initialize a variable. This problem is nicknamed the _most vexing parse_ and stems from the fact that some syntaxes can be ambiguous, and that in that case the language unintuitively favors function declaration:
 
-Additionally, where a declaration statement could either declare a function or an object, the compiler will choose to declare the function. To avoid potential developer confusion over the meaning of a declaration, functions should not be declared at block scope.
+[source,cpp,diff-id=1,diff-type=noncompliant]
+----
+void f() {
+  int a;
+  int b();
+  short c(short (a));
+}
+----
 
+* `b` could be interpreted as:
+
+** A variable of type `int` with empty initialization or
+** A function with no argument and returning an `int`. 
+
++
+The second interpretation is selected.
+
+* Similarly, `c` could be interpreted as:
+
+** A variable of type `short` initialized with the value `a` converted to `short` or 
+** A function that takes a parameter named `a` (with extra parentheses) of type `short` and returning a `short`
+
++
+Here again, the second interpretation is selected.
+
+There are several ways to write the code differently so that `b` and `c` can only be interpreted as variables. For instance:
+
+[source,cpp,diff-id=1,diff-type=compliant]
+----
+void f() {
+  int a;
+  int b {};
+  auto c = short (a);
+}
+----
+
+By raising issues on local function declaration, this rule helps detect when a function is inadvertently declared.
 
 === Noncompliant code example
 
@@ -22,10 +58,11 @@ void fun() {
 
 
 == Resources
+=== External coding guidelines
 
-* MISRA C:2004, 8.6 - Functions shall be declared at file scope
+* MISRA {cpp}:2023, 6.0.1 - Block scope declarations shall not be visually ambiguous
 * MISRA {cpp}:2008, 3-1-2 - Functions shall not be declared at block scope
-
+* MISRA C:2004, 8.6 - Functions shall be declared at file scope
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
New suggested message (the rule implementation has not been updated yet):
> Move this function declaration outside of this block scope, or if the intent was to declare a variable, use a syntax that avoids the most vexing parse.
