### PR TITLE
SONARGO-175 ParsingError should be disabled by default

### DIFF
--- a/rules/S2260/go/metadata.json
+++ b/rules/S2260/go/metadata.json
@@ -1,6 +1,3 @@
 {
-  "title": "Go parser failure",
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ]
+  "title": "Go parser failure"
 }


### PR DESCRIPTION
[SONARGO-175](https://sonarsource.atlassian.net/browse/SONARGO-175)

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)



[SONARGO-175]: https://sonarsource.atlassian.net/browse/SONARGO-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ