### PR TITLE
Deprecate rule S1227 (CPP-6131 and NET-1116)

### DIFF
--- a/rules/S1227/metadata.json
+++ b/rules/S1227/metadata.json
@@ -7,7 +7,7 @@
     },
     "attribute": "CLEAR"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"


### PR DESCRIPTION
[CPP-6131](https://sonarsource.atlassian.net/browse/CPP-6131)

After checking with .NET, the rule can be deprecated for both languages

[CPP-6131]: https://sonarsource.atlassian.net/browse/CPP-6131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ