### PR TITLE
Modify rule S3881: Remove typo in code example

### DIFF
--- a/rules/S3881/csharp/rule.adoc
+++ b/rules/S3881/csharp/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-The ``++IDisposable++`` interface is a mechanism to release unmanaged resources, if not implemented correctly this could result in resource leaks or more severe bugs.
+The `IDisposable` interface is a mechanism to release unmanaged resources, if not implemented correctly this could result in resource leaks or more severe bugs.
 
 
 This rule raises an issue when the recommended dispose pattern, as defined by Microsoft, is not adhered to. See the *Compliant Solution* section for examples.
@@ -8,14 +8,13 @@ This rule raises an issue when the recommended dispose pattern, as defined by Mi
 
 Satisfying the rule's conditions will enable potential derived classes to correctly dispose the members of your class:
 
-* ``++sealed++`` classes are not checked.
-* If a base class implements ``++IDisposable++`` your class should not have ``++IDisposable++`` in the list of its interfaces. In such cases it is recommended to override the base class's ``++protected virtual void Dispose(bool)++`` method or its equivalent.
-* The class should not implement ``++IDisposable++`` explicitly, e.g. the ``++Dispose()++`` method should be public.
-* The class should contain ``++protected virtual void Dispose(bool)++`` method. This method allows the derived classes to correctly dispose the resources of this class.
-* The content of the ``++Dispose()++`` method should be invocation of ``++Dispose(true)++`` followed by ``++GC.SuppressFinalize(this)++``
-* If the class has a finalizer, i.e. a destructor, the only code in its body should be a single invocation of ``++Dispose(false)++``.
-* If the class inherits from a class that implements ``++IDisposable++`` it must call the ``++Dispose++``, or ``++Dispose(bool)++`` method of the base class from within its own implementation of ``++Dispose++`` or ``++Dispose(bool)++``, respectively. This ensures that all resources from the base class are properly released.
-
+* `sealed` classes are not checked.
+* If a base class implements `IDisposable` your class should not have `IDisposable` in the list of its interfaces. In such cases it is recommended to override the base class's `protected virtual void Dispose(bool)` method or its equivalent.
+* The class should not implement `IDisposable` explicitly, e.g. the `Dispose()` method should be public.
+* The class should contain `protected virtual void Dispose(bool)` method. This method allows the derived classes to correctly dispose the resources of this class.
+* The content of the `Dispose()` method should be invocation of `Dispose(true)` followed by `GC.SuppressFinalize(this)`
+* If the class has a finalizer, i.e. a destructor, the only code in its body should be a single invocation of `Dispose(false)`.
+* If the class inherits from a class that implements `IDisposable` it must call the `Dispose`, or `Dispose(bool)` method of the base class from within its own implementation of `Dispose` or `Dispose(bool)`, respectively. This ensures that all resources from the base class are properly released.
 
 === Noncompliant code example
 
@@ -61,8 +60,7 @@ public class Foo3 : IDisposable
     {
         // Cleanup
     }
-}{code}
-
+}
 ----
 
 === Compliant solution
@@ -128,7 +126,7 @@ public class Foo4 : DisposableBase
 
 == Resources
 
-Refer to 
+=== Documentation
 
 * https://msdn.microsoft.com/en-us/library/498928w2.aspx[MSDN] for complete documentation on the dispose pattern.
 * https://blog.stephencleary.com/2009/08/how-to-implement-idisposable-and.html[Stephen Cleary] for excellent Q&A about IDisposable
@@ -144,7 +142,7 @@ ifdef::env-github,rspecator-view[]
 
 === Message
 
-Fix this implementation of ``++IDisposable++`` to conform to the dispose pattern.
+Fix this implementation of `IDisposable` to conform to the dispose pattern.
 
 
 '''


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [x] logical errors and incorrect information
- [x] information gaps and missing content
- [x] text style and tone
- [x] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

