### PR TITLE
Fix coverage script when there is no new coverage

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -88,7 +88,7 @@ jobs:
       if: |
         steps.gen-coverage.outputs.new_coverage == 'true' &&
         steps.wait-for-build.outputs.conclusion == 'success' &&
-        (github.event_name != 'workflow_dispatch' || github.ref_name == ${{ github.event.repository.default_branch }})
+        (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       working-directory: 'rspec'
       run: |
         git checkout master


### PR DESCRIPTION
The previous change to the task `'Push the updated coverage to master'` made it passthrough because it used `{{` as part of the condition, which seems to be forbidden.
Changing the condition to what we usually use to check default_branch in other workflow scripts throughout our repositories.