### PR TITLE
Close S7063 for javascript

### DIFF
--- a/rules/S7063/javascript/metadata.json
+++ b/rules/S7063/javascript/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "Module with exports should not include side effects",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "closed",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "20min"


### PR DESCRIPTION
We decided not to go ahead with this rule. Let us close it.