### PR TITLE
Explicit permissions for GITHUB_TOKEN where write is needed

### DIFF
--- a/.github/workflows/add_language.yml
+++ b/.github/workflows/add_language.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   add_language_to_rule:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create_new_rspec.yml
+++ b/.github/workflows/create_new_rspec.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   create_new_rule:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update_quickfix_status.yml
+++ b/.github/workflows/update_quickfix_status.yml
@@ -26,6 +26,9 @@ jobs:
   update_quickfix_status:
     name: Update quick fix status
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
The default GITHUB_TOKEN permissions will be set to read-only organization-wide. See https://sonarsource.atlassian.net/browse/SSF-619 for background information.

Changes were tested in:

 - https://github.com/SonarSource/rspec/actions/runs/10761394392
 - https://github.com/SonarSource/rspec/actions/runs/10761442606
