### PR TITLE
Modify rule S5334: Add noncompliant comment in C# (APPSEC-258)

### DIFF
--- a/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
+++ b/rules/S5334/csharp/how-to-fix-it/dotnet.adoc
@@ -28,7 +28,8 @@ public class ExampleController : Controller
 
         var provider = CodeDomProvider.CreateProvider("CSharp");
         var compilerParameters = new CompilerParameters { ReferencedAssemblies = { "System.dll", "System.Runtime.dll" } };
-        var compilerResults = provider.CompileAssemblyFromSource(compilerParameters, code);
+        var compilerResults = provider.CompileAssemblyFromSource(compilerParameters, code); // Noncompliant
+
         object myInstance = compilerResults.CompiledAssembly.CreateInstance("MyClass");
         myInstance.GetType().GetMethod("MyMethod").Invoke(myInstance, new object[0]);
     }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

