### PR TITLE
Modify rule S6024: Remove useless paretheses

### DIFF
--- a/rules/S6024/cfamily/rule.adoc
+++ b/rules/S6024/cfamily/rule.adoc
@@ -20,8 +20,8 @@ When writing generic code, you should prefer using those functions for objects t
 template<class T>
 bool f(T const &t, std::vector<int> const &v) {
   if (!t.empty()) { // Noncompliant in C++17
-    auto val = (t.begin() // Noncompliant in C++11
-      ->size()); // Noncompliant in C++17
+    auto val = t.begin() // Noncompliant in C++11
+      ->size(); // Noncompliant in C++17
     return val == v.size(); // Compliant, v does not depend on a template parameter
   }
   return false;


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

