### PR TITLE
Apply missing `android` tags to rules that support Android APIs (APPSEC-2374)

### DIFF
--- a/rules/S3649/java/metadata.json
+++ b/rules/S3649/java/metadata.json
@@ -1,3 +1,7 @@
 {
-  
+    "tags": [
+        "cwe",
+        "sql",
+        "android"
+      ]
 }

--- a/rules/S5332/java/metadata.json
+++ b/rules/S5332/java/metadata.json
@@ -1,3 +1,7 @@
 {
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "tags": [
+    "cwe",
+    "android"
+  ]
 }

--- a/rules/S5332/kotlin/metadata.json
+++ b/rules/S5332/kotlin/metadata.json
@@ -1,3 +1,7 @@
 {
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "tags": [
+    "cwe",
+    "android"
+  ]
 }

--- a/rules/S5332/xml/metadata.json
+++ b/rules/S5332/xml/metadata.json
@@ -1,3 +1,7 @@
 {
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "tags": [
+    "cwe",
+    "android"
+  ]
 }

--- a/rules/S6293/metadata.json
+++ b/rules/S6293/metadata.json
@@ -13,7 +13,8 @@
     "constantCost": "5min"
   },
   "tags": [
-    "cwe"
+    "cwe",
+    "android"
   ],
   "extra": {
     "replacementRules": [


### PR DESCRIPTION
[APPSEC-2374](https://sonarsource.atlassian.net/browse/APPSEC-2374)



[APPSEC-2374]: https://sonarsource.atlassian.net/browse/APPSEC-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ