### PR TITLE
JS-277 Update rules with missing `code` tag

### DIFF
--- a/rules/S1441/javascript/metadata.json
+++ b/rules/S1441/javascript/metadata.json
@@ -20,5 +20,11 @@
   "quickfix": "covered",
   "defaultQualityProfiles": [],
   "status": "deprecated",
-  "tags": []
+  "tags": [],
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "FORMATTED"
+  }
 }

--- a/rules/S1537/metadata.json
+++ b/rules/S1537/metadata.json
@@ -24,5 +24,11 @@
   "defaultQualityProfiles": [
 
   ],
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW"
+    },
+    "attribute": "FORMATTED"
+  }
 }

--- a/rules/S2260/javascript/metadata.json
+++ b/rules/S2260/javascript/metadata.json
@@ -1,4 +1,11 @@
 {
   "title": "JavaScript parser failure",
-  "scope": "Main"
+  "scope": "Main",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM",
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S2310/javascript/metadata.json
+++ b/rules/S2310/javascript/metadata.json
@@ -24,5 +24,11 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
 }

--- a/rules/S3523/javascript/metadata.json
+++ b/rules/S3523/javascript/metadata.json
@@ -24,5 +24,11 @@
   "defaultQualityProfiles": [
 
   ],
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S3723/metadata.json
+++ b/rules/S3723/metadata.json
@@ -22,5 +22,11 @@
   "sqKey": "S3723",
   "scope": "All",
   "defaultQualityProfiles": [],
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "FORMATTED"
+  }
 }

--- a/rules/S6660/javascript/metadata.json
+++ b/rules/S6660/javascript/metadata.json
@@ -13,5 +13,11 @@
   "sqKey": "S6660",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "covered"
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S6661/javascript/metadata.json
+++ b/rules/S6661/javascript/metadata.json
@@ -14,5 +14,11 @@
   "sqKey": "S6661",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "covered"
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S6666/javascript/metadata.json
+++ b/rules/S6666/javascript/metadata.json
@@ -13,5 +13,11 @@
   "sqKey": "S6666",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "covered"
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S6671/javascript/metadata.json
+++ b/rules/S6671/javascript/metadata.json
@@ -13,5 +13,11 @@
   "sqKey": "S6671",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "infeasible"
+  "quickfix": "infeasible",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S6676/javascript/metadata.json
+++ b/rules/S6676/javascript/metadata.json
@@ -13,5 +13,11 @@
   "sqKey": "S6676",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "covered"
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }

--- a/rules/S6679/javascript/metadata.json
+++ b/rules/S6679/javascript/metadata.json
@@ -13,5 +13,11 @@
   "sqKey": "S6679",
   "scope": "All",
   "defaultQualityProfiles": ["Sonar way"],
-  "quickfix": "covered"
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
 }


### PR DESCRIPTION
Went through the rules in the task description and added the missing "code" tag.

