### PR TITLE
Modify rule S1542: Prevent strong substitution

### DIFF
--- a/rules/S1542/vb6/rule.adoc
+++ b/rules/S1542/vb6/rule.adoc
@@ -4,7 +4,7 @@ include::../description.adoc[]
 
 === Noncompliant code example
 
-With default provided regular expression: ^([A-Z][a-zA-Z0-9_]*)|([a-z][a-zA-Z0-9]*_[A-Z][a-zA-Z]*)$
+With default provided regular expression: ^([A-Z][a-zA-Z0-9_]\*)|([a-z][a-zA-Z0-9]*_[A-Z][a-zA-Z]*)$
 
 
 [source,vb6]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

