### PR TITLE
Modify rule S6651: fix erroneous inclusion in SonarWay

### DIFF
--- a/rules/S6651/java/metadata.json
+++ b/rules/S6651/java/metadata.json
@@ -38,7 +38,6 @@
     ]
   },
   "defaultQualityProfiles": [
-    "Sonar way"
   ],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

