### PR TITLE
Modify rule S7047: Fix formatting of inline code

### DIFF
--- a/rules/S7047/dart/rule.adoc
+++ b/rules/S7047/dart/rule.adoc
@@ -6,7 +6,7 @@ Given a type parameter `T`, the type `T?` is nullable version of `T`, i.e. A var
 
 However, when `T` itself is bound to a nullable type, a variable `y` of type `T` can hold a `null` value by itself. For example, if `y` is defined as `int?`, `null` is a valid value for `y`.
 
-Therefore, when `T` is bound to a nullable type, `x` can be hold `null` as a valid value, which means that `x!` is an incorrect check for the validity of `x`, since it would raise a runtime exception when `x ` holds `null`.
+Therefore, when `T` is bound to a nullable type, `x` can hold `null` as a valid value, which means that `x!` is an incorrect check for the validity of `x`, since it would raise a runtime exception when `x` holds `null`.
 
 [source,dart]
 ----


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

