### PR TITLE
Deprecate S6299: Disabling Vue.js built-in escaping is security-sensitive

### DIFF
--- a/rules/S6299/javascript/metadata.json
+++ b/rules/S6299/javascript/metadata.json
@@ -7,7 +7,7 @@
     },
     "attribute": "CONVENTIONAL"
   },
-  "status": "ready",
+  "status": "deprecated",
   "tags": [
     "cwe"
   ],
@@ -39,6 +39,5 @@
     ]
   },
   "defaultQualityProfiles": [
-    "Sonar way"
   ]
 }


### PR DESCRIPTION

This rule is not consistent with the rule quality the AppSec squad enforces:

The rule risks a non-negligible number of FPs for the chance of having TPs.
It is non-productive as TPs would get drowned in between FPs. we lose credibility and engagement even if we do find TPs

The rule is hardly actionable as is, as it only shows a “sink”, not the rest of where the variable is coming from, to check if it is an actual problem

Security Hotspots are meant to raise issues that require data that cannot be put in the same code base, such as organizational needs. The why of the rule seems related to the fact that the analyzer does not support VueJS and the specificator still wanted to make a move.
This is not a standard practice at AppSec and does not follow the company delivery model

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

