### PR TITLE
Modify rule S3715: Mention empty initializer before C23

### DIFF
--- a/rules/S3715/cfamily/rule.adoc
+++ b/rules/S3715/cfamily/rule.adoc
@@ -11,6 +11,7 @@ Proprietary compiler extensions can be handy, but they commit you to always usin
 * A structure member initializer with a colon
 * Decimal floating points numbers ``++_Decimal32++``, ``++_Decimal64++``, and ``++_Decimal128++``
 * Structures and union without named data members
+* Empty initializers ``= {}`` in pre-C23 code, as the feature was standardized in C23
 
 === Noncompliant code example
 


### PR DESCRIPTION
Do not merge before MMF-3874 is merged