### PR TITLE
BUILD-5580: add missing pages:write permission to Build and Deploy work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       id-token: write # OIDC auth for Vault
       pull-requests: read # Get the list and metadata of open new-rule PRs
       contents: write # Get the contents of open new-rule PRs, the 'master'; write to 'gh-pages' branch
+      pages: write # for github-pages-deploy-action
     steps:
       - name: 'get secrets'
         id: secrets
@@ -41,6 +42,6 @@ jobs:
         with:
           SINGLE_COMMIT: true
           CLEAN: true
-          COVERAGE_GITHUB_TOKEN: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: frontend/build # The folder the action should deploy.


### PR DESCRIPTION
flow and fix the usage of github-pages-deploy-action


