### PR TITLE
Modify rule S2068: Update title to "Hard-coded passwords are security-sensitive"

### DIFF
--- a/rules/S2068/python/metadata.json
+++ b/rules/S2068/python/metadata.json
@@ -1,3 +1,4 @@
 {
-  
+  "title": "Hard-coded passwords are security-sensitive",
+  "quickfix": "unknown"
 }


### PR DESCRIPTION

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

