### PR TITLE
Deprecate Rule S2325 for C#

### DIFF
--- a/rules/S2325/comments-and-links.adoc
+++ b/rules/S2325/comments-and-links.adoc
@@ -2,7 +2,7 @@
 I modified the noncompliant-compliant comment in the code. Apart from this, this rule is now implemented for C#
 
 === on 11 May 2015, 13:53:01 Ann Campbell wrote:
-FYI [~tamas.vajk] there's no need to explicitly mark anything Compliant in the Compliant Solution (updated). 
+FYI [~tamas.vajk] there's no need to explicitly mark anything Compliant in the Compliant Solution (updated).
 
 Thanks for the corrections.
 
@@ -24,8 +24,10 @@ Changed the ``++String++`` to ``++string++`` in the samples, but otherwise it LG
 === on 4 Jun 2015, 12:57:17 Tamas Vajk wrote:
 \[~ann.campbell.2] Calling a ``++static++`` method is slightly more performant than calling a non-``++static++`` one, because there is no need to pass the ``++this++`` reference. But the performance difference is tiny if any.
 
-
 I found this on the topic:
 
 http://stackoverflow.com/questions/12279438/performance-of-static-methods-vs-instance-methods
+
+=== on 5 Aug 2024, 14:46:29 Zsolt Kolbay wrote:
+I'm deprecating the C# rule as it's fully covered by the CA1822 analyzer from Microsoft (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822).
 

--- a/rules/S2325/csharp/metadata.json
+++ b/rules/S2325/csharp/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "status": "deprecated",
+  "tags": [],
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
The rule is covered by the [CA1822](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822) analyzer from Microsoft.