### PR TITLE
Modify rule S6294: "Log Groups" should be declared explicitly

### DIFF
--- a/rules/S6294/cloudformation/rule.adoc
+++ b/rules/S6294/cloudformation/rule.adoc
@@ -76,7 +76,7 @@ Resources:
       RetentionInDays: 30
 ----
 
-Example with a `!Ref` in `Function` (it also works for `AWS::Serverless::Function`):
+Example with a `!Ref` in `AWS::Lambda::Function` (it also works for `AWS::Serverless::Function`):
 
 [source,yaml]
 ----
@@ -116,7 +116,7 @@ Resources:
       RetentionInDays: 30
 ----
 
-Example with `CloudWatchLogs` (it works only for `AWS::CodeBuild::Project`):
+Example with `CloudWatchLogs` (it only works for `AWS::CodeBuild::Project`):
 
 [source,yaml]
 ----

--- a/rules/S6294/cloudformation/rule.adoc
+++ b/rules/S6294/cloudformation/rule.adoc
@@ -57,7 +57,7 @@ Resources:
 
 ==== Compliant solution
 
-Example with a `!Ref`:
+Example with a `!Ref` in `LogGroup`:
 
 [source,yaml]
 ----
@@ -73,6 +73,27 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Join ['/', ['/aws/lambda', !Ref ExampleFunction]]
+      RetentionInDays: 30
+----
+
+Example with a `!Ref` in `Function` (it also works for `AWS::Serverless::Function`):
+
+[source,yaml]
+----
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  ExampleFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs12.x
+      Description: Example of Lambda Function
+      LoggingConfig:
+        LogGroup: !Ref ExampleLogGroup
+
+  ExampleLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/aws/lambda/exampleFunction"
       RetentionInDays: 30
 ----
 
@@ -93,6 +114,21 @@ Resources:
     Properties:
       LogGroupName: !Sub '/aws/lambda/${ExampleFunction}'
       RetentionInDays: 30
+----
+
+Example with `CloudWatchLogs` (it works only for `AWS::CodeBuild::Project`):
+
+[source,yaml]
+----
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      LogsConfig:
+        CloudWatchLogs:
+          Status: "ENABLED"
+          GroupName: "aws/codeBuild/project"
 ----
 
 == Resources


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

