### PR TITLE
NET-934 Modify S1643: Use NetFx 4.8.1 in Brenchmark

### DIFF
--- a/rules/S1643/csharp/rule.adoc
+++ b/rules/S1643/csharp/rule.adoc
@@ -42,12 +42,11 @@ string str = bld.ToString();
 [options="header"]
 |===
 | Method               | Runtime              | Mean         | Standard Deviation     | Allocated
-| StringConcatenation  | .NET 9.0             | 45,723.79 us | 4,589.713 us           | 586280.56 KB
-| StringBuilder        | .NET 9.0             |     77.73 us |     1.221 us           |    243.79 KB
-| StringConcatenation  | .NET Framework 4.6.2 | 33,922.61 us |   302.498 us           | 586450.35 KB
-| StringBuilder        | .NET Framework 4.6.2 |    178.14 us |     9.010 us           |    244.15 KB
+| StringConcatenation  | .NET 9.0             | 50,530.75 us | 2,699.189 us           | 586280.70 KB
+| StringBuilder        | .NET 9.0             |     82.31 us |     3.387 us           |    243.79 KB
+| StringConcatenation  | .NET Framework 4.8.1 | 37,453.72 us | 1,543.051 us           | 586450.38 KB
+| StringBuilder        | .NET Framework 4.8.1 |    178.32 us |     6.148 us           |    244.15 KB
 |===
-
 
 ==== Glossary
 
@@ -91,7 +90,7 @@ BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5247/22H2/2022Update)
 12th Gen Intel Core i7-12800H, 1 CPU, 20 logical and 14 physical cores
   [Host]               : .NET Framework 4.8.1 (4.8.9282.0), X64 RyuJIT VectorSize=256
   .NET 9.0             : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
-  .NET Framework 4.6.2 : .NET Framework 4.8.1 (4.8.9282.0), X64 RyuJIT VectorSize=256
+  .NET Framework 4.8.1 : .NET Framework 4.8.1 (4.8.9282.0), X64 RyuJIT VectorSize=256
 ----
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

