### PR TITLE
Modify rule S7113: Fix link prefix under resources documentation

### DIFF
--- a/rules/S7113/dart/rule.adoc
+++ b/rules/S7113/dart/rule.adoc
@@ -111,7 +111,7 @@ class Point {
 * Dart Docs - https://dart.dev/tools/linter-rules/prefer_const_constructors_in_immutables[Dart Linter rule - prefer_const_constructors_in_immutables]
 * Dart Docs - https://dart.dev/language/variables#final-and-const[Language - Final and const]
 * Dart Docs - https://dart.dev/language/constructors#constant-constructors[Language - Constant constructors]
-* Flutter Docs - https://api.flutter.dev/flutter/meta/immutable-constant.html[meta.dart - immutable top-level constant]
+* Flutter API Reference - https://api.flutter.dev/flutter/meta/immutable-constant.html[meta.dart - immutable top-level constant]
 * Wikipedia - https://en.wikipedia.org/wiki/Immutable_object[Immutable object]
 
 === Related rules


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

