### PR TITLE
Modify rule S1172 Fix FP for Objective-C block definitions CPP-5916

### DIFF
--- a/rules/S1172/cfamily/rule.adoc
+++ b/rules/S1172/cfamily/rule.adoc
@@ -13,7 +13,7 @@ void f([[maybe_unused]] int i) {
 }
 ----
 
-In case of Objective-C, it is acceptable to have unused parameters if the method is supposed to be overridden.
+In case of Objective-C, it is acceptable to have unused parameters if the method is supposed to be overridden. Additionally, since Objective-C blocks don't allow unnamed parameters while they are typically used as callbacks, it is acceptable to have unused parameters in blocks.
 
 == How to fix it
 


### PR DESCRIPTION
Related to https://github.com/SonarSource/sonar-cpp/pull/4323