### PR TITLE
Modify rule S6977: Change type to BUG

### DIFF
--- a/rules/S6977/jcl/metadata.json
+++ b/rules/S6977/jcl/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "RLSE should be used in SPACE directive",
-  "type": "CODE_SMELL",
+  "type": "BUG",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",


### PR DESCRIPTION
S6977 definitely impacts RELIABILITY, but it was typed as a `CODE_SMELL`.
However, if reliability is the main quality of an issue, then it should be paired with the `BUG` type.

S6977 is not a BUG in the sense that correctness is affected. At the same time, the previous MAINTAINABILITY quality is not impacted at all. Also, the issue does negatively affect performance, so it is bug in that sense.

Thus, the decision was made to change the type to `BUG`.
Finally, this change **is necessary to address `SONARJCL-184`.**

<!--
Jira Automation:

* Mention existing issue in the PR title to move it around automatically.
* Mention existing issue in the PR description and a sub-task will be created for you to track this rspec PR separately.

No issue is created by default.
-->

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)


[SONARJCL-188]: https://sonarsource.atlassian.net/browse/SONARJCL-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ