### PR TITLE
Revert "Fix frontend_tests job long running times (#4829)"

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -8,4 +8,3 @@ sonar.test.inclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx
 sonar.javascript.coveragePlugin=lcov
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.cpd.exclusions=src/deployment/__tests__/resources/**
-sonar.sca.recursiveManifestSearch=false


### PR DESCRIPTION
This workaround should no longer be required, the initial bug in SCA analysis has been fixed.

This reverts commit 1012f37ffaf9774ad41f4826ea5854ae08893ec7.
