### PR TITLE
Modify rule S7045: fix list formatting in Why section

### DIFF
--- a/rules/S7045/dart/rule.adoc
+++ b/rules/S7045/dart/rule.adoc
@@ -9,6 +9,7 @@ The compiler enforces access restrictions so that private elements can only be a
 Because local variables and parameters are only accessible within the scope in which they are declared, and cannot be exposed to other libraries, the private accessibility scope doesn't apply to them. Using an underscore prefix for local variables suggests otherwise and can be misleading.
 
 This rule applies to local variables and parameters of:
+
 * top-level functions
 * nested functions and lambdas
 * class methods


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

