### PR TITLE
Modify rule S7045: Fix underscore escaping in rule description

### DIFF
--- a/rules/S7045/dart/rule.adoc
+++ b/rules/S7045/dart/rule.adoc
@@ -18,7 +18,7 @@ This rule applies to local variables and parameters of:
 
 === Exceptions
 
-Unused parameters are typically named ``++_++``, ``++__++``, etc. to indicate that they are intentionally unused. This is a common practice and is not considered a violation of this rule.
+Unused parameters are typically named ``++__++``, ``++___++``, etc. to indicate that they are intentionally unused. This is a common practice and is not considered a violation of this rule.
 
 Typical examples of this practice arise with lambdas:
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

