### PR TITLE
Modify rule S7036: mark as `beta`

### DIFF
--- a/rules/S7036/text/metadata.json
+++ b/rules/S7036/text/metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "Don't use offensive language",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "beta",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

