### PR TITLE
SONARFLEX-176 Deprecate Flex rules

### DIFF
--- a/rules/S100/flex/metadata.json
+++ b/rules/S100/flex/metadata.json
@@ -1,2 +1,5 @@
 {
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1005/flex/metadata.json
+++ b/rules/S1005/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S101/flex/metadata.json
+++ b/rules/S101/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S103/flex/metadata.json
+++ b/rules/S103/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1066/flex/metadata.json
+++ b/rules/S1066/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1068/flex/metadata.json
+++ b/rules/S1068/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S107/flex/metadata.json
+++ b/rules/S107/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S108/flex/metadata.json
+++ b/rules/S108/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1116/flex/metadata.json
+++ b/rules/S1116/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1117/flex/metadata.json
+++ b/rules/S1117/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Local variables should not shadow class fields"
+  "title": "Local variables should not shadow class fields",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1125/flex/metadata.json
+++ b/rules/S1125/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1135/flex/metadata.json
+++ b/rules/S1135/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1142/flex/metadata.json
+++ b/rules/S1142/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1144/flex/metadata.json
+++ b/rules/S1144/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Unused \"private\" functions should be removed"
+  "title": "Unused \"private\" functions should be removed",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1145/flex/metadata.json
+++ b/rules/S1145/flex/metadata.json
@@ -1,2 +1,5 @@
 {
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S115/flex/metadata.json
+++ b/rules/S115/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1151/flex/metadata.json
+++ b/rules/S1151/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S116/flex/metadata.json
+++ b/rules/S116/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S117/flex/metadata.json
+++ b/rules/S117/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1170/flex/metadata.json
+++ b/rules/S1170/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Public constants and fields initialized at declaration should be \"const static\" rather than merely \"const\""
+  "title": "Public constants and fields initialized at declaration should be \"const static\" rather than merely \"const\"",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1172/flex/metadata.json
+++ b/rules/S1172/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1176/flex/metadata.json
+++ b/rules/S1176/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Public classes, methods, properties and metadata should be documented with ASDoc"
+  "title": "Public classes, methods, properties and metadata should be documented with ASDoc",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1185/flex/metadata.json
+++ b/rules/S1185/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1186/flex/metadata.json
+++ b/rules/S1186/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S120/flex/metadata.json
+++ b/rules/S120/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S122/flex/metadata.json
+++ b/rules/S122/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1224/flex/metadata.json
+++ b/rules/S1224/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1224/flex/metadata.json
+++ b/rules/S1224/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S124/flex/metadata.json
+++ b/rules/S124/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S125/flex/metadata.json
+++ b/rules/S125/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S127/flex/metadata.json
+++ b/rules/S127/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S128/flex/metadata.json
+++ b/rules/S128/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S129/flex/metadata.json
+++ b/rules/S129/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S129/flex/metadata.json
+++ b/rules/S129/flex/metadata.json
@@ -1,5 +1,10 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "10min"
+  }
 }

--- a/rules/S1301/flex/metadata.json
+++ b/rules/S1301/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S131/flex/metadata.json
+++ b/rules/S131/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1311/flex/metadata.json
+++ b/rules/S1311/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1312/flex/metadata.json
+++ b/rules/S1312/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Loggers should be \"private static const\" and should share naming convention"
+  "title": "Loggers should be \"private static const\" and should share naming convention",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1314/flex/metadata.json
+++ b/rules/S1314/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1320/flex/metadata.json
+++ b/rules/S1320/flex/metadata.json
@@ -7,18 +7,14 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "2min"
   },
-  "tags": [
-    "obsolete"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
+    "replacementRules": [],
     "legacyKeys": [
       "ActionScript2"
     ]
@@ -27,8 +23,6 @@
   "ruleSpecification": "RSPEC-1320",
   "sqKey": "ActionScript2",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1321/flex/metadata.json
+++ b/rules/S1321/flex/metadata.json
@@ -1,6 +1,6 @@
 {
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
   "code": {
@@ -10,7 +10,7 @@
     "attribute": "CLEAR"
   },
   "defaultSeverity": "Major",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": [],
+  "tags": [],
+  "status": "deprecated"
 }

--- a/rules/S134/flex/metadata.json
+++ b/rules/S134/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Control flow statements \"if\", \"for\", \"while\" and \"switch\" should not be nested too deeply"
+  "title": "Control flow statements \"if\", \"for\", \"while\" and \"switch\" should not be nested too deeply",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S138/flex/metadata.json
+++ b/rules/S138/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S140/flex/metadata.json
+++ b/rules/S140/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1434/flex/metadata.json
+++ b/rules/S1434/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CLEAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "20min"
   },
-  "tags": [
-    "suspicious"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1434",
   "sqKey": "S1434",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1435/flex/metadata.json
+++ b/rules/S1435/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CLEAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-    "unpredictable"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1435",
   "sqKey": "S1435",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1438/flex/metadata.json
+++ b/rules/S1438/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1439/flex/metadata.json
+++ b/rules/S1439/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1440/flex/metadata.json
+++ b/rules/S1440/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1442/flex/metadata.json
+++ b/rules/S1442/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "\"Alert.show(...)\" should not be used"
+  "title": "\"Alert.show(...)\" should not be used",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1444/flex/metadata.json
+++ b/rules/S1444/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1445/flex/metadata.json
+++ b/rules/S1445/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CLEAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "confusing"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-1445",
   "sqKey": "S1445",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1446/flex/metadata.json
+++ b/rules/S1446/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CLEAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "30min"
   },
-  "tags": [
-    "pitfall"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-1446",
   "sqKey": "S1446",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1447/flex/metadata.json
+++ b/rules/S1447/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "EFFICIENT"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "performance"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1447",
   "sqKey": "S1447",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1448/flex/metadata.json
+++ b/rules/S1448/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1451/flex/metadata.json
+++ b/rules/S1451/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1454/flex/metadata.json
+++ b/rules/S1454/flex/metadata.json
@@ -3,26 +3,20 @@
   "type": "BUG",
   "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "2min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
       "RSPEC-881"
     ],
-    "legacyKeys": [
-
-    ]
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1454",
   "sqKey": "S1454",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1455/flex/metadata.json
+++ b/rules/S1455/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "obsolete"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-1455",
   "sqKey": "S1455",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1462/flex/metadata.json
+++ b/rules/S1462/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "MODULAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "design"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1462",
   "sqKey": "S1462",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1463/flex/metadata.json
+++ b/rules/S1463/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "design"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1463",
   "sqKey": "S1463",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1464/flex/metadata.json
+++ b/rules/S1464/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1464",
   "sqKey": "S1464",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1465/flex/metadata.json
+++ b/rules/S1465/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1465",
   "sqKey": "S1465",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1466/flex/metadata.json
+++ b/rules/S1466/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-1466",
   "sqKey": "S1466",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1467/flex/metadata.json
+++ b/rules/S1467/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "LOGICAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1467",
   "sqKey": "S1467",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1468/flex/metadata.json
+++ b/rules/S1468/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "COMPLETE"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-1468",
   "sqKey": "S1468",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1469/flex/metadata.json
+++ b/rules/S1469/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-    "pitfall"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-1469",
   "sqKey": "S1469",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1470/flex/metadata.json
+++ b/rules/S1470/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "LOGICAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "5min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-1470",
   "sqKey": "S1470",
   "scope": "Main",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1472/flex/metadata.json
+++ b/rules/S1472/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1477/flex/metadata.json
+++ b/rules/S1477/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1481/flex/metadata.json
+++ b/rules/S1481/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1482/flex/metadata.json
+++ b/rules/S1482/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1483/flex/metadata.json
+++ b/rules/S1483/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1484/flex/metadata.json
+++ b/rules/S1484/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1541/flex/metadata.json
+++ b/rules/S1541/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1606/flex/metadata.json
+++ b/rules/S1606/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1677/flex/metadata.json
+++ b/rules/S1677/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1677/flex/metadata.json
+++ b/rules/S1677/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S1784/flex/metadata.json
+++ b/rules/S1784/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1820/flex/metadata.json
+++ b/rules/S1820/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1821/flex/metadata.json
+++ b/rules/S1821/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1871/flex/metadata.json
+++ b/rules/S1871/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1950/flex/metadata.json
+++ b/rules/S1950/flex/metadata.json
@@ -3,26 +3,20 @@
   "type": "BUG",
   "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "15min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
       "RSPEC-1862"
     ],
-    "legacyKeys": [
-
-    ]
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-1950",
   "sqKey": "S1950",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1951/flex/metadata.json
+++ b/rules/S1951/flex/metadata.json
@@ -3,26 +3,20 @@
   "type": "VULNERABILITY",
   "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "2min"
   },
-  "tags": [
-
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
       "RSPEC-4507"
     ],
-    "legacyKeys": [
-
-    ]
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-1951",
   "sqKey": "S1951",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S1952/flex/metadata.json
+++ b/rules/S1952/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S1982/flex/metadata.json
+++ b/rules/S1982/flex/metadata.json
@@ -7,28 +7,20 @@
     },
     "attribute": "EFFICIENT"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
-    "func": "Constant\/Issue",
+    "func": "Constant/Issue",
     "constantCost": "20min"
   },
-  "tags": [
-    "performance"
-  ],
+  "tags": [],
   "extra": {
-    "replacementRules": [
-
-    ],
-    "legacyKeys": [
-
-    ]
+    "replacementRules": [],
+    "legacyKeys": []
   },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-1982",
   "sqKey": "S1982",
   "scope": "Main",
-  "defaultQualityProfiles": [
-
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S2155/flex/metadata.json
+++ b/rules/S2155/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2155/flex/metadata.json
+++ b/rules/S2155/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S2224/flex/metadata.json
+++ b/rules/S2224/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2224/flex/metadata.json
+++ b/rules/S2224/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S2260/flex/metadata.json
+++ b/rules/S2260/flex/metadata.json
@@ -1,3 +1,6 @@
 {
-  "title": "Flex parser failure"
+  "title": "Flex parser failure",
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2495/flex/metadata.json
+++ b/rules/S2495/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2495/flex/metadata.json
+++ b/rules/S2495/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S2595/flex/metadata.json
+++ b/rules/S2595/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2595/flex/metadata.json
+++ b/rules/S2595/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S2608/flex/metadata.json
+++ b/rules/S2608/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2630/flex/metadata.json
+++ b/rules/S2630/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2630/flex/metadata.json
+++ b/rules/S2630/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S2751/flex/metadata.json
+++ b/rules/S2751/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S2751/flex/metadata.json
+++ b/rules/S2751/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3045/flex/metadata.json
+++ b/rules/S3045/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3045/flex/metadata.json
+++ b/rules/S3045/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3221/flex/metadata.json
+++ b/rules/S3221/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3221/flex/metadata.json
+++ b/rules/S3221/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3255/flex/metadata.json
+++ b/rules/S3255/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3255/flex/metadata.json
+++ b/rules/S3255/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3424/flex/metadata.json
+++ b/rules/S3424/flex/metadata.json
@@ -1,2 +1,5 @@
 {
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3502/flex/metadata.json
+++ b/rules/S3502/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3502/flex/metadata.json
+++ b/rules/S3502/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3554/flex/metadata.json
+++ b/rules/S3554/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S3554/flex/metadata.json
+++ b/rules/S3554/flex/metadata.json
@@ -1,5 +1,6 @@
 {
   "tags": [],
   "status": "deprecated",
-  "defaultQualityProfiles": []
+  "defaultQualityProfiles": [],
+  "quickfix": "unknown"
 }

--- a/rules/S3923/flex/metadata.json
+++ b/rules/S3923/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S4507/flex/metadata.json
+++ b/rules/S4507/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S4524/flex/metadata.json
+++ b/rules/S4524/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }

--- a/rules/S800/flex/metadata.json
+++ b/rules/S800/flex/metadata.json
@@ -1,3 +1,5 @@
 {
-  
+  "tags": [],
+  "status": "deprecated",
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
I used this script to update the metadata of flex rules:

```js
const path = require('path');
const fs = require('fs');

const RULES_FOLDER = path.join(__dirname, 'rules');

const flexMetadataFiles = findFlexMetadata(RULES_FOLDER);
flexMetadataFiles.map(flexMetadataFile => {
  const metadata = deprecateMetadata(flexMetadataFile);
  fs.writeFileSync(flexMetadataFile, JSON.stringify(metadata, null, 2));
});

function deprecateMetadata(metadataFile) {
  const metadata = JSON.parse(fs.readFileSync(metadataFile));
  metadata.tags = [];
  metadata.status = 'deprecated';
  metadata.defaultQualityProfiles = [];
  return metadata;
}

function findFlexMetadata() {
  const ruleFolders = fs.readdirSync(RULES_FOLDER);
  const rulesWithFlex = ruleFolders.filter(hasFlexFolder);
  return rulesWithFlex.map((ruleFolder) => {
    return path.join(RULES_FOLDER, ruleFolder, 'flex', 'metadata.json');
  });

  function hasFlexFolder(ruleFolder) {
    const rulePath = path.join(RULES_FOLDER, ruleFolder);
    const ruleFiles = fs.readdirSync(rulePath);
    if (ruleFiles.some((ruleFile) => ruleFile === 'flex')) {
      return true;
    }
    return false;
  }
}
```