### PR TITLE
Revert Coverage script to functional state

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 env:
-  COVERAGE_GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-ro token]
+  GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-ro token]
   SONAR_HOST_URL: VAULT[development/kv/data/next data.url]
   SONAR_TOKEN: VAULT[development/kv/data/next data.token]
   SONAR_SCANNER_VERSION: 5.0.1.3006

--- a/.github/workflows/add_language.yml
+++ b/.github/workflows/add_language.yml
@@ -14,15 +14,12 @@ on:
 
 jobs:
   add_language_to_rule:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # OIDC auth for Vault
-      contents: read # checkout
+    runs-on: ubuntu-latest    
 
     steps:
     - name: 'get secrets'
       id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
+      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
       with:
         secrets: |
           development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;

--- a/.github/workflows/add_language.yml
+++ b/.github/workflows/add_language.yml
@@ -14,16 +14,11 @@ on:
 
 jobs:
   add_language_to_rule:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - name: 'get secrets'
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
-      with:
-        secrets: |
-          development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;
-
     - uses: actions/checkout@v4
       with:
         persist-credentials: true
@@ -43,7 +38,5 @@ jobs:
       run: pipenv install
 
     - name: 'Add Language'
-      env:
-        COVERAGE_GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
       working-directory: 'rspec/rspec-tools'
       run: pipenv run rspec-tools add-lang-to-rule --user ${{ github.actor }} --language "${{ github.event.inputs.language }}" --rule "${{ github.event.inputs.rule }}"

--- a/.github/workflows/create_new_rspec.yml
+++ b/.github/workflows/create_new_rspec.yml
@@ -12,14 +12,11 @@ on:
 jobs:
   create_new_rule:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # OIDC auth for Vault
-      contents: read # checkout
 
     steps:
     - name: 'get secrets'
       id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
+      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
       with:
         secrets: |
           development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;

--- a/.github/workflows/create_new_rspec.yml
+++ b/.github/workflows/create_new_rspec.yml
@@ -12,15 +12,10 @@ on:
 jobs:
   create_new_rule:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - name: 'get secrets'
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
-      with:
-        secrets: |
-          development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;
-
     - uses: actions/checkout@v4
       with:
         persist-credentials: true
@@ -40,7 +35,5 @@ jobs:
       run: pipenv install
 
     - name: 'Create Rule'
-      env:
-        COVERAGE_GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
       working-directory: 'rspec/rspec-tools'
       run: pipenv run rspec-tools create-rule --user ${{ github.actor }} --languages "${{ github.event.inputs.languages }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,6 @@ jobs:
       contents: write # Get the contents of open new-rule PRs, the 'master'; write to 'gh-pages' branch
       pages: write # for github-pages-deploy-action
     steps:
-      - name: 'get secrets'
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
-        with:
-          secrets: |
-            development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;
-
       - name: Checkout 🛎️
         uses: actions/checkout@v4 # If you're using actions/checkout you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
@@ -35,7 +28,7 @@ jobs:
           npm run predeploy
         env:
           NODE_OPTIONS: "--max-old-space-size=3048"
-          COVERAGE_GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04
     permissions:
-      id-token: write # OIDC auth for Vault
       pull-requests: read # Get the list and metadata of open new-rule PRs
       contents: write # Get the contents of open new-rule PRs, the 'master'; write to 'gh-pages' branch
       pages: write # for github-pages-deploy-action
     steps:
       - name: 'get secrets'
         id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
+        uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
         with:
           secrets: |
             development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;

--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -2,7 +2,7 @@ name: Update rule coverage
 on:
   schedule:
     - cron: '17 2 * * *'
-
+  workflow_dispatch
 jobs:
   update_coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -6,27 +6,17 @@ on:
 jobs:
   update_coverage:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # OIDC auth for Vault
-      contents: read # checkout
     env:
       TMP_BRANCH: temporary/coverage_update
 
     steps:
-    - name: 'get secrets'
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
-      with:
-        secrets: |
-          development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;
-          development/kv/data/slack token | slack_token;
-
     - uses: actions/checkout@v4
       with:
         persist-credentials: true
         ref: master
         path: 'rspec'
-        token: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
+        token: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
+
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
@@ -41,7 +31,7 @@ jobs:
 
     - name: 'Regenerate coverage information'
       env:
-        COVERAGE_GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
       id: gen-coverage
       working-directory: 'rspec/rspec-tools'
       run: |
@@ -74,7 +64,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
-        token: ${{ secrets.COVERAGE_GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         checkName: all_required_checks
         ref: ${{ env.TMP_BRANCH }}
         timeoutSeconds: 2400
@@ -94,7 +84,7 @@ jobs:
       if: always() && steps.create-temp-branch.conclusion == 'success'
       uses: dawidd6/action-delete-branch@v3
       with:
-        COVERAGE_GITHUB_TOKEN: ${{ secrets.COVERAGE_GITHUB_TOKEN}}
+        github_token: ${{ secrets.GITHUB_TOKEN}}
         branches: ${{ env.TMP_BRANCH}}
 
     - name: 'Fail if the change breaks CI'
@@ -106,7 +96,7 @@ jobs:
     - name: 'Notify on slack about the failure'
       if: ${{ failure() }}
       env:
-        SLACK_API_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).slack_token }}
+        SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
       working-directory: 'rspec/rspec-tools'
       run: |
         pipenv run rspec-tools notify-failure-on-slack \

--- a/.github/workflows/update_quickfix_status.yml
+++ b/.github/workflows/update_quickfix_status.yml
@@ -1,6 +1,6 @@
 name: Update quick fix status
 
-on:
+on: 
   workflow_dispatch:
     inputs:
       rule:
@@ -26,13 +26,10 @@ jobs:
   update_quickfix_status:
     name: Update quick fix status
     runs-on: ubuntu-20.04
-    permissions:
-      id-token: write # OIDC auth for Vault
-      contents: read # checkout
     steps:
     - name: 'get secrets'
       id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
+      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
       with:
         secrets: |
           development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;

--- a/.github/workflows/update_quickfix_status.yml
+++ b/.github/workflows/update_quickfix_status.yml
@@ -26,13 +26,9 @@ jobs:
   update_quickfix_status:
     name: Update quick fix status
     runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: 'get secrets'
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@7160b50d75c02fe48eb3c8d354ca4fd7029f546a # tag=2.5.0-4
-      with:
-        secrets: |
-          development/github/token/SonarSource-rspec-coverage token | COVERAGE_GITHUB_TOKEN;
     - uses: actions/checkout@v2
       with:
         persist-credentials: true
@@ -53,6 +49,4 @@ jobs:
 
     - name: 'Update quickfix status'
       working-directory: 'rspec/rspec-tools'
-      env:
-        COVERAGE_GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).COVERAGE_GITHUB_TOKEN }}
       run: pipenv run rspec-tools update-quickfix-status --user ${{ github.actor }} --rule "${{ github.event.inputs.rule }}" --language "${{ github.event.inputs.language }}" --status "${{ github.event.inputs.status }}"

--- a/frontend/README.adoc
+++ b/frontend/README.adoc
@@ -36,7 +36,7 @@ NOTE: If the script fails to clone or fetch due to an SSL certificate failure
       As a workaround you can https://github.com/nodegit/nodegit/issues/1742[disable the certificate check].
 
 NOTE: In the predeploy step (specifically the `prepare-rules` part of it) the script fetches all the open PRs locally.
-      You might want to set `COVERAGE_GITHUB_TOKEN` to your personal GitHub token
+      You might want to set `GITHUB_TOKEN` to your personal GitHub token
       to avoid GitHub throttling your requests during the predeploy stage.
 
 

--- a/frontend/src/deployment/pullRequestIndexing.ts
+++ b/frontend/src/deployment/pullRequestIndexing.ts
@@ -24,14 +24,14 @@ export interface PullRequest {
  */
 export async function process_incomplete_rspecs(tmpRepoDir: string,
                                                 callback: (srcDir: string, pr: PullRequest)=>void) {
-  const octokit = process.env.COVERAGE_GITHUB_TOKEN ?
-    new Octokit({userAgent: 'rspec-tools', auth: process.env.COVERAGE_GITHUB_TOKEN}):
+  const octokit = process.env.GITHUB_TOKEN ?
+    new Octokit({userAgent: 'rspec-tools', auth: process.env.GITHUB_TOKEN}):
     new Octokit({userAgent: 'rspec-tools'});
 
   const repo = await (() => {
     if (!fs.existsSync(path.join(tmpRepoDir, '.git'))) {
-      if (process.env.COVERAGE_GITHUB_TOKEN) {        
-        return Git.Clone.clone(`https://${process.env.COVERAGE_GITHUB_TOKEN}@github.com/SonarSource/rspec/`, tmpRepoDir);
+      if (process.env.GITHUB_TOKEN) {
+        return Git.Clone.clone('https://' + process.env.GITHUB_TOKEN + '@github.com/SonarSource/rspec/', tmpRepoDir);
       } else {
         return Git.Clone.clone('https://github.com/SonarSource/rspec/', tmpRepoDir);
       }

--- a/rspec-tools/rspec_tools/cli.py
+++ b/rspec-tools/rspec_tools/cli.py
@@ -45,7 +45,7 @@ def check_links(d):
 @click.option('--user', required=False)
 def create_rule(languages: str, user: Optional[str]):
   '''Create a new rule.'''
-  token = os.environ.get('COVERAGE_GITHUB_TOKEN')
+  token = os.environ.get('GITHUB_TOKEN')
   rspec_tools.create_rule.create_new_rule(languages, token, user)
 
 
@@ -55,7 +55,7 @@ def create_rule(languages: str, user: Optional[str]):
 @click.option('--user', required=False)
 def add_lang_to_rule(language: str, rule: str, user: Optional[str]):
   '''Add a new language to rule.'''
-  token = os.environ.get('COVERAGE_GITHUB_TOKEN')
+  token = os.environ.get('GITHUB_TOKEN')
   rspec_tools.create_rule.add_language_to_rule(language, rule, token, user)
 
 
@@ -66,7 +66,7 @@ def add_lang_to_rule(language: str, rule: str, user: Optional[str]):
 @click.option('--user', required=False)
 def update_quickfix_status(language: str, rule: str, status: str, user: Optional[str]):
   '''Update the status of quick fix for the given rule/language'''
-  token = os.environ.get('COVERAGE_GITHUB_TOKEN')
+  token = os.environ.get('GITHUB_TOKEN')
   rspec_tools.modify_rule.update_rule_quickfix_status(language, rule, status, token, user)
 
 

--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -153,9 +153,9 @@ def all_implemented_rules():
 
 def checkout_repo(repo):
   git_url=f"https://github.com/SonarSource/{repo}"
-  token=os.getenv('COVERAGE_GITHUB_TOKEN')
+  token=os.getenv('GITHUB_TOKEN')
   if token:
-    git_url=f"https://${token}@github.com/SonarSource/{repo}"
+    git_url=f"https://oauth2:${token}@github.com/SonarSource/{repo}"
   if not os.path.exists(repo):
     return Repo.clone_from(git_url, repo)
   else:

--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -155,7 +155,7 @@ def checkout_repo(repo):
   git_url=f"https://github.com/SonarSource/{repo}"
   token=os.getenv('GITHUB_TOKEN')
   if token:
-    git_url=f"https://oauth2:${token}@github.com/SonarSource/{repo}"
+    git_url=f"https://{token}@github.com/SonarSource/{repo}"
   if not os.path.exists(repo):
     return Repo.clone_from(git_url, repo)
   else:

--- a/rspec-tools/tests/test_cli.py
+++ b/rspec-tools/tests/test_cli.py
@@ -12,7 +12,7 @@ from rspec_tools.rules import RulesRepository
 class TestCLIUpdateQuickfixStatus:
   '''Unit test for quickfix status update through Command Line Interface.'''
 
-  @patch.dict(os.environ, {'COVERAGE_GITHUB_TOKEN': 'TOKEN'})
+  @patch.dict(os.environ, {'GITHUB_TOKEN': 'TOKEN'})
   @patch('rspec_tools.modify_rule.update_rule_quickfix_status')
   def test_basic_cli_usage(self, mock):
     arguments = [


### PR DESCRIPTION
The coverage script has been broken since Jun 26 and we've been pushing a lot of fixes since that not only didn't fix it, but reduced readability and didn't improve security (addition of a "COVERAGE" token that was used for all operations even unrelated to coverage, with the token having more authorizations than necessary for coverage calculation). I think we should revert and look into a correct solution offline without impacting the whole analysis team.