### PR TITLE
Refresh rspec-tools to fix tests when run locally

### DIFF
--- a/rspec-tools/Pipfile
+++ b/rspec-tools/Pipfile
@@ -18,7 +18,6 @@ slackclient = "*"
 pytest = ">=6.2.2"
 mypy = ">=0.800"
 pytest-snapshot = "*"
-rspec-tools = {file = ".", editable = true}
 pytest-cov = "*"
 
 [requires]

--- a/rspec-tools/Pipfile.lock
+++ b/rspec-tools/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e3e74b4095a4e31ef7857067fa5cd2cc59d659d08c19a5c11ca0e0e81338b28d"
+            "sha256": "ddb34a01ad4ec8999928f1f5f5d8b0096f1bf0044a4d61981f70cd3c8d69bbf1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1329,10 +1329,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==0.9.0"
-        },
-        "rspec-tools": {
-            "editable": true,
-            "path": "."
         },
         "typing-extensions": {
             "hashes": [

--- a/rspec-tools/README.adoc
+++ b/rspec-tools/README.adoc
@@ -38,7 +38,7 @@ Development
 
 [source,sh]
 ----
-$ pipenv install --dev -e .
+$ pipenv install --dev
 ----
 
 .Run tests

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -115,7 +115,7 @@ def live_url(url: str, timeout=5):
 def findurl_in_html(filename,urls):
   with open(filename, 'r', encoding="utf8") as file:
     soup = BeautifulSoup(file,features="html.parser")
-    for link in soup.findAll('a'):
+    for link in soup.find_all('a'):
       key=link.get('href')
       if key in urls:
         urls[key].append(filename)

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -82,7 +82,9 @@ def live_url(url: str, timeout=5):
                                                   'Accept-Language': 'en-US,en;q=0.9',
                                                   'Connection': 'keep-alive'})
     session = requests.Session()
-    code = session.send(req.prepare(), timeout=timeout).status_code
+    prepped = session.prepare_request(req)
+    settings = session.merge_environment_settings(prepped.url, {}, None, None, None)
+    code = session.send(prepped, timeout=timeout, **settings).status_code
     if (code / 100 >= 4):
       print(f"ERROR: {code} Nothing there")
       return False

--- a/rspec-tools/rspec_tools/utils.py
+++ b/rspec-tools/rspec_tools/utils.py
@@ -8,7 +8,8 @@ import json
 import os
 from rspec_tools.errors import InvalidArgumentError
 
-SUPPORTED_LANGUAGES_FILENAME = '../supported_languages.adoc'
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SUPPORTED_LANGUAGES_FILENAME = REPO_ROOT / 'supported_languages.adoc'
 LANG_TO_LABEL = {'abap': 'abap',
                  'apex': 'slang',
                  'azureresourcemanager': 'iac',

--- a/rspec-tools/rspec_tools/validation/description.py
+++ b/rspec-tools/rspec_tools/validation/description.py
@@ -193,7 +193,7 @@ def known_highlight(language):
 
 def validate_source_language(rule_language: LanguageSpecificRule):
   descr = rule_language.description
-  for h2 in descr.findAll('h2'):
+  for h2 in descr.find_all('h2'):
     name = h2.text.strip()
     if name.startswith('Compliant') or name.startswith('Noncompliant'):
       for pre in h2.parent.find_all('pre'):

--- a/rspec-tools/tests/conftest.py
+++ b/rspec-tools/tests/conftest.py
@@ -43,7 +43,7 @@ def git_config():
 @pytest.fixture
 def mock_git_rspec_repo(tmpdir, mockrules: Path):
   repo_dir = tmpdir.mkdir("mock_rspec")
-  repo = Repo.init(str(repo_dir))
+  repo = Repo.init(str(repo_dir), b='master')
   rules_dir = repo_dir.join('rules')
   shutil.copytree(mockrules, rules_dir)
 

--- a/rspec-tools/tests/links/__init__.py
+++ b/rspec-tools/tests/links/__init__.py
@@ -1,0 +1,1 @@
+# this is a package

--- a/rspec-tools/tests/links/test_links.py
+++ b/rspec-tools/tests/links/test_links.py
@@ -1,11 +1,14 @@
 from click.testing import CliRunner
 from rspec_tools import cli
 from rspec_tools import checklinks
+from pathlib import Path
+
+FILE_DIR = Path(__file__).resolve().parent
 
 def test_find_urls():
   urls={}
-  checklinks.findurl_in_html("tests/links/404/S100/java/rule.html",urls)
-  assert urls == {'https://www.google.com/404': ['tests/links/404/S100/java/rule.html']}
+  checklinks.findurl_in_html(FILE_DIR / "404/S100/java/rule.html",urls)
+  assert urls == {'https://www.google.com/404': [FILE_DIR / '404/S100/java/rule.html']}
   assert len(urls) == 1
 
 def test_live():
@@ -16,28 +19,28 @@ def test_live():
 
 def test_404():
   runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d=tests/links/404'])
+  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / '404'])
   print(result.output)
   assert result.exit_code == 1
   assert "1/1 links are dead, see above ^^ the list and the related files" in result.output
 
 def test_url():
   runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d=tests/links/URL'])
+  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'URL'])
   print(result.output)
   assert result.exit_code == 1
   assert "1/1 links are dead, see above ^^ the list and the related files" in result.output
 
 def test_ok():
   runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d=tests/links/OK'])
+  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'OK'])
   print(result.output)
   assert result.exit_code == 0
   assert "All 1 links are good" in result.output
 
 def test_deprecated():
   runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d=tests/links/deprecated'])
+  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'deprecated'])
   print(result.output)
   assert result.exit_code == 0
   assert "All 1 links are good" in result.output

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -98,7 +98,7 @@ def mock_git_analyzer_repos(tmpdir):
   for mock_spec in MOCK_REPOS:
     repo_name = mock_spec['name']
     repo_dir = tmpdir.mkdir('mock-' + repo_name)
-    repo = Repo.init(str(repo_dir))
+    repo = Repo.init(str(repo_dir), b='master')
     with repo.config_writer() as config_writer:
       config_writer.set_value('user', 'name', 'originuser')
       config_writer.set_value('user', 'email', 'originuser@mock.mock')

--- a/rspec-tools/tests/validation/__init__.py
+++ b/rspec-tools/tests/validation/__init__.py
@@ -1,0 +1,1 @@
+# this is a package


### PR DESCRIPTION
When I tried to run the tests locally, I encountered two issues:
- rspec-tools ignore `REQUESTS_CA_BUNDLE`, which makes them fail given that I have traffic inspection on my work laptop
- rspec-tools assume `master` to be the default branch, which is not the case in my config

This change fixes both problems, and addreses the bs4 deprecation warning.