### PR TITLE
Modify rule S6485: quickfix set to covered

### DIFF
--- a/rules/S6485/java/metadata.json
+++ b/rules/S6485/java/metadata.json
@@ -22,5 +22,5 @@
   "defaultQualityProfiles": [
     "Sonar way"
   ],
-  "quickfix": "targeted"
+  "quickfix": "covered"
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

