### PR TITLE
BUILD-4175 Fix permission issue when canceling the update coverage action

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -8,9 +8,10 @@ jobs:
   update_coverage:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # required by SonarSource/vault-action-wrapper
       contents: write
-      checks: read
+      checks: read # required by fountainhead/action-wait-for-check
+      actions: write # required by andymckay/cancel-action
     env:
       TMP_BRANCH: temporary/coverage_update
 

--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -2,7 +2,7 @@ name: Update rule coverage
 on:
   schedule:
     - cron: '17 2 * * *'
-  workflow_dispatch:
+  workflow_dispatch: # When manually triggered from a non-default branch, the results will not be pushed
 
 jobs:
   update_coverage:
@@ -86,7 +86,8 @@ jobs:
     - name: 'Push the updated coverage to master'
       if: |
         steps.gen-coverage.outputs.new_coverage == 'true' &&
-        steps.wait-for-build.outputs.conclusion == 'success'
+        steps.wait-for-build.outputs.conclusion == 'success' &&
+        (github.event_name != 'workflow_dispatch' || github.ref_name == ${{ github.event.repository.default_branch }})
       working-directory: 'rspec'
       run: |
         git checkout master


### PR DESCRIPTION
- Fixes error at https://github.com/SonarSource/rspec/actions/runs/10004012710
  ```
  Run andymckay/cancel-action@0.2
  Error: Resource not accessible by integration
  ```
- Enable testing: when manually triggered from a non-default branch, the results will not be pushed

Successful run: https://github.com/SonarSource/rspec/actions/runs/10004036543