### PR TITLE
Modify S2325: Promote C# rule to Sonar-Way

### DIFF
--- a/rules/S2325/csharp/metadata.json
+++ b/rules/S2325/csharp/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ]
 }

--- a/rules/S2325/csharp/rule.adoc
+++ b/rules/S2325/csharp/rule.adoc
@@ -1,65 +1,86 @@
 == Why is this an issue?
 
-Methods and properties that don't access instance data can be ``++static++`` to prevent any misunderstanding about the contract of the method.
+Methods and properties that don't access instance data should be marked as `static` for the following reasons:
 
+* Clarity and Intent: Marking a method/property as static makes it clear that the method does not depend on instance data and can be called without creating an instance of the class. This improves the readability of the code by clearly conveying the member's intended use.
+* Performance: Instance methods/properties in C# require an instance of the class to be called. This means that even if the it doesn't use any instance data, the runtime still needs to pass a reference to the instance during the call. For static methods and properties, this overhead is avoided, leading to slightly better performance.
+* Memory Usage: Since instance methods implicitly carry a reference to the instance (the caller object), they can potentially prevent the garbage collector from collecting the instance whem it is not otherwise referenced. Static members do not carry this overhead, potentially reducing memory usage.
+* Testing: Static members can be easier to test since they do not require an instance of the class. This can simplify unit testing and reduce the amount of boilerplate code needed to set up tests.
 
-=== Noncompliant code example
+=== Exceptions
 
-[source,csharp]
+Methods with the following names are excluded because they can't be made `static`:
+
+* https://learn.microsoft.com/en-us/dotnet/api/system.web.httpapplication.authenticaterequest[Application_AuthenticateRequest]
+* https://learn.microsoft.com/en-us/dotnet/api/system.web.httpapplication.beginrequest[Application_BeginRequest]
+* https://learn.microsoft.com/en-us/previous-versions/aspnet/ms178473(v=vs.100)[Application_End]
+* https://learn.microsoft.com/en-us/dotnet/api/system.web.httpapplication.endrequest[Application_EndRequest]
+* https://learn.microsoft.com/en-us/previous-versions/aspnet/24395wz3(v=vs.100)[Application_Error]
+* https://learn.microsoft.com/en-us/previous-versions/aspnet/ms178473(v=vs.100)[Application_Init]
+* https://learn.microsoft.com/en-us/previous-versions/aspnet/ms178473(v=vs.100)[Application_Start]
+* https://learn.microsoft.com/en-us/dotnet/api/system.web.sessionstate.sessionstatemodule.end[Session_End]
+* https://learn.microsoft.com/en-us/dotnet/api/system.web.sessionstate.sessionstatemodule.start[Session_Start]
+
+== How to fix it
+
+=== Code examples
+
+==== Noncompliant code example
+
+[source,csharp,diff-id=1,diff-type=noncompliant]
 ----
 public class Utilities
 {
-    public int MagicNum // Noncompliant
+    public int MagicNum // Noncompliant - only returns a constant value
     {
-        get 
+        get
         {
             return 42;
         }
     }
 
     private static string magicWord = "please";
-    public string MagicWord  // Noncompliant
+    public string MagicWord  // Noncompliant - only accesses a static field
     {
-        get 
+        get
         {
             return magicWord;
         }
-        set 
+        set
         {
             magicWord = value;
         }
   }
 
-    public int Sum(int a, int b)  // Noncompliant
+    public int Sum(int a, int b)  // Noncompliant - doesn't access instance data, only the method parameters
     {
         return a + b;
     }
 }
 ----
 
+==== Compliant solution
 
-=== Compliant solution
-
-[source,csharp]
+[source,csharp,diff-id=1,diff-type=compliant]
 ----
 public class Utilities
 {
     public static int MagicNum
     {
-        get 
+        get
         {
             return 42;
         }
     }
 
     private static string magicWord = "please";
-    public static string MagicWord 
+    public static string MagicWord
     {
-        get 
+        get
         {
             return magicWord;
         }
-        set 
+        set
         {
             magicWord = value;
         }
@@ -72,21 +93,11 @@ public class Utilities
 }
 ----
 
+== Resources
 
-=== Exceptions
+=== Documentation
 
-Methods with the following names are excluded because they can't be made ``++static++``:
-
-* Application_AuthenticateRequest
-* Application_BeginRequest
-* Application_End
-* Application_EndRequest
-* Application_Error
-* Application_Init
-* Application_Start
-* Session_End
-* Session_Start
-
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/static[The static modifier]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
Although it rule is covered by the [CA1822](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822) Roslyn analyzer, but that doesn't show up in SQ, because by default it's only a Suggestion rather than a Warning.
