### PR TITLE
Convention: use colon as separator in comments within code blocks

### DIFF
--- a/docs/description.adoc
+++ b/docs/description.adoc
@@ -259,7 +259,7 @@ int main(int argc, const char** argv) {
 ----
 ....
 
-That is mandatory for the Noncompliant and Compliant code example sections, just recommended - at the moment - for other sections.
+That is mandatory for the Noncompliant and Compliant code example sections, just recommended - at the moment - for other sections. 
 
 The language names accepted are usually the name we already use for the language folders in RSPEC. Exceptions are:
 
@@ -271,14 +271,22 @@ tsql:: use `sql`
 
 In case no language is appropriate for a code block (for example shared examples between multiple languages), you can use `text` as the language.
 
-=== References within code blocks
+=== Comments within code blocks
+
+Colon (`:`) should be used as separator between `Noncompliant`/`Compliant` comments and the text explanation that follows, if any.
+
+[source,cpp]
+----
+int X = 2; // Noncompliant: variable should be in lowercase
+----
+
 
 When referencing a name within a comment in a code example, use double quotes to make it clear it refers to an existing element in the code.
 
 [source,cpp]
 ----
 int i = 0;
-cout << noexcept(++i); // Noncompliant, "i" is not incremented
+cout << noexcept(++i); // Noncompliant: "i" is not incremented
 ----
 
 === Diff view

--- a/docs/description.adoc
+++ b/docs/description.adoc
@@ -259,7 +259,7 @@ int main(int argc, const char** argv) {
 ----
 ....
 
-That is mandatory for the Noncompliant and Compliant code example sections, just recommended - at the moment - for other sections. 
+That is mandatory for the Noncompliant and Compliant code example sections, just recommended - at the moment - for other sections.
 
 The language names accepted are usually the name we already use for the language folders in RSPEC. Exceptions are:
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

