### PR TITLE
Modify Rule S2260: update Dart metadata

### DIFF
--- a/rules/S2260/dart/metadata.json
+++ b/rules/S2260/dart/metadata.json
@@ -1,3 +1,10 @@
 {
-  "title": "Dart analyzer failure"
+  "title": "Dart analyzer failure",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "0min"
+  },
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ]
 }


### PR DESCRIPTION
As discussed with @agigleux , this rule should be included in "Sonar way" at least in the first release.