### PR TITLE
Update impact or defaultSeverity to match each other

### DIFF
--- a/rules/S6667/metadata.json
+++ b/rules/S6667/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "COMPLETE"
   },

--- a/rules/S6668/metadata.json
+++ b/rules/S6668/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "RELIABILITY": "MEDIUM"
+      "RELIABILITY": "LOW"
     },
     "attribute": "LOGICAL"
   },

--- a/rules/S6669/metadata.json
+++ b/rules/S6669/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"
   },

--- a/rules/S6670/metadata.json
+++ b/rules/S6670/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "RELIABILITY": "MEDIUM"
+      "RELIABILITY": "LOW"
     },
     "attribute": "LOGICAL"
   },

--- a/rules/S6672/metadata.json
+++ b/rules/S6672/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"
   },

--- a/rules/S6674/metadata.json
+++ b/rules/S6674/metadata.json
@@ -3,7 +3,7 @@
   "type": "BUG",
   "code": {
     "impacts": {
-      "RELIABILITY": "MEDIUM"
+      "RELIABILITY": "HIGH"
     },
     "attribute": "LOGICAL"
   },

--- a/rules/S6675/metadata.json
+++ b/rules/S6675/metadata.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "LOGICAL"
   },

--- a/rules/S6776/metadata.json
+++ b/rules/S6776/metadata.json
@@ -8,7 +8,7 @@
   },
   "tags": [
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-6776",
   "sqKey": "S6776",
   "scope": "All",
@@ -41,7 +41,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "SECURITY": "MEDIUM"
+      "SECURITY": "LOW"
     },
     "attribute": "COMPLETE"
   }

--- a/rules/S6776/metadata.json
+++ b/rules/S6776/metadata.json
@@ -41,7 +41,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "SECURITY": "LOW"
+      "SECURITY": "MEDIUM"
     },
     "attribute": "COMPLETE"
   }

--- a/rules/S6798/csharp/metadata.json
+++ b/rules/S6798/csharp/metadata.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "RELIABILITY": "MEDIUM"
     },
     "attribute": "LOGICAL"
   }

--- a/rules/S6800/csharp/metadata.json
+++ b/rules/S6800/csharp/metadata.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "RELIABILITY": "MEDIUM"
     },
     "attribute": "LOGICAL"
   }

--- a/rules/S6930/metadata.json
+++ b/rules/S6930/metadata.json
@@ -19,7 +19,7 @@
   "quickfix": "targeted",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "RELIABILITY": "MEDIUM"
     },
     "attribute": "LOGICAL"
   }

--- a/rules/S6931/metadata.json
+++ b/rules/S6931/metadata.json
@@ -19,7 +19,7 @@
   "quickfix": "partial",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "HIGH"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CLEAR"
   }

--- a/rules/S6932/csharp/metadata.json
+++ b/rules/S6932/csharp/metadata.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "HIGH",
+      "MAINTAINABILITY": "MEDIUM",
       "RELIABILITY": "MEDIUM",
       "SECURITY": "MEDIUM"
     },

--- a/rules/S6934/metadata.json
+++ b/rules/S6934/metadata.json
@@ -17,7 +17,7 @@
     "quickfix": "partial",
     "code": {
       "impacts": {
-        "MAINTAINABILITY": "HIGH"
+        "MAINTAINABILITY": "MEDIUM"
       },
       "attribute": "CLEAR"
     }

--- a/rules/S6960/metadata.json
+++ b/rules/S6960/metadata.json
@@ -18,7 +18,7 @@
     "quickfix": "partial",
     "code": {
       "impacts": {
-        "MAINTAINABILITY": "HIGH"
+        "MAINTAINABILITY": "MEDIUM"
       },
       "attribute": "MODULAR"
     }    

--- a/rules/S6964/metadata.json
+++ b/rules/S6964/metadata.json
@@ -17,7 +17,7 @@
   "quickfix": "targeted",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "RELIABILITY": "MEDIUM"
     },
     "attribute": "TRUSTWORTHY"
   }

--- a/rules/S6967/metadata.json
+++ b/rules/S6967/metadata.json
@@ -9,7 +9,7 @@
     "tags": [
         "asp.net"
     ],
-    "defaultSeverity": "Major",
+    "defaultSeverity": "Critical",
     "ruleSpecification": "RSPEC-6967",
     "sqKey": "S6967",
     "scope": "All",

--- a/rules/S6968/csharp/metadata.json
+++ b/rules/S6968/csharp/metadata.json
@@ -17,7 +17,7 @@
   "quickfix": "partial",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "HIGH"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CLEAR"
   }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

## Rules updated

Reviewer: please mark as checked after review.

Discrepancies
* [x] S6667 
* [x] S6668 
* [x] S6669 
* [x] S6670 
* [x] S6672 
* [x] S6674 
* [x] S6675 
* [x] S6776 -> Python also affected
* [x] S6798 
* [x] S6800 
* [x] S6930
* [x] S6931 
* [x] S6934
* [x] S6960 
* [x] S6964 
* [x] S6968

Multiple CCT:
* [x] S1523 -> Security multi-language rule. Not changed
* [x] S2077 -> Security multi-language rule. Not changed
* [x] S6932 
* [x] S6967 -> defaultSeverity changed to Critical because two impacts are High

### Sources

https://trello.com/c/uPdUhaFh

Discrepencies.txt
```
Historical defaultSeverity was Minor but CCT is MEDIUM for S1441 in javascript
Historical defaultSeverity was Major but CCT is HIGH for S2259 in cfamily
Historical defaultSeverity was Critical but CCT is MEDIUM for S2310 in javascript
Historical defaultSeverity was Critical but CCT is MEDIUM for S3523 in javascript
Historical defaultSeverity was Minor but CCT is MEDIUM for S3723 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6485 in java
Historical defaultSeverity was Minor but CCT is MEDIUM for S6524 in kotlin
Historical defaultSeverity was Major but CCT is LOW for S6527 in kotlin
Historical defaultSeverity was Major but CCT is LOW for S6528 in kotlin
Historical defaultSeverity was Minor but CCT is MEDIUM for S6661 in javascript
Historical defaultSeverity was Minor but CCT is MEDIUM for S6666 in javascript
Historical defaultSeverity was Minor but CCT is MEDIUM for S6667 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6668 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6669 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6670 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6671 in javascript
Historical defaultSeverity was Minor but CCT is MEDIUM for S6672 in csharp
Historical defaultSeverity was Critical but CCT is MEDIUM for S6674 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6675 in csharp
Historical defaultSeverity was Minor but CCT is MEDIUM for S6676 in javascript
Historical defaultSeverity was Minor but CCT is MEDIUM for S6679 in javascript
Historical defaultSeverity was Major but CCT is HIGH for S6735 in python
Historical defaultSeverity was Major but CCT is LOW for S6749 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6754 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6759 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6767 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6770 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6775 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6776 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6798 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6800 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6809 in java
Historical defaultSeverity was Major but CCT is HIGH for S6814 in java
Historical defaultSeverity was Major but CCT is HIGH for S6816 in java
Historical defaultSeverity was Major but CCT is HIGH for S6817 in java
Historical defaultSeverity was Minor but CCT is MEDIUM for S6830 in java
Historical defaultSeverity was Minor but CCT is MEDIUM for S6836 in javascript
Historical defaultSeverity was Major but CCT is LOW for S6837 in java
Historical defaultSeverity was Minor but CCT is MEDIUM for S6849 in javascript
Historical defaultSeverity was Major but CCT is HIGH for S6857 in java
Historical defaultSeverity was Major but CCT is LOW for S6863 in java
Historical defaultSeverity was Major but CCT is HIGH for S6876 in java
Historical defaultSeverity was Major but CCT is HIGH for S6877 in java
Historical defaultSeverity was Minor but CCT is MEDIUM for S6878 in java
Historical defaultSeverity was Major but CCT is HIGH for S6881 in java
Historical defaultSeverity was Major but CCT is HIGH for S6886 in python
Historical defaultSeverity was Major but CCT is LOW for S6889 in java
Historical defaultSeverity was Major but CCT is LOW for S6891 in java
Historical defaultSeverity was Major but CCT is LOW for S6898 in java
Historical defaultSeverity was Major but CCT is HIGH for S6899 in python
Historical defaultSeverity was Major but CCT is LOW for S6904 in java
Historical defaultSeverity was Major but CCT is LOW for S6905 in java
Historical defaultSeverity was Major but CCT is HIGH for S6908 in python
Historical defaultSeverity was Major but CCT is LOW for S6909 in java
Historical defaultSeverity was Major but CCT is HIGH for S6911 in python
Historical defaultSeverity was Major but CCT is LOW for S6912 in java
Historical defaultSeverity was Major but CCT is LOW for S6914 in java
Historical defaultSeverity was Major but CCT is HIGH for S6918 in python
Historical defaultSeverity was Major but CCT is LOW for S6923 in java
Historical defaultSeverity was Major but CCT is LOW for S6926 in java
Historical defaultSeverity was Major but CCT is HIGH for S6930 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6931 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6934 in csharp
Historical defaultSeverity was Blocker but CCT is MEDIUM for S6936 in cfamily
Historical defaultSeverity was Major but CCT is HIGH for S6960 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6964 in csharp
Historical defaultSeverity was Major but CCT is HIGH for S6968 in csharp
Historical defaultSeverity was Major but CCT is LOW for S6969 in python
Historical defaultSeverity was Major but CCT is HIGH for S6972 in python
Historical defaultSeverity was Major but CCT is HIGH for S6978 in python
Historical defaultSeverity was Major but CCT is HIGH for S6984 in python
Historical defaultSeverity was Major but CCT is HIGH for S6985 in python
Historical defaultSeverity was Major but CCT is LOW for S6996 in cfamily
Historical defaultSeverity was Major but CCT is HIGH for S7020 in docker
Historical defaultSeverity was Major but CCT is HIGH for S7021 in docker
Historical defaultSeverity was Minor but CCT is MEDIUM for S7026 in docker
Historical defaultSeverity was Major but CCT is HIGH for S7027 in java
Historical defaultSeverity was Major but CCT is HIGH for S7031 in docker
Historical defaultSeverity was Major but CCT is HIGH for S7032 in cfamily
Historical defaultSeverity was Minor but CCT is MEDIUM for S7040 in family
```
Multiple CCT
```
multi cct for S1523 in csharp
multi cct for S2077 in csharp
multi cct for S3281 in xml
multi cct for S3355 in xml
multi cct for S5782 in cfamily
multi cct for S6709 in python
multi cct for S6714 in python
multi cct for S6727 in python
multi cct for S6729 in python
multi cct for S6734 in python
multi cct for S6740 in python
multi cct for S6741 in python
multi cct for S6746 in javascript
multi cct for S6747 in javascript
multi cct for S6748 in javascript
multi cct for S6750 in javascript
multi cct for S6756 in javascript
multi cct for S6757 in javascript
multi cct for S6761 in javascript
multi cct for S6763 in javascript
multi cct for S6766 in javascript
multi cct for S6772 in javascript
multi cct for S6774 in javascript
multi cct for S6788 in javascript
multi cct for S6789 in javascript
multi cct for S6790 in javascript
multi cct for S6791 in javascript
multi cct for S6804 in java
multi cct for S6806 in java
multi cct for S6813 in java
multi cct for S6818 in java
multi cct for S6821 in html
multi cct for S6829 in java
multi cct for S6831 in java
multi cct for S6859 in javascript
multi cct for S6861 in javascript
multi cct for S6864 in kubernetes
multi cct for S6865 in kubernetes
multi cct for S6867 in kubernetes
multi cct for S6868 in kubernetes
multi cct for S6869 in kubernetes
multi cct for S6870 in kubernetes
multi cct for S6873 in kubernetes
multi cct for S6882 in python
multi cct for S6883 in python
multi cct for S6887 in python
multi cct for S6890 in python
multi cct for S6892 in kubernetes
multi cct for S6894 in python
multi cct for S6897 in kubernetes
multi cct for S6900 in python
multi cct for S6903 in python
multi cct for S6907 in kubernetes
multi cct for S6919 in python
multi cct for S6925 in python
multi cct for S6928 in python
multi cct for S6929 in python
multi cct for S6932 in csharp
multi cct for S6967 in csharp
multi cct for S6971 in python
multi cct for S6973 in python
multi cct for S6974 in python
multi cct for S6982 in python
multi cct for S6991 in cfamily
multi cct for S7012 in cfamily
multi cct for S7018 in docker
multi cct for S7019 in docker
multi cct for S7023 in docker
multi cct for S7029 in docker
multi cct for S7030 in docker
multi cct for S7038 in cfamily
multi cct for S7042 in cfamily
multi cct for S7059 in javascript
multi cct for S7060 in javascript
```

