### PR TITLE
Modify rule S3257: add rspecator and fix resources layout

### DIFF
--- a/rules/S3257/dart/rule.adoc
+++ b/rules/S3257/dart/rule.adoc
@@ -28,4 +28,26 @@ var occurrences = Map<String, int>();
 
 == Resources
 
+=== Documentation
+
 * Dart Docs - https://dart.dev/tools/linter-rules/prefer_collection_literals[Dart Linter rule - prefer_collection_literals]
+
+ifdef::env-github,rspecator-view[]
+
+'''
+== Implementation Specification
+(visible only on this page)
+
+=== Message
+
+Unnecessary constructor invocation.
+
+=== Highlighting
+
+The entire constructor invocation expression, including the type and the parentheses (e.g. `Set<int>()`).
+
+'''
+== Comments And Links
+(visible only on this page)
+
+endif::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

