### PR TITLE
Modify rule S1948: clarify that only non-static fields are serialized.

### DIFF
--- a/rules/S1948/java/rule.adoc
+++ b/rules/S1948/java/rule.adoc
@@ -2,7 +2,7 @@ This rule raises an issue on a non-transient and non-serializable field within a
 
 == Why is this an issue?
 
-By contract, fields in a `Serializable` class must themselves be either `Serializable` or `transient`.
+By contract, non-static fields in a `Serializable` class must themselves be either `Serializable` or `transient`.
 Even if the class is never explicitly serialized or deserialized, it is not safe to assume that this cannot happen.
 For instance, under load, most J2EE application frameworks flush objects to disk.
 
@@ -91,6 +91,19 @@ public class Person implements Serializable {
   private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
     // Appropriate deserialization logic here
   }
+}
+----
+
+Finally, static fields are out of scope for serialization, so making a field static prevents issues from being raised.
+
+[source,java]
+----
+public class Person implements Serializable {
+  private static final long serialVersionUID = 1905122041950251207L;
+
+  private String name;
+
+  private static Logger log = getLogger(); // Compliant, static fields are not serialized
 }
 ----
 


### PR DESCRIPTION
https://sonarsource.atlassian.net/browse/SONARJAVA-5238

Existing documentation never mentions that serialization does not apply to static fields. We recently had a community post about fixing serialization issue by making a field static.