### PR TITLE
Modify rule S7112: Fix spelling in description

### DIFF
--- a/rules/S7111/dart/rule.adoc
+++ b/rules/S7111/dart/rule.adoc
@@ -4,15 +4,14 @@
 
 Often Dart libraries are small enough to be entirely contained in a single file. 
 
-However, when the file becomes too large and it's not possible to split the library into smaller libraries (as adviced by the Dart team in the note https://dart.dev/guides/libraries/create-packages#organizing-a-package[here]), Dart defines a
-`part of` directive, which allows developers to split the library into multiple smaller chunks.
+However, when the file becomes too large and it's not possible to split the library into smaller libraries (as advised by the Dart team in the note https://dart.dev/guides/libraries/create-packages#organizing-a-package[here]), Dart defines a `part of` directive, which allows developers to split the library into multiple smaller chunks.
 
 When a library is split into multiple files, each part has to refer the library it belongs to, and it can do so with two similar but alternative syntaxes:
 
 * by name identifier: `part of my_library;`
 * by a URI string: `part of 'my_library.dart';`
 
-The second syntax is more precise and flexible, because it explicitely identifies the file that contains the main body of the library, whereas a reference by identifier needs to be resolved to a URI by the Dart compiler. 
+The second syntax is more precise and flexible, because it explicitly identifies the file that contains the main body of the library, whereas a reference by identifier needs to be resolved to a URI by the Dart compiler. 
 
 === What is the potential impact?
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

