### PR TITLE
Modify rule S4123: remove ref to other RSPEC

### DIFF
--- a/rules/S4123/dart/rule.adoc
+++ b/rules/S4123/dart/rule.adoc
@@ -25,10 +25,6 @@ await x;
 * Dart Docs - https://dart.dev/tools/linter-rules/await_only_futures[Dart Linter rule - await_only_futures]
 * Dart Docs - https://dart.dev/libraries/async/async-await[Asynchronous programming: futures, async, await]
 
-=== Related rules
-
-* S6315 - The return value of functions returning "Future" should be used
-
 ifdef::env-github,rspecator-view[]
 
 '''


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

