### PR TITLE
Deprecate rule S2387

### DIFF
--- a/rules/S2387/csharp/metadata.json
+++ b/rules/S2387/csharp/metadata.json
@@ -1,5 +1,5 @@
 {
-  "defaultQualityProfiles": [
-    
-  ]
+  "status": "deprecated",
+  "tags": [],
+  "defaultQualityProfiles": []
 }

--- a/rules/S2387/vbnet/metadata.json
+++ b/rules/S2387/vbnet/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "status": "deprecated",
+  "tags": [],
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
Superseded by [CS0108](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0108) in C#
Superseded by [BC40004](https://learn.microsoft.com/en-us/dotnet/visual-basic/misc/bc40004) in VB.NET
