### PR TITLE
Modify rule S5416: add spaces to the why section

### DIFF
--- a/rules/S5416/dart/rule.adoc
+++ b/rules/S5416/dart/rule.adoc
@@ -1,7 +1,10 @@
 == Why is this an issue?
 
 In Dart type aliases can be declared via function type aliases `typedef void F()` or generic function type aliases  `typedef F = void Function()`. Generic function type aliases can be parametrized `typedef Compare<T> = int Function(T a, T b);`. Function type aliases miss this feature.
-While it's not always needed to have them parametrized, for the sake of readability it's recommended to use consistent way of declaring type aliases. Thus, generic function type aliases should be preferred.
+
+While it's not always needed to have them parametrized, for the sake of readability it's recommended to use consistent way of declaring type aliases. 
+
+Thus, generic function type aliases should be preferred.
 
 === Noncompliant code example
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

