### PR TITLE
Modifiy S2325 & S2674: Fix typo and missing links

### DIFF
--- a/rules/S2325/csharp/rule.adoc
+++ b/rules/S2325/csharp/rule.adoc
@@ -50,7 +50,7 @@ public class Utilities
         {
             magicWord = value;
         }
-  }
+    }
 
     public int Sum(int a, int b)  // Noncompliant - doesn't access instance data, only the method parameters
     {

--- a/rules/S2674/csharp/rule.adoc
+++ b/rules/S2674/csharp/rule.adoc
@@ -58,7 +58,8 @@ public byte[] ReadFile(string fileName)
 
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.read[Stream.Read Method]
 * Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readasync[Stream.ReadAsync Method]
-
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readatleast[Stream.ReadAtLeast Method]
+* Microsoft Learn - https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.readatleastasync[Stream.ReadAtLeastAsync Method]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

