### PR TITLE
S6418/php: fix typo in variable name

### DIFF
--- a/rules/S6418/php/rule.adoc
+++ b/rules/S6418/php/rule.adoc
@@ -1,4 +1,4 @@
-:detectson: variables/fields
+:detections: variables/fields
 :defaultsensibility: 5
 
 include::../description.adoc[]


### PR DESCRIPTION
`description.adoc` is using `detections` and not `detectons` as a variable:
```
This rule detects {detections} having a name matching a list of words (secret, token, credential, auth, api[_.-]?key) being assigned a pseudorandom hard-coded value.
```

This PR makes the value rendered correctly on https://sonarsource.github.io/rspec/#/rspec/S6418/php

<!--
Jira Automation:

* Mention existing issue in the PR title to move it around automatically.
* Mention existing issue in the PR description and a sub-task will be created for you to track this rspec PR separately.

No issue is created by default.
-->

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

