### PR TITLE
Update rule S2807: typos

### DIFF
--- a/rules/S2807/cfamily/rule.adoc
+++ b/rules/S2807/cfamily/rule.adoc
@@ -68,7 +68,8 @@ namespace lib {
 }
 ----
 
-The `operator/` will be considered as a candidate for any call `a / b` when either `a` or `b` is the namespace `lib`.
+The `operator/` will be considered as a candidate for any call `a / b`
+when either `a` or `b` are of a type declared in the namespace `lib`.
 This not only makes compilation slower but also lists the function as a candidate in case of a compilation error,
 making such a message less readable.
 
@@ -138,7 +139,7 @@ public:
   }
 };
 ----
-The call `i + 10` is well-formed and resolves to `i.operator(10)`,
+The call `i + 10` is well-formed and resolves to `i.operator+(10)`,
 which will convert `10` to an `Integer` object using the implicit converting constructor.
 However, `10 + i` is ill-formed.
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

