### PR TITLE
Modify rule S2260: Fix list of actions to deal with analyzer failures

### DIFF
--- a/rules/S2260/dart/rule.adoc
+++ b/rules/S2260/dart/rule.adoc
@@ -16,7 +16,8 @@ There are three recommended ways to deal with analysis failures:
 * Fix compiler errors.
 * Make sure you got all project dependencies, via `flutter pub get`, `dart pub get`, ...
 * Make sure all referenced generated files were generated before the analysis.
-* If you cannot fix them, let us know through the https://community.sonarsource.com/[Sonar Community forum].
+
+If you cannot fix them, let us know through the https://community.sonarsource.com/[Sonar Community forum].
 
 === Noncompliant code example
 


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

