### PR TITLE
DO NOT MERGE - IGNORE

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.test.inclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx
 sonar.javascript.coveragePlugin=lcov
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.cpd.exclusions=src/deployment/__tests__/resources/**
-sonar.sca.recursiveManifestSearch=false
+sonar.sca.debug=true


### PR DESCRIPTION
Just confirming that removing `sonar.sca.recursiveManifestSearch=false` behaves correctly now after the upstream fix.