### PR TITLE
S6018 Add example showing use of `inline` out of line (CPP-4342)

### DIFF
--- a/rules/S6018/cfamily/rule.adoc
+++ b/rules/S6018/cfamily/rule.adoc
@@ -20,14 +20,19 @@ This rule will detect these workarounds and suggest using inline variables inste
 
 [source,cpp]
 ----
-struct A {
+struct Clazz {
   static std::string& getS1() { // Noncompliant
     static std::string s1 = "s1";
     return s1;
   }
+
+  static Clazz const& getSelf() { // Noncompliant
+    static Clazz self;
+    return self;
+  }
 };
 
-inline std::string& gets2() { // Noncompliant
+inline std::string& getS2() { // Noncompliant
   static std::string s2 = "s2";
   return s2;
 }
@@ -41,9 +46,12 @@ T s3 = "s3"; // Noncompliant. Available starting C++14
 
 [source,cpp]
 ----
-struct A {
-  inline static std::string s1 = "s1"; // Compliant
+struct Clazz {
+  inline static std::string s1 = "s1"; // Compliant, 
+  static Clazz self;
 };
+inline Class Clazz::self; // Compliant
+// Out of line definition is required, for `Clazz` to be complete
 
 inline std::string s2 = "s2"; // Compliant
 ----

--- a/rules/S6018/cfamily/rule.adoc
+++ b/rules/S6018/cfamily/rule.adoc
@@ -51,7 +51,7 @@ struct Clazz {
   static Clazz self;
 };
 inline Class Clazz::self; // Compliant
-// Out of line definition is required, for `Clazz` to be complete
+// Out of line definition is required for `Clazz` to be complete.
 
 inline std::string s2 = "s2"; // Compliant
 ----

--- a/rules/S6018/cfamily/rule.adoc
+++ b/rules/S6018/cfamily/rule.adoc
@@ -2,6 +2,7 @@
 
 ``{cpp}17`` introduced inline variables. They provide a proper way to define global variables in header files. Before inline variables, it wasn’t possible to simply define global variables without compile or link errors:
 
+[source,cpp]
 ----
 struct A {
   static std::string s1 = "s1"; // doesn’t compile


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

