### PR TITLE
Modify rule S6290: Remove reference to AWS Access Key ID (APPSEC-526)

### DIFF
--- a/rules/S6290/secrets/rule.adoc
+++ b/rules/S6290/secrets/rule.adoc
@@ -8,7 +8,6 @@ include::../../../shared_content/secrets/rationale.adoc[]
 This rule detects the following leaks:
 
 * AWS Secret Access Keys
-* AWS Access IDs
 * AWS Session Tokens
 
 === What is the potential impact?


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

