### PR TITLE
JS-676 Update mapping for js/ts files

### DIFF
--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -41,8 +41,10 @@ REPOS = [
 
 CANONICAL_NAMES = {
   'CLOUD_FORMATION': 'CLOUDFORMATION',
-  'JS': 'JAVASCRIPT',
-  'TS': 'TYPESCRIPT',
+  'JS': 'js',
+  'TS': 'ts',
+  'JAVASCRIPT': 'js',
+  'TYPESCRIPT': 'ts',
   'WEB': 'HTML'
 }
 

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -129,11 +129,11 @@ def test_update_coverage_for_repo_version(tmpdir, rules_dir: Path, mock_git_anal
     coverage = tmpdir.join('covered_rules.json')
     assert coverage.exists()
     cov = load_json(coverage)
-    assert 'JAVASCRIPT' in cov
-    assert 'S100' in cov['JAVASCRIPT']
-    assert 'MethodName' not in cov['JAVASCRIPT'] # MethodName is a legacy key for S100
-    assert 'S200' not in cov['JAVASCRIPT'] # S200.json is not in the rules directory in mock
-    assert cov['JAVASCRIPT']['S100'] == {'since': REPO + ' ' + VER, 'until': REPO + ' ' + VER}
+    assert 'js' in cov
+    assert 'S100' in cov['js']
+    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
+    assert 'S200' not in cov['js'] # S200.json is not in the rules directory in mock
+    assert cov['js']['S100'] == {'since': REPO + ' ' + VER, 'until': REPO + ' ' + VER}
 
     # Running it again changes nothing
     update_coverage_for_repo_version(REPO, VER, rules_dir)
@@ -143,11 +143,11 @@ def test_update_coverage_for_repo_version(tmpdir, rules_dir: Path, mock_git_anal
     VER2 = '5.0.0.6962'
     update_coverage_for_repo_version(REPO, VER2, rules_dir)
     cov_new = load_json(coverage)
-    assert set(cov['JAVASCRIPT'].keys()).issubset(set(cov_new['JAVASCRIPT'].keys()))
-    assert cov_new['JAVASCRIPT']['S100']['since'] == REPO + ' ' + VER
-    assert cov_new['JAVASCRIPT']['S100']['until'] == REPO + ' ' + VER2
-    assert cov_new['JAVASCRIPT']['S1192']['since'] == REPO + ' ' + VER2
-    assert cov_new['JAVASCRIPT']['S1192']['until'] == REPO + ' ' + VER2
+    assert set(cov['js'].keys()).issubset(set(cov_new['JAVASCRIPT'].keys()))
+    assert cov_new['js']['S100']['since'] == REPO + ' ' + VER
+    assert cov_new['js']['S100']['until'] == REPO + ' ' + VER2
+    assert cov_new['js']['S1192']['since'] == REPO + ' ' + VER2
+    assert cov_new['js']['S1192']['until'] == REPO + ' ' + VER2
 
     # For rules supported on master only the 'since' part is kept
     update_coverage_for_repo_version(REPO, 'master', rules_dir)
@@ -161,13 +161,13 @@ def test_update_coverage_for_repo(tmpdir, rules_dir: Path, mock_git_analyzer_rep
     coverage = tmpdir.join('covered_rules.json')
     assert coverage.exists()
     cov = load_json(coverage)
-    assert 'JAVASCRIPT' in cov
-    assert 'TYPESCRIPT' in cov
-    assert 'S100' in cov['JAVASCRIPT']
-    assert 'MethodName' not in cov['JAVASCRIPT'] # MethodName is a legacy key for S100
-    assert cov['JAVASCRIPT']['S100'] == REPO + ' 3.3.0.5702'
-    assert 'S1145' in cov['JAVASCRIPT']
-    assert cov['JAVASCRIPT']['S1145'] == {'since': REPO + ' 3.3.0.5702', 'until': REPO + ' 6.7.0.14237'}
+    assert 'js' in cov
+    assert 'ts' in cov
+    assert 'S100' in cov['js']
+    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
+    assert cov['js']['S100'] == REPO + ' 3.3.0.5702'
+    assert 'S1145' in cov['js']
+    assert cov['js']['S1145'] == {'since': REPO + ' 3.3.0.5702', 'until': REPO + ' 6.7.0.14237'}
 
 
 @patch('rspec_tools.coverage.REPOS', ['SonarJS', 'sonar-xml', 'sonar-java'])
@@ -177,9 +177,9 @@ def test_update_coverage_for_all_repos(tmpdir, rules_dir: Path, mock_git_analyze
     coverage = tmpdir.join('covered_rules.json')
     assert coverage.exists()
     cov = load_json(coverage)
-    assert {'JAVASCRIPT', 'TYPESCRIPT', 'XML', 'CSS', 'JAVA'} == set(cov.keys())
-    assert 'S100' in cov['JAVASCRIPT']
-    assert 'MethodName' not in cov['JAVASCRIPT'] # MethodName is a legacy key for S100
+    assert {'js', 'ts', 'XML', 'CSS', 'JAVA'} == set(cov.keys())
+    assert 'S100' in cov['js']
+    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
     assert {'S100'} == set(cov['CSS'].keys())
     assert {'S103', 'S1000'} == set(cov['XML'].keys())
     assert cov['XML']['S1000'] == 'SonarJS 7.0.0.14528'

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -143,7 +143,7 @@ def test_update_coverage_for_repo_version(tmpdir, rules_dir: Path, mock_git_anal
     VER2 = '5.0.0.6962'
     update_coverage_for_repo_version(REPO, VER2, rules_dir)
     cov_new = load_json(coverage)
-    assert set(cov['js'].keys()).issubset(set(cov_new['JAVASCRIPT'].keys()))
+    assert set(cov['js'].keys()).issubset(set(cov_new['js'].keys()))
     assert cov_new['js']['S100']['since'] == REPO + ' ' + VER
     assert cov_new['js']['S100']['until'] == REPO + ' ' + VER2
     assert cov_new['js']['S1192']['since'] == REPO + ' ' + VER2
@@ -151,7 +151,7 @@ def test_update_coverage_for_repo_version(tmpdir, rules_dir: Path, mock_git_anal
 
     # For rules supported on master only the 'since' part is kept
     update_coverage_for_repo_version(REPO, 'master', rules_dir)
-    assert load_json(coverage)['JAVASCRIPT']['S100'] == REPO + ' ' + VER
+    assert load_json(coverage)['js']['S100'] == REPO + ' ' + VER
 
 
 def test_update_coverage_for_repo(tmpdir, rules_dir: Path, mock_git_analyzer_repos):


### PR DESCRIPTION
[JS-676](https://sonarsource.atlassian.net/browse/JS-676)

## Review

In https://github.com/SonarSource/rspec/pull/4731, the compatibleLanguages were introduced for js/ts rules. For backward compatibility for the coverage.py script from rspec, these need to mapped to the same key. This leads to a split brain, as the older rules would map to 'JAVASCRIPT' and 'TYPESCRIPT' and in master we have 'js' and 'ts'.

Let us update the mapping so that we are consistent. I really, really hope, this will be the last time we change these mappings. Twice should be enough 😄 


## test

Ran locally the coverage.py script and checked the contents of the generated `covered_rules.json`

`pipenv run rspec-tools update-coverage --repository SonarJS --rulesdir ../rules`

The resulting file has only 2 keys for languages: 'js' and 'ts' and majority of rules are covered since a long time. See excerpt:
`
    "S6859": "SonarJS 10.11.0.25043",
    "S6861": "SonarJS 10.11.0.25043",
    "S6957": "SonarJS 10.13.0.25911",
    "S6958": "SonarJS 10.13.0.25911",
    "S6959": "SonarJS 10.13.0.25911",
    "S7059": "SonarJS 10.15.0.27423",
    "S7060": "SonarJS 10.15.0.27423",
    "S878": "SonarJS 6.0.0.9595",
    "S881": "SonarJS 6.1.0.11503",
    "S888": "SonarJS 6.2.0.12043",
    "S905": "SonarJS 6.0.0.9595",
    "S909": "SonarJS 6.5.0.13383"
`

[JS-676]: https://sonarsource.atlassian.net/browse/JS-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ