### PR TITLE
Add guidelines to format references to code elements

### DIFF
--- a/docs/description.adoc
+++ b/docs/description.adoc
@@ -274,12 +274,11 @@ In case no language is appropriate for a code block (for example shared examples
 === References within code blocks
 
 When referencing a name within a comment in a code example, use double quotes to make it clear it refers to an existing element in the code.
+
 [source,cpp]
 ----
 int i = 0;
-cout << noexcept(++i); // Noncompliant, "i" is not incremented -> Double quotes, ok
-cout << noexcept(++i); // Noncompliant, i is not incremented -> No quotes, bad
-cout << noexcept(++i); // Noncompliant, `i` is not incremented -> Backticks, bad
+cout << noexcept(++i); // Noncompliant, "i" is not incremented
 ----
 
 === Diff view

--- a/docs/description.adoc
+++ b/docs/description.adoc
@@ -271,6 +271,17 @@ tsql:: use `sql`
 
 In case no language is appropriate for a code block (for example shared examples between multiple languages), you can use `text` as the language.
 
+=== References within code blocks
+
+When referencing a name within a comment in a code example, use double quotes to make it clear it refers to an existing element in the code.
+[source,cpp]
+----
+int i = 0;
+cout << noexcept(++i); // Noncompliant, "i" is not incremented -> Double quotes, ok
+cout << noexcept(++i); // Noncompliant, i is not incremented -> No quotes, bad
+cout << noexcept(++i); // Noncompliant, `i` is not incremented -> Backticks, bad
+----
+
 === Diff view
 
 Additionally, you can also use two attributes to let the products know your code examples should be highlighted with a diff view when possible

--- a/docs/styling_guide.adoc
+++ b/docs/styling_guide.adoc
@@ -109,3 +109,17 @@ Use it when referencing variable names, file names, tokens, and all kinds of spe
 Write:: Compiling source file `src/generic_file.py` breaks an `assert` call in pytest framework.
 Avoid:: Compiling source file "src/generic_file.py" breaks an `assert` call in `pytest` framework.
 
+== Referencing elements from the code
+
+When referencing elements from the code within a normal sentence, use the `backticks` (```) to format it. This includes variable names, function names, class names, and so on.
+
+When referencing the same elements within a comment in a code block, surrpond it with double quotes.
+[source,cpp]
+----
+int i = 0;
+// Write
+cout << noexcept(++i); // Noncompliant, "i" is not incremented -> Double quotes
+// Avoid
+cout << noexcept(++i); // Noncompliant, i is not incremented -> No quotes
+cout << noexcept(++i); // Noncompliant, `i` is not incremented -> Backticks
+----


### PR DESCRIPTION
Since the information is split into different files, I thought it better to duplicate the new guideline (I did not want to fully reorganize the doc...)