### PR TITLE
BUILD-4733: Use the correct url format for cloning with an access token

### DIFF
--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -155,7 +155,7 @@ def checkout_repo(repo):
   git_url=f"https://github.com/SonarSource/{repo}"
   token=os.getenv('GITHUB_TOKEN')
   if token:
-    git_url=f"https://{token}:x-oauth-basic@github.com/SonarSource/{repo}"
+    git_url=f"https://oauth2:${token}@github.com/SonarSource/{repo}"
   if not os.path.exists(repo):
     return Repo.clone_from(git_url, repo)
   else:


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

