### PR TITLE
Modify S6255: Remove rule from SonarWay (APPSEC-2291)

### DIFF
--- a/rules/S6255/terraform/metadata.json
+++ b/rules/S6255/terraform/metadata.json
@@ -38,7 +38,5 @@
       "6.2.4"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "defaultQualityProfiles": []
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

