### PR TITLE
Modify rule S6433: Remove Kubernetes from Sonar Way profile (APPSEC-2276)

### DIFF
--- a/rules/S6433/kubernetes/metadata.json
+++ b/rules/S6433/kubernetes/metadata.json
@@ -1,2 +1,3 @@
 {
+    "defaultQualityProfiles": []
 }


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

