### PR TITLE
Modify rule S2053: Update salt length to be 32 bytes everywhere

### DIFF
--- a/rules/S2053/csharp/how-to-fix-it/dot-net.adoc
+++ b/rules/S2053/csharp/how-to-fix-it/dot-net.adoc
@@ -25,7 +25,7 @@ using System.Security.Cryptography;
 
 public static void hash(string password)
 {
-    var hashed = new Rfc2898DeriveBytes(password, 16);
+    var hashed = new Rfc2898DeriveBytes(password, 32, 10000, HashAlgorithmName.SHA256);
 }
 ----
 

--- a/rules/S2053/kotlin/how-to-fix-it/java-se.adoc
+++ b/rules/S2053/kotlin/how-to-fix-it/java-se.adoc
@@ -25,7 +25,7 @@ import javax.crypto.spec.PBEParameterSpec
 
 fun hash() {
     val random = SecureRandom()
-    val salt = ByteArray(16)
+    val salt = ByteArray(32)
     random.nextBytes(salt)
     val cipherSpec = PBEParameterSpec(salt, 10000)
 }

--- a/rules/S2053/php/how-to-fix-it/core.adoc
+++ b/rules/S2053/php/how-to-fix-it/core.adoc
@@ -16,7 +16,7 @@ $hash = hash_pbkdf2('sha256', $password, $salt, 100000); // Noncompliant
 
 [source,php,diff-id=1,diff-type=compliant]
 ----
-$salt = random_bytes(16);
+$salt = random_bytes(32);
 $hash = hash_pbkdf2('sha256', $password, $salt, 100000);
 ----
 

--- a/rules/S2053/vbnet/how-to-fix-it/dot-net.adoc
+++ b/rules/S2053/vbnet/how-to-fix-it/dot-net.adoc
@@ -23,7 +23,7 @@ End Sub
 Imports System.Security.Cryptography
 
 Public Sub Hash(Password As String)
-    Dim Hashed As New Rfc2898DeriveBytes(Password, 64)
+    Dim Hashed As New Rfc2898DeriveBytes(password, 32, 10000, HashAlgorithmName.SHA256)
 End Sub
 ----
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

