### PR TITLE
Modify rule S4423 for Go: Add examples for HTTP servers

### DIFF
--- a/rules/S4423/go/how-to-fix-it/stdlib.adoc
+++ b/rules/S4423/go/how-to-fix-it/stdlib.adoc
@@ -28,7 +28,7 @@ func main() {
 }
 ----
 
-For HTTP servers:
+For HTTP servers when using a go version older than 1.22:
 
 [source,go,diff-id=2,diff-type=noncompliant]
 ----
@@ -67,7 +67,7 @@ func main() {
 }
 ----
 
-For HTTP servers:
+For HTTP servers when using a go version older than 1.22:
 
 [source,go,diff-id=2,diff-type=compliant]
 ----

--- a/rules/S4423/go/how-to-fix-it/stdlib.adoc
+++ b/rules/S4423/go/how-to-fix-it/stdlib.adoc
@@ -28,6 +28,25 @@ func main() {
 }
 ----
 
+For HTTP servers:
+
+[source,go,diff-id=2,diff-type=noncompliant]
+----
+import (
+    "net/http"
+)
+
+func main() {
+    http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+        w.Write([]byte("Hello world!\n"))
+    })
+    err := http.ListenAndServeTLS(":443", "tls.crt", "tls.key", nil) // Noncompliant: TLS 1.0 by default for servers
+    if err != nil {
+        panic(err)
+    }
+}
+----
+
 ==== Compliant solution
 
 For HTTP clients:
@@ -45,6 +64,35 @@ func main() {
         panic(err)
     }
     defer resp.Body.Close()
+}
+----
+
+For HTTP servers:
+
+[source,go,diff-id=2,diff-type=compliant]
+----
+import (
+    "crypto/tls"
+    "net/http"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+        w.Write([]byte("Hello world!\n"))
+    })
+    cfg := &tls.Config{
+        MinVersion: tls.VersionTLS12,
+    }
+    srv := &http.Server{
+        Addr: ":443",
+        Handler: mux,
+        TLSConfig: cfg,
+    }
+    err := srv.ListenAndServeTLS("tls.crt", "tls.key")
+    if err != nil {
+        panic(err)
+    }
 }
 ----
 


### PR DESCRIPTION
Reverts SonarSource/rspec#4726

