### PR TITLE
JS-332 Add `type-dependent` tag to TypeScript variant of RSPEC 2301

### DIFF
--- a/rules/S2301/javascript/metadata.json
+++ b/rules/S2301/javascript/metadata.json
@@ -2,5 +2,9 @@
   "title": "Methods should not contain selector parameters",
   "defaultQualityProfiles": [
     "Sonar way"
+  ],
+  "tags": [
+    "design",
+    "type-dependent"
   ]
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

