### PR TITLE
Modify Rule S3949: Add missing tag for CFamily

### DIFF
--- a/rules/S3949/cfamily/metadata.json
+++ b/rules/S3949/cfamily/metadata.json
@@ -4,6 +4,7 @@
     "overflow",
     "based-on-misra",
     "cert",
+    "symbolic-execution",
     "misra-c2004",
     "misra-c2012"
   ],


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

