### PR TITLE
Modify rule S5411: explain that @NonNull values are ignored.

### DIFF
--- a/rules/S5411/java/rule.adoc
+++ b/rules/S5411/java/rule.adoc
@@ -5,7 +5,7 @@ When boxed type `java.lang.Boolean` is used as an expression to determine the co
 
 It is safer to avoid such conversion altogether and handle the `null` value explicitly.
 
-Note, however, that no issues will be raised for Booleans that have already been null-checked.
+Note, however, that no issues will be raised for Booleans that have already been null-checked or are marked `@NonNull/@NotNull`.
 
 === Noncompliant code example
 
@@ -36,6 +36,35 @@ Boolean b = getBoolean();
 if(b != null){
   String test = b ? "test" : "";
 }
+----
+
+=== Exceptions
+
+The issue is not raised if the expression is annotated `@NonNull` / `@NotNull`.
+This is useful if a boxed type is an instantiation of a generic type parameter
+and cannot be avoided.
+
+[source,java]
+----
+List<Boolean> list = new ArrayList<>();
+list.add(true);
+list.add(false);
+list.forEach((@NonNull Boolean value) -> {
+  // Compliant
+  if(value) {
+    System.out.println("yes");
+  }
+});
+
+@NonNull Boolean someMethod() { /* ... */ }
+
+// Compliant
+if(someMethod()) { /* ... */ }
+
+@NonNull Boolean boxedNonNull = Boolean.TRUE;
+
+// Compliant
+if(boxedNonNull) { /* ... */ }
 ----
 
 == Resources

--- a/rules/S5411/java/rule.adoc
+++ b/rules/S5411/java/rule.adoc
@@ -41,8 +41,7 @@ if(b != null){
 === Exceptions
 
 The issue is not raised if the expression is annotated `@NonNull` / `@NotNull`.
-This is useful if a boxed type is an instantiation of a generic type parameter
-and cannot be avoided.
+This is useful if a boxed type is an instantiation of a generic type parameter and cannot be avoided.
 
 [source,java]
 ----


### PR DESCRIPTION
Modify S5411 explaining that @NonNull values are ignored. The rule was recently improved in SONARJAVA-5184 to cover more @NonNull variables. 