### PR TITLE
Modify rule S7007: Update example to trigger the rule

### DIFF
--- a/rules/S7007/secrets/rule.adoc
+++ b/rules/S7007/secrets/rule.adoc
@@ -27,11 +27,21 @@ include::../../../shared_content/secrets/fix/vault.adoc[]
 
 === Code examples
 
-:example_secret: 6YPElC5Wip6ECQcMHwv350RjkgONEMTn
-:example_name: tencent.secret-key
-:example_env: TENCENT_SECRET_KEY
+==== Noncompliant code example
 
-include::../../../shared_content/secrets/examples.adoc[]
+[source,java,diff-id=1,diff-type=noncompliant,subs="attributes"]
+----
+props.set("tencent.secret-id", "AKID6CtdYzpITwVpVj8rPUbVYoh8VexW0WOv");
+props.set("tencent.secret-key", "zPdkmi5UUKjqkXgJFsHf6HMOZsxNrgRk"); // Noncompliant
+----
+
+==== Compliant solution
+
+[source,java,diff-id=1,diff-type=compliant,subs="attributes"]
+----
+props.set("tencent.secret-id", System.getenv("TENCENT_SECRET_ID"));
+props.set("tencent.secret-key", System.getenv("TENCENT_SECRET_KEY"));
+----
 
 //=== How does this work?
 


### PR DESCRIPTION
While validating this rule, it was found that the noncompliant example in the RSPEC did not trigger. This is because the detection also looks for the secret ID, which is missing from the example.

The example has now been updated to include a secret ID and it now correctly triggers the rule.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

