### PR TITLE
S5408 Remove constexpr static data members from rspec (CPP-5809)

### DIFF
--- a/rules/S5408/cfamily/rule.adoc
+++ b/rules/S5408/cfamily/rule.adoc
@@ -1,7 +1,6 @@
 == Why is this an issue?
 
-Declaring a function or a static member variable ``++constexpr++`` makes it implicitly inline.
-
+Declaring a function ``++constexpr++`` makes it implicitly inline.
 
 In that situation, explicitly using the ``++inline++`` keyword would be redundant, and might lead to confusion if it's used in some cases but not others. It's better to simply omit it.
 
@@ -11,22 +10,14 @@ In that situation, explicitly using the ``++inline++`` keyword would be redundan
 [source,cpp]
 ----
 inline constexpr int addOne(int n) { return n+1; } // Noncompliant
-struct A {
-inline constexpr static int secretNumber = 0; // Noncompliant
-};
 ----
-
 
 === Compliant solution
 
 [source,cpp]
 ----
 constexpr int addOne(int n) { return n+1; }
-struct A {
-constexpr static int secretNumber = 0;
-};
 ----
- 
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

