### PR TITLE
Modify rule S6945: Add MAINTAINABILITY quality, increase severity and impact levels

### DIFF
--- a/rules/S6945/jcl/metadata.json
+++ b/rules/S6945/jcl/metadata.json
@@ -8,7 +8,7 @@
   },
   "tags": [
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6945",
   "sqKey": "S6945",
   "scope": "All",
@@ -16,8 +16,8 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "RELIABILITY": "MEDIUM",
-      "MAINTAINABILITY": "MEDIUM"
+      "RELIABILITY": "HIGH",
+      "MAINTAINABILITY": "HIGH"
     },
     "attribute": "LOGICAL"
   }

--- a/rules/S6945/jcl/metadata.json
+++ b/rules/S6945/jcl/metadata.json
@@ -16,7 +16,8 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "RELIABILITY": "MEDIUM"
+      "RELIABILITY": "MEDIUM",
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "LOGICAL"
   }


### PR DESCRIPTION
## Regarding adding the `MAINTAINABILITY` quality:
S6945 does not necessarily indicate a bug since COND might not be set on purpose.
Hence, keeping the type as `CODE_SMELL` appears correct.

However, as a code smell, we need to qualify its `MAINTAINABILITY` impact.
    
At the same time, we keep the existing `RELIABILITY` impact:
Not setting COND is a practice that not only leads to harder to debug code but it may also lead to bugs

## Regarding increasing the severity and impact levels
Following the documentation, MAINTAINABILITY issues should have at least HIGH impact, and Critical severity, if they can lead to the introduction of bugs.

RELIABILITY issues should have at least HIGH impact, and Critical severity, if they can for example cause corrupted data.

Both applies here. Hence, we upgrade the `defaultSeverity` and impact levels.

These are the documentation link:
https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/adding-coding-rules/#setting-severities-in-mqr-mode
https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/adding-coding-rules/#setting-severities-in-se-mode

---

This rspec change is also a pre-requisite for `SONARJCL-184`.
This change itself is tracked as `SONARJCL-187`.

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

