### PR TITLE
Modify rule S2175: add spaces to the why section

### DIFF
--- a/rules/S2175/dart/rule.adoc
+++ b/rules/S2175/dart/rule.adoc
@@ -1,6 +1,8 @@
 == Why is this an issue?
 
-The Dart collections API has methods that allow developers to overcome type-safety restriction of the parameter, such as `Iterable.contains`. When the actual type of the object provided to these methods is not consistent with the target collection's actual type, those methods will always return `false` or `null`. This is most likely unintended and hides a design problem.
+The Dart collections API has methods that allow developers to overcome type-safety restriction of the parameter, such as `Iterable.contains`. 
+
+When the actual type of the object provided to these methods is not consistent with the target collection's actual type, those methods will always return `false` or `null`. This is most likely unintended and hides a design problem.
 
 This rule raises an issue when the type of the argument of the following APIs is unrelated to the type used for the collection declaration:
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

