### PR TITLE
Batch-reformat rspec-tools to follow the python conventions and enforce code style in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,6 +43,8 @@ tooling_tests_task:
     - bash ci/fetch_branches.sh
     - cd rspec-tools
     - pipenv run pytest --cov=rspec_tools --cov-report=xml
+    - pipenv run black --check rspec_tools tests
+    - pipenv run usort check rspec_tools tests
   <<: *SETUP_SONAR_SCANNER
   analyze_script:
     - cd rspec-tools

--- a/rspec-tools/Pipfile
+++ b/rspec-tools/Pipfile
@@ -21,6 +21,7 @@ pytest-snapshot = "*"
 pytest-cov = "*"
 black = "*"
 usort = "*"
+flake8 = "*"
 
 [requires]
 python_version = "3.12"

--- a/rspec-tools/Pipfile
+++ b/rspec-tools/Pipfile
@@ -19,6 +19,8 @@ pytest = ">=6.2.2"
 mypy = ">=0.800"
 pytest-snapshot = "*"
 pytest-cov = "*"
+black = "*"
+usort = "*"
 
 [requires]
 python_version = "3.12"

--- a/rspec-tools/Pipfile.lock
+++ b/rspec-tools/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "30075c8f32a8504cbd8246c0c575868b14efb789de89143b876735ae79bdb331"
+            "sha256": "051c2b2dc99c0186205c2ad66bbccee1ee2458f85364605902857e38c53e30f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1278,6 +1278,15 @@
             "markers": "python_version >= '3.9'",
             "version": "==7.8.0"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343",
+                "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==7.2.0"
+        },
         "iniconfig": {
             "hashes": [
                 "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
@@ -1327,6 +1336,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.7.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
         },
         "moreorless": {
             "hashes": [
@@ -1414,6 +1431,22 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.5.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9",
+                "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.13.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a",
+                "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.3.2"
         },
         "pytest": {
             "hashes": [

--- a/rspec-tools/Pipfile.lock
+++ b/rspec-tools/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddb34a01ad4ec8999928f1f5f5d8b0096f1bf0044a4d61981f70cd3c8d69bbf1"
+            "sha256": "30075c8f32a8504cbd8246c0c575868b14efb789de89143b876735ae79bdb331"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1160,6 +1160,52 @@
         }
     },
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+                "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==25.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
+                "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7",
+                "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da",
+                "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2",
+                "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc",
+                "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666",
+                "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f",
+                "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b",
+                "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32",
+                "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f",
+                "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717",
+                "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299",
+                "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0",
+                "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18",
+                "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0",
+                "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3",
+                "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355",
+                "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096",
+                "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e",
+                "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9",
+                "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba",
+                "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==25.1.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
+        },
         "coverage": {
             "extras": [
                 "toml"
@@ -1240,6 +1286,56 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.1.0"
         },
+        "libcst": {
+            "hashes": [
+                "sha256:0456381c939169c4f11caecdb30f7aca6f234640731f8f965849c1631930536b",
+                "sha256:09a5530b40a15dbe6fac842ef2ad87ad561760779380ccf3ade6850854d81406",
+                "sha256:14e5c1d427c33d50df75be6bc999a7b2d7c6b7840e2361a18a6f354db50cb18e",
+                "sha256:1560598f5c56681adbd32f4b08e9cffcd45a021921d1d784370a7d4d9a2fac11",
+                "sha256:340054c57abcd42953248af18ed278be651a03b1c2a1616f7e1f1ef90b6018ce",
+                "sha256:3923a341a787c1f454909e726a6213dd59c3db26c6e56d0a1fc4f2f7e96b45d7",
+                "sha256:3d2ec10015e86a4402c3d2084ede6c7c9268faea1ecb99592fe9e291c515aaa2",
+                "sha256:4c568e14d29489f09faf4915af18235f805d5aa60fa194023b4fadf3209f0c94",
+                "sha256:57a6bcfc8ca8a0bb9e89a2dbf63ee8f0c7e8353a130528dcb47c9e59c2dc8c94",
+                "sha256:5d5ba9314569865effd5baff3a58ceb2cced52228e181824759c68486a7ec8f4",
+                "sha256:5e22738ec2855803f8242e6bf78057389d10f8954db34bf7079c82abab1b8b95",
+                "sha256:5e50e6960ecc3ed67f39fec63aa329e772d5d27f8e2334e30f19a94aa14489f1",
+                "sha256:6137fe549bfbb017283c3cf85419eb0dfaa20a211ad6d525538a2494e248a84b",
+                "sha256:61bfc90c8a4594296f8b68702f494dfdfec6e745a4abc0cfa8069d7f22061424",
+                "sha256:6523731bfbdbc045ff8649130fe14a46b31ad6925f67acdc0e0d80a0c61719fd",
+                "sha256:71a8f59f3472fe8c0f6e2fad457825ea2ccad8c4c713cca55a91ff2cbfa9bc03",
+                "sha256:81036e820249937608db7e72d0799180122d40d76d0c0414c454f8aa2ffa9c51",
+                "sha256:8f6e693281d6e9a62414205fb300ec228ddc902ca9cb965a09f11561dc10aa94",
+                "sha256:932a4c4508bd4cf5248c99b7218bb86af97d87fefa2bdab7ea8a0c28c270724a",
+                "sha256:93417d36c2a1b70d651d0e970ff73339e8dcd64d341672b68823fa0039665022",
+                "sha256:9370c23a3f609280c3f2296d61d34dd32afd7a1c9b19e4e29cc35cb2e2544363",
+                "sha256:94acd51ea1206460c20dea764c59222e62c45ae8a486f22024f063d11a7bca88",
+                "sha256:9add619a825d6f176774110d79dc3137f353a236c1e3bcd6e063ca6d93d6e0ae",
+                "sha256:9cd5ab15b12a37f0e9994d8847d5670da936a93d98672c442a956fab34ea0c15",
+                "sha256:a252fa03ea00986f03100379f11e15d381103a09667900fb0fa2076cec19081a",
+                "sha256:a63f44ffa81292f183656234c7f2848653ff45c17d867db83c9335119e28aafa",
+                "sha256:b52692a28d0d958ebfabcf8bfce5fcf2c8582967310d35e6111a6e2d4db96659",
+                "sha256:c3445dce908fd4971ce9bb5fef5742e26c984027676e3dcf24875fbed1ff7e4c",
+                "sha256:c8d6176a667d2db0132d133dad6bbf965f915f3071559342ca2cdbbec537ed12",
+                "sha256:ca4e91aa854758040fa6fe7036fbe7f90a36a7d283fa1df8587b6f73084fc997",
+                "sha256:cdae6e632d222d8db7cb98d7cecb45597c21b8e3841d0c98d4fca79c49dad04b",
+                "sha256:d12ffe199ff677a37abfb6b21aba1407eb02246dc7e6bcaf4f8e24a195ec4ad6",
+                "sha256:d894c48f682b0061fdb2c983d5e64c30334db6ce0783560dbbb9df0163179c0c",
+                "sha256:e635eadb6043d5f967450af27125811c6ccc7eeb4d8c5fd4f1bece9d96418781",
+                "sha256:e7d9a796c2f3d5b71dd06b7578e8d1fb1c031d2eb8d59e7b40e288752ae1b210",
+                "sha256:fa519d4391326329f37860c2f2aaf80cb11a6122d14afa2f4f00dde6fcfa7ae4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.7.0"
+        },
+        "moreorless": {
+            "hashes": [
+                "sha256:17f1fbef60fd21c84ee085a929fe3acefcaddca30df5dd09c024e9939a9e6a00",
+                "sha256:85e19972c1a0b3a49f8543914f57bd83f6e1b10df144d5b97b8c5e9744d9c08c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.4.0"
+        },
         "mypy": {
             "hashes": [
                 "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e",
@@ -1295,6 +1391,22 @@
             "markers": "python_version >= '3.8'",
             "version": "==24.2"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94",
+                "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.3.7"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
@@ -1330,6 +1442,89 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.9.0"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
+        },
+        "stdlibs": {
+            "hashes": [
+                "sha256:bb327c1369434c453ef68f3d0ac37d707f568e498f19d7a88f483843b99338e1",
+                "sha256:df358ef5556a9e3ac78d6ec04213ee6f10903db2b6da25f273a10de148c4f165"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2025.4.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.2"
+        },
+        "trailrunner": {
+            "hashes": [
+                "sha256:3fe61e259e6b2e5192f321c265985b7a0dc18497ced62b2da244f08104978398",
+                "sha256:a286d39f2723f28d167347f41cf8f232832648709366e722f55cf5545772a48e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.4.0"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69",
@@ -1337,6 +1532,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==4.13.1"
+        },
+        "usort": {
+            "hashes": [
+                "sha256:68def75f2b20b97390c552c503e071ee06c65ad502c5f94f3bd03f095cf4dfe6",
+                "sha256:6c57cdf17b458c79f8a61eb3ce8bf3f93e36d3c2edd602b9b2aa16b6875d3255"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.8.post1"
         }
     }
 }

--- a/rspec-tools/README.adoc
+++ b/rspec-tools/README.adoc
@@ -54,6 +54,15 @@ $ pipenv run black rspec_tools tests
 $ pipenv run usort format rspec_tools tests
 ----
 
+.Lint
+
+Note, this step is not run in CI because it is not configured in CAYC mode.
+You can also run flake8 in your IDE.
+[source,sh]
+----
+$ pipenv run flake8
+----
+
 .Fixtures
 
 When writing a new test, create a fixture rule in `tests/resources/{invalid_rules, rules}`.

--- a/rspec-tools/README.adoc
+++ b/rspec-tools/README.adoc
@@ -47,6 +47,13 @@ $ pipenv install --dev
 $ pipenv run pytest
 ----
 
+.Format
+[source,sh]
+----
+$ pipenv run black rspec_tools tests
+$ pipenv run usort format rspec_tools tests
+----
+
 .Fixtures
 
 When writing a new test, create a fixture rule in `tests/resources/{invalid_rules, rules}`.

--- a/rspec-tools/rspec_tools/__init__.py
+++ b/rspec-tools/rspec_tools/__init__.py
@@ -1,3 +1,3 @@
 from .cli import cli
 
-__all__=["cli"]
+__all__ = ["cli"]

--- a/rspec-tools/rspec_tools/checklinks.py
+++ b/rspec-tools/rspec_tools/checklinks.py
@@ -8,221 +8,244 @@ import requests
 from bs4 import BeautifulSoup
 
 TOLERABLE_LINK_DOWNTIME = datetime.timedelta(days=7)
-LINK_PROBES_HISTORY_FILE = './link_probes.history'
+LINK_PROBES_HISTORY_FILE = "./link_probes.history"
 PROBING_COOLDOWN = datetime.timedelta(days=2)
-PROBING_SPREAD = 60 * 24 # in minutes, 1 day
+PROBING_SPREAD = 60 * 24  # in minutes, 1 day
 link_probes_history = {}
 
 # These links consistently fail in CI, but work-on-my-machine
 EXCEPTION_PREFIXES = [
-  # It seems the server certificate was renewed on 2nd of August 2024.
-  # The server is sending only its certificate, without including the
-  # Intermediate certificate used to issue the server cert. Because of that
-  # some application are not able to verify the complete chain of trust.
-  "https://wiki.sei.cmu.edu/",
-  # The CI reports 403 on drupal.org while it works locally.
-  # Maybe the CI's IP is blocklisted...
-  "https://www.drupal.org/",
+    # It seems the server certificate was renewed on 2nd of August 2024.
+    # The server is sending only its certificate, without including the
+    # Intermediate certificate used to issue the server cert. Because of that
+    # some application are not able to verify the complete chain of trust.
+    "https://wiki.sei.cmu.edu/",
+    # The CI reports 403 on drupal.org while it works locally.
+    # Maybe the CI's IP is blocklisted...
+    "https://www.drupal.org/",
 ]
 
+
 def show_files(filenames):
-  for filename in filenames:
-    print(filename)
+    for filename in filenames:
+        print(filename)
+
 
 def load_url_probing_history():
-  global link_probes_history
-  try:
-    with open(LINK_PROBES_HISTORY_FILE, 'r') as link_probes_history_stream:
-      print('Using the historical url-probe results from ' + LINK_PROBES_HISTORY_FILE)
-      link_probes_history = eval(link_probes_history_stream.read())
-  except Exception as e:
-    # If the history file is not present, ignore, will create one in the end.
-    print(f"Failed to load historical url-probe results: {e}")
+    global link_probes_history
+    try:
+        with open(LINK_PROBES_HISTORY_FILE, "r") as link_probes_history_stream:
+            print(
+                "Using the historical url-probe results from "
+                + LINK_PROBES_HISTORY_FILE
+            )
+            link_probes_history = eval(link_probes_history_stream.read())
+    except Exception as e:
+        # If the history file is not present, ignore, will create one in the end.
+        print(f"Failed to load historical url-probe results: {e}")
+
 
 def save_url_probing_history():
-  global link_probes_history
-  with open(LINK_PROBES_HISTORY_FILE, 'w') as link_probes_history_stream:
-    link_probes_history_stream.write(str(link_probes_history))
+    global link_probes_history
+    with open(LINK_PROBES_HISTORY_FILE, "w") as link_probes_history_stream:
+        link_probes_history_stream.write(str(link_probes_history))
+
 
 def rejuvenate_url(url: str):
-  global link_probes_history
-  link_probes_history[url] = datetime.datetime.now()
+    global link_probes_history
+    link_probes_history[url] = datetime.datetime.now()
+
 
 def url_is_long_dead(url: str):
-  global link_probes_history
-  if url not in link_probes_history:
-    return True
-  last_time_up = link_probes_history[url]
-  print(f"{url} was reached most recently on {last_time_up}")
-  return TOLERABLE_LINK_DOWNTIME < (datetime.datetime.now() - last_time_up)
+    global link_probes_history
+    if url not in link_probes_history:
+        return True
+    last_time_up = link_probes_history[url]
+    print(f"{url} was reached most recently on {last_time_up}")
+    return TOLERABLE_LINK_DOWNTIME < (datetime.datetime.now() - last_time_up)
+
 
 def url_was_reached_recently(url: str):
-  global link_probes_history
-  if url not in link_probes_history:
-    return False
-  last_time_up = link_probes_history[url]
-  spread = random.randrange(PROBING_SPREAD)
-  probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
-  return (datetime.datetime.now() - last_time_up) < probing_cooldown
+    global link_probes_history
+    if url not in link_probes_history:
+        return False
+    last_time_up = link_probes_history[url]
+    spread = random.randrange(PROBING_SPREAD)
+    probing_cooldown = PROBING_COOLDOWN + datetime.timedelta(minutes=spread)
+    return (datetime.datetime.now() - last_time_up) < probing_cooldown
+
 
 def live_url(url: str, timeout=5):
-  if url.startswith('#'):
-    return True
-  try:
-    req = requests.Request('GET', url, headers = {'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="90"',
-                                                  'sec-ch-ua-mobile': '?0',
-                                                  'Upgrade-Insecure-Requests': '1',
-                                                  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 GLS/100.10.9939.100',
-                                                  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-                                                  'Sec-Fetch-Site':'none',
-                                                  'Sec-Fetch-Mode':'navigate',
-                                                  'Sec-Fetch-User':'?1',
-                                                  'Sec-Fetch-Dest':'document',
-                                                  'Accept-Encoding': 'gzip, deflate, br',
-                                                  'Accept-Language': 'en-US,en;q=0.9',
-                                                  'Connection': 'keep-alive'})
-    session = requests.Session()
-    prepped = session.prepare_request(req)
-    settings = session.merge_environment_settings(prepped.url, {}, None, None, None)
-    code = session.send(prepped, timeout=timeout, **settings).status_code
-    if (code / 100 >= 4):
-      print(f"ERROR: {code} Nothing there")
-      return False
-    else:
-      return True
-  except requests.ConnectionError as ce:
-    print(f"ERROR: Connection error {ce}")
-    return False
-  except requests.HTTPError as h:
-    print(f"ERROR: HTTP error {h}")
-    return False
-  except requests.URLRequired as e:
-    print(f"ERROR: Bad URL: {e}")
-    return False
-  except requests.TooManyRedirects as rr:
-    print(f"ERROR: Too many redirects: {rr}")
-    return False
-  except requests.Timeout as t:
-    print(f"ERROR: Request timeout {t}")
-    return False
-  except socket.timeout as t:
-    print(f"ERROR: Socket timeout {t}")
-    return False
-  except Exception as e:
-    print(f"ERROR: {e}")
-    return False
+    if url.startswith("#"):
+        return True
+    try:
+        req = requests.Request(
+            "GET",
+            url,
+            headers={
+                "sec-ch-ua": '" Not A;Brand";v="99", "Chromium";v="90"',
+                "sec-ch-ua-mobile": "?0",
+                "Upgrade-Insecure-Requests": "1",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 GLS/100.10.9939.100",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+                "Sec-Fetch-Site": "none",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-User": "?1",
+                "Sec-Fetch-Dest": "document",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Connection": "keep-alive",
+            },
+        )
+        session = requests.Session()
+        prepped = session.prepare_request(req)
+        settings = session.merge_environment_settings(prepped.url, {}, None, None, None)
+        code = session.send(prepped, timeout=timeout, **settings).status_code
+        if code / 100 >= 4:
+            print(f"ERROR: {code} Nothing there")
+            return False
+        else:
+            return True
+    except requests.ConnectionError as ce:
+        print(f"ERROR: Connection error {ce}")
+        return False
+    except requests.HTTPError as h:
+        print(f"ERROR: HTTP error {h}")
+        return False
+    except requests.URLRequired as e:
+        print(f"ERROR: Bad URL: {e}")
+        return False
+    except requests.TooManyRedirects as rr:
+        print(f"ERROR: Too many redirects: {rr}")
+        return False
+    except requests.Timeout as t:
+        print(f"ERROR: Request timeout {t}")
+        return False
+    except socket.timeout as t:
+        print(f"ERROR: Socket timeout {t}")
+        return False
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return False
 
-def findurl_in_html(filename,urls):
-  with open(filename, 'r', encoding="utf8") as file:
-    soup = BeautifulSoup(file,features="html.parser")
-    for link in soup.find_all('a'):
-      key=link.get('href')
-      if key in urls:
-        urls[key].append(filename)
-      else:
-        urls[key]=[filename]
+
+def findurl_in_html(filename, urls):
+    with open(filename, "r", encoding="utf8") as file:
+        soup = BeautifulSoup(file, features="html.parser")
+        for link in soup.find_all("a"):
+            key = link.get("href")
+            if key in urls:
+                urls[key].append(filename)
+            else:
+                urls[key] = [filename]
+
 
 def is_active(metadata_fname, generic_metadata_fname):
-  try:
-    with open(metadata_fname) as metadata_file:
-      metadata = json.load(metadata_file)
-      if 'status' in metadata:
-        return metadata['status'] == 'ready'
-    with open(generic_metadata_fname) as generic_metadata_file:
-      generic_metdata = json.load(generic_metadata_file)
-      if 'status' in generic_metdata:
-        return generic_metdata['status'] == 'ready'
-  except EnvironmentError:
+    try:
+        with open(metadata_fname) as metadata_file:
+            metadata = json.load(metadata_file)
+            if "status" in metadata:
+                return metadata["status"] == "ready"
+        with open(generic_metadata_fname) as generic_metadata_file:
+            generic_metdata = json.load(generic_metadata_file)
+            if "status" in generic_metdata:
+                return generic_metdata["status"] == "ready"
+    except EnvironmentError:
+        return True
     return True
-  return True
+
 
 def get_all_links_from_htmls(dir):
-  print("Finding links in html files")
-  urls={}
-  for rulepath in pathlib.Path(dir).iterdir():
-    if not rulepath.is_dir():
-      continue
-    generic_metadata=rulepath.joinpath('metadata.json')
-    for langpath in rulepath.iterdir():
-      if not langpath.is_dir():
-        continue
-      metadata=langpath.joinpath('metadata.json')
-      filepath=langpath.joinpath('rule.html')
-      filename=str(filepath.absolute())
-      if filepath.exists() and is_active(metadata, generic_metadata):
-        findurl_in_html(filename,urls)
-  print("All html files crawled")
-  return urls
+    print("Finding links in html files")
+    urls = {}
+    for rulepath in pathlib.Path(dir).iterdir():
+        if not rulepath.is_dir():
+            continue
+        generic_metadata = rulepath.joinpath("metadata.json")
+        for langpath in rulepath.iterdir():
+            if not langpath.is_dir():
+                continue
+            metadata = langpath.joinpath("metadata.json")
+            filepath = langpath.joinpath("rule.html")
+            filename = str(filepath.absolute())
+            if filepath.exists() and is_active(metadata, generic_metadata):
+                findurl_in_html(filename, urls)
+    print("All html files crawled")
+    return urls
+
 
 def url_is_exception(url: str) -> bool:
-  return any(
-    url.startswith(e) for e in EXCEPTION_PREFIXES
-  )
+    return any(url.startswith(e) for e in EXCEPTION_PREFIXES)
+
 
 def probe_links(urls: dict) -> bool:
-  errors = []
-  link_cache_exception = 0
-  link_cache_hit = 0
-  link_cache_miss = 0
-  print("Testing links")
-  link_count = len(urls)
-  for idx, url in enumerate(urls):
-    print(f"[{idx+1}/{link_count}] {url} in {len(urls[url])} files")
-    if url_is_exception(url):
-      link_cache_exception += 1
-      print("skip as an exception")
-    elif url_was_reached_recently(url):
-      link_cache_hit += 1
-      print("skip probing because it was reached recently")
-    elif live_url(url, timeout=5):
-      link_cache_miss += 1
-      rejuvenate_url(url)
-    elif url_is_long_dead(url):
-      link_cache_miss += 1
-      errors.append(url)
-    else:
-      link_cache_miss += 1
+    errors = []
+    link_cache_exception = 0
+    link_cache_hit = 0
+    link_cache_miss = 0
+    print("Testing links")
+    link_count = len(urls)
+    for idx, url in enumerate(urls):
+        print(f"[{idx+1}/{link_count}] {url} in {len(urls[url])} files")
+        if url_is_exception(url):
+            link_cache_exception += 1
+            print("skip as an exception")
+        elif url_was_reached_recently(url):
+            link_cache_hit += 1
+            print("skip probing because it was reached recently")
+        elif live_url(url, timeout=5):
+            link_cache_miss += 1
+            rejuvenate_url(url)
+        elif url_is_long_dead(url):
+            link_cache_miss += 1
+            errors.append(url)
+        else:
+            link_cache_miss += 1
 
-  confirmed_errors = confirm_errors(errors, urls)
+    confirmed_errors = confirm_errors(errors, urls)
 
-  print(f"\n\n\n{'=' * 80}\n\n\n")
-  if confirmed_errors:
-    report_errors(confirmed_errors, urls)
-    print(f"{len(confirmed_errors)}/{len(urls)} links are dead, see above ^^ the list and the related files\n\n")
-  print("Cache statistics:")
-  print(f"\t{link_cache_hit=}")
-  print(f"\t{link_cache_miss=}")
-  link_cache_hit_ratio = (link_cache_hit) / (link_cache_hit + link_cache_miss)
-  print(f"\t{link_cache_hit_ratio:03.2%} hits")
-  print(f"\t{link_cache_exception=}")
-  print(f"\n\n\n{'=' * 80}\n\n\n")
+    print(f"\n\n\n{'=' * 80}\n\n\n")
+    if confirmed_errors:
+        report_errors(confirmed_errors, urls)
+        print(
+            f"{len(confirmed_errors)}/{len(urls)} links are dead, see above ^^ the list and the related files\n\n"
+        )
+    print("Cache statistics:")
+    print(f"\t{link_cache_hit=}")
+    print(f"\t{link_cache_miss=}")
+    link_cache_hit_ratio = (link_cache_hit) / (link_cache_hit + link_cache_miss)
+    print(f"\t{link_cache_hit_ratio:03.2%} hits")
+    print(f"\t{link_cache_exception=}")
+    print(f"\n\n\n{'=' * 80}\n\n\n")
 
-  success = len(confirmed_errors) == 0
-  return success
+    success = len(confirmed_errors) == 0
+    return success
+
 
 def confirm_errors(presumed_errors, urls):
-  confirmed_errors = []
-  print(f"Retrying {len(presumed_errors)} failed probes")
-  for key in presumed_errors:
-    print(f"{key} in {len(urls[key])} files (previously failed)")
-    if not live_url(key, timeout=15):
-      confirmed_errors.append(key)
-    else:
-      rejuvenate_url(key)
-  return confirmed_errors
+    confirmed_errors = []
+    print(f"Retrying {len(presumed_errors)} failed probes")
+    for key in presumed_errors:
+        print(f"{key} in {len(urls[key])} files (previously failed)")
+        if not live_url(key, timeout=15):
+            confirmed_errors.append(key)
+        else:
+            rejuvenate_url(key)
+    return confirmed_errors
+
 
 def report_errors(errors, urls):
-  print("There were errors")
-  for key in errors:
-    print(f"{key} in:")
-    show_files(urls[key])
+    print("There were errors")
+    for key in errors:
+        print(f"{key} in:")
+        show_files(urls[key])
+
 
 def check_html_links(dir):
-  load_url_probing_history()
-  urls = get_all_links_from_htmls(dir)
-  success = probe_links(urls)
-  if success:
-    print(f"All {len(urls)} links are good")
-  save_url_probing_history()
-  exit(0 if success else 1)
-
+    load_url_probing_history()
+    urls = get_all_links_from_htmls(dir)
+    success = probe_links(urls)
+    if success:
+        print(f"All {len(urls)} links are good")
+    save_url_probing_history()
+    exit(0 if success else 1)

--- a/rspec-tools/rspec_tools/cli.py
+++ b/rspec-tools/rspec_tools/cli.py
@@ -7,152 +7,167 @@ import click
 import rspec_tools.create_rule
 import rspec_tools.modify_rule
 from rspec_tools.checklinks import check_html_links
-from rspec_tools.coverage import (update_coverage_for_all_repos,
-                                  update_coverage_for_repo,
-                                  update_coverage_for_repo_version)
+from rspec_tools.coverage import (
+    update_coverage_for_all_repos,
+    update_coverage_for_repo,
+    update_coverage_for_repo_version,
+)
 from rspec_tools.errors import RuleValidationError
 from rspec_tools.notify_failure_on_slack import notify_slack
 from rspec_tools.rules import LanguageSpecificRule, RulesRepository
-from rspec_tools.validation.description import (validate_subsections,
-                                                validate_parameters,
-                                                validate_section_levels,
-                                                validate_section_names,
-                                                validate_source_language,
-                                                validate_security_standard_links)
-from rspec_tools.validation.sanitize_asciidoc import sanitize_asciidoc
+from rspec_tools.validation.description import (
+    validate_parameters,
+    validate_section_levels,
+    validate_section_names,
+    validate_security_standard_links,
+    validate_source_language,
+    validate_subsections,
+)
 from rspec_tools.validation.metadata import validate_rule_metadata
+from rspec_tools.validation.sanitize_asciidoc import sanitize_asciidoc
 
 
 def _fatal_error(message: str):
-  click.echo(message, err=True)
-  raise click.Abort(message)
+    click.echo(message, err=True)
+    raise click.Abort(message)
+
 
 @click.group()
-@click.option('--debug/--no-debug', default=False)
+@click.option("--debug/--no-debug", default=False)
 def cli(debug):
-    'Tools automating RSPEC workflows.'
+    "Tools automating RSPEC workflows."
 
 
 @cli.command()
-@click.option('--d', required=True)
+@click.option("--d", required=True)
 def check_links(d):
-  '''Check links in html.'''
-  check_html_links(d)
+    """Check links in html."""
+    check_html_links(d)
 
 
 @cli.command()
-@click.option('--languages', required=True)
-@click.option('--user', required=False)
+@click.option("--languages", required=True)
+@click.option("--user", required=False)
 def create_rule(languages: str, user: Optional[str]):
-  '''Create a new rule.'''
-  token = os.environ.get('GITHUB_TOKEN')
-  rspec_tools.create_rule.create_new_rule(languages, token, user)
+    """Create a new rule."""
+    token = os.environ.get("GITHUB_TOKEN")
+    rspec_tools.create_rule.create_new_rule(languages, token, user)
 
 
 @cli.command()
-@click.option('--language', required=True)
-@click.option('--rule', required=True)
-@click.option('--user', required=False)
+@click.option("--language", required=True)
+@click.option("--rule", required=True)
+@click.option("--user", required=False)
 def add_lang_to_rule(language: str, rule: str, user: Optional[str]):
-  '''Add a new language to rule.'''
-  token = os.environ.get('GITHUB_TOKEN')
-  rspec_tools.create_rule.add_language_to_rule(language, rule, token, user)
+    """Add a new language to rule."""
+    token = os.environ.get("GITHUB_TOKEN")
+    rspec_tools.create_rule.add_language_to_rule(language, rule, token, user)
 
 
 @cli.command()
-@click.option('--language', required=True)
-@click.option('--rule', required=True)
-@click.option('--status', required=True)
-@click.option('--user', required=False)
+@click.option("--language", required=True)
+@click.option("--rule", required=True)
+@click.option("--status", required=True)
+@click.option("--user", required=False)
 def update_quickfix_status(language: str, rule: str, status: str, user: Optional[str]):
-  '''Update the status of quick fix for the given rule/language'''
-  token = os.environ.get('GITHUB_TOKEN')
-  rspec_tools.modify_rule.update_rule_quickfix_status(language, rule, status, token, user)
+    """Update the status of quick fix for the given rule/language"""
+    token = os.environ.get("GITHUB_TOKEN")
+    rspec_tools.modify_rule.update_rule_quickfix_status(
+        language, rule, status, token, user
+    )
 
 
 @cli.command()
-@click.argument('rules', nargs=-1, required=True)
+@click.argument("rules", nargs=-1, required=True)
 def validate_rules_metadata(rules):
-  '''Validate rules metadata.'''
-  rule_repository = RulesRepository()
-  error_counter = 0
+    """Validate rules metadata."""
+    rule_repository = RulesRepository()
+    error_counter = 0
 
-  for rule_id in rules:
-    try:
-      rule = rule_repository.get_rule(rule_id)
-      validate_rule_metadata(rule)
-    except RuleValidationError as e:
-      click.echo(e.message, err=True)
-      error_counter += 1
+    for rule_id in rules:
+        try:
+            rule = rule_repository.get_rule(rule_id)
+            validate_rule_metadata(rule)
+        except RuleValidationError as e:
+            click.echo(e.message, err=True)
+            error_counter += 1
 
-  if error_counter > 0:
-    _fatal_error(f"Validation failed due to {error_counter} errors out of {len(rules)} analyzed rules")
+    if error_counter > 0:
+        _fatal_error(
+            f"Validation failed due to {error_counter} errors out of {len(rules)} analyzed rules"
+        )
 
 
 @cli.command()
-@click.argument('files', nargs=-1, required=True)
+@click.argument("files", nargs=-1, required=True)
 def check_asciidoc(files):
-  '''Sanitize the AsciiDoc description.'''
-  error_counter = 0
-  for file in files:
-      error_counter += sanitize_asciidoc(Path(file))
-  if error_counter > 0:
-    _fatal_error(f"Validation of the asciidoc description failed due to {error_counter} errors")
+    """Sanitize the AsciiDoc description."""
+    error_counter = 0
+    for file in files:
+        error_counter += sanitize_asciidoc(Path(file))
+    if error_counter > 0:
+        _fatal_error(
+            f"Validation of the asciidoc description failed due to {error_counter} errors"
+        )
 
 
-VALIDATORS = [validate_subsections,
-              validate_section_names,
-              validate_section_levels,
-              validate_parameters,
-              validate_source_language,
-              validate_security_standard_links,
-              ]
+VALIDATORS = [
+    validate_subsections,
+    validate_section_names,
+    validate_section_levels,
+    validate_parameters,
+    validate_source_language,
+    validate_security_standard_links,
+]
+
+
 def _validate_rule_specialization(lang_spec_rule: LanguageSpecificRule):
-  error_counter = 0
-  for validator in VALIDATORS:
-    try:
-      validator(lang_spec_rule)
-    except RuleValidationError as e:
-      click.echo(e.message, err=True)
-      error_counter += 1
-  return error_counter
+    error_counter = 0
+    for validator in VALIDATORS:
+        try:
+            validator(lang_spec_rule)
+        except RuleValidationError as e:
+            click.echo(e.message, err=True)
+            error_counter += 1
+    return error_counter
 
 
 @cli.command()
-@click.option('--d', required=True)
-@click.argument('rules', nargs=-1)
+@click.option("--d", required=True)
+@click.argument("rules", nargs=-1)
 def check_description(d, rules):
-  '''Validate the rule.adoc description.'''
-  out_dir = Path(__file__).parent.parent.joinpath(d)
-  rule_repository = RulesRepository(rules_path=out_dir)
-  error_counter = 0
-  for rule in rule_repository.rules:
-    if rules and rule.id not in rules:
-      continue
-    for lang_spec_rule in rule.specializations:
-      error_counter += _validate_rule_specialization(lang_spec_rule)
-  if error_counter > 0:
-    _fatal_error(f"Validation failed due to {error_counter} errors")
+    """Validate the rule.adoc description."""
+    out_dir = Path(__file__).parent.parent.joinpath(d)
+    rule_repository = RulesRepository(rules_path=out_dir)
+    error_counter = 0
+    for rule in rule_repository.rules:
+        if rules and rule.id not in rules:
+            continue
+        for lang_spec_rule in rule.specializations:
+            error_counter += _validate_rule_specialization(lang_spec_rule)
+    if error_counter > 0:
+        _fatal_error(f"Validation failed due to {error_counter} errors")
 
 
 @cli.command()
-@click.option('--rulesdir', required=True)
-@click.option('--repository', required=False)
-@click.option('--version', required=False)
+@click.option("--rulesdir", required=True)
+@click.option("--repository", required=False)
+@click.option("--version", required=False)
 def update_coverage(rulesdir: str, repository: Optional[str], version: Optional[str]):
-  '''Update rule coverage by adding rules implemented in the {version} of {repository}.'''
-  if repository is None:
-      update_coverage_for_all_repos(Path(rulesdir))
-  elif version is None:
-      update_coverage_for_repo(repository, Path(rulesdir))
-  else:
-      update_coverage_for_repo_version(repository, version, Path(rulesdir))
+    """Update rule coverage by adding rules implemented in the {version} of {repository}."""
+    if repository is None:
+        update_coverage_for_all_repos(Path(rulesdir))
+    elif version is None:
+        update_coverage_for_repo(repository, Path(rulesdir))
+    else:
+        update_coverage_for_repo_version(repository, version, Path(rulesdir))
+
 
 @cli.command()
-@click.option('--message', required=True)
-@click.option('--channel', required=True)
+@click.option("--message", required=True)
+@click.option("--channel", required=True)
 def notify_failure_on_slack(message: str, channel: str):
-  notify_slack(message, channel)
+    notify_slack(message, channel)
 
 
-__all__=['cli']
+__all__ = ["cli"]

--- a/rspec-tools/rspec_tools/coverage.py
+++ b/rspec-tools/rspec_tools/coverage.py
@@ -6,245 +6,273 @@ import sys
 from pathlib import Path
 
 from git import Git, Repo
+
 from rspec_tools.utils import load_json, pushd
 
 REPOS = [
-  'sonar-abap',
-  'sonar-apex',
-  'sonar-architecture',
-  'sonar-cobol',
-  'sonar-cpp',
-  'sonar-dart',
-  'sonar-dataflow-bug-detection',
-  'sonar-dotnet-enterprise',
-  'sonar-flex',
-  'sonar-go-enterprise',
-  'sonar-html',
-  'sonar-iac-enterprise',
-  'sonar-java',
-  'SonarJS',
-  'sonar-kotlin',
-  'sonar-php',
-  'sonar-pli',
-  'sonar-plsql',
-  'sonar-python-enterprise',
-  'sonar-rpg',
-  'sonar-ruby',
-  'sonar-scala',
-  'sonar-security',
-  'sonar-swift',
-  'sonar-text-enterprise',
-  'sonar-tsql',
-  'sonar-vb',
-  'sonar-xml'
+    "sonar-abap",
+    "sonar-apex",
+    "sonar-architecture",
+    "sonar-cobol",
+    "sonar-cpp",
+    "sonar-dart",
+    "sonar-dataflow-bug-detection",
+    "sonar-dotnet-enterprise",
+    "sonar-flex",
+    "sonar-go-enterprise",
+    "sonar-html",
+    "sonar-iac-enterprise",
+    "sonar-java",
+    "SonarJS",
+    "sonar-kotlin",
+    "sonar-php",
+    "sonar-pli",
+    "sonar-plsql",
+    "sonar-python-enterprise",
+    "sonar-rpg",
+    "sonar-ruby",
+    "sonar-scala",
+    "sonar-security",
+    "sonar-swift",
+    "sonar-text-enterprise",
+    "sonar-tsql",
+    "sonar-vb",
+    "sonar-xml",
 ]
 
 CANONICAL_NAMES = {
-  'CLOUD_FORMATION': 'CLOUDFORMATION',
-  'JS': 'js',
-  'TS': 'ts',
-  'JAVASCRIPT': 'js',
-  'TYPESCRIPT': 'ts',
-  'WEB': 'HTML'
+    "CLOUD_FORMATION": "CLOUDFORMATION",
+    "JS": "js",
+    "TS": "ts",
+    "JAVASCRIPT": "js",
+    "TYPESCRIPT": "ts",
+    "WEB": "HTML",
 }
 
 
-RULES_FILENAME = 'covered_rules.json'
+RULES_FILENAME = "covered_rules.json"
 
 
 def get_rule_id(filename):
-  rule_id = filename[:-5]
-  return rule_id.removesuffix('_abap').removesuffix('_java')
+    rule_id = filename[:-5]
+    return rule_id.removesuffix("_abap").removesuffix("_java")
 
 
 def compatible_languages(rule, languages_from_sonarpedia):
-  '''
-  Some analyzers, like SonarJS and sonar-cpp handle multiple languages
-  by the same rule implementation. They add a special field "compatibleLanguages"
-  to the rule metadata to specify which languges each implementation is applicable to.
-  By default, the rule is applicable to all languages declared in sonarpedia.
-  '''
-  if "compatibleLanguages" in rule:
-    return rule["compatibleLanguages"]
-  else:
-    return languages_from_sonarpedia
+    """
+    Some analyzers, like SonarJS and sonar-cpp handle multiple languages
+    by the same rule implementation. They add a special field "compatibleLanguages"
+    to the rule metadata to specify which languges each implementation is applicable to.
+    By default, the rule is applicable to all languages declared in sonarpedia.
+    """
+    if "compatibleLanguages" in rule:
+        return rule["compatibleLanguages"]
+    else:
+        return languages_from_sonarpedia
+
 
 def get_implemented_rules(path, languages_from_sonarpedia):
-  implemented_rules = {}
-  for lang in languages_from_sonarpedia:
-    implemented_rules[lang] = []
-  for filename in os.listdir(path):
-    if filename.endswith(".json") and 'profile' not in filename:
-      rule = load_json(os.path.join(path, filename))
-      rule_id = get_rule_id(filename)
-      for language in compatible_languages(rule, languages_from_sonarpedia):
-        if language not in implemented_rules:
-          implemented_rules[language] = []
-        implemented_rules[language].append(rule_id)
-    else:
-      continue
-  return implemented_rules
+    implemented_rules = {}
+    for lang in languages_from_sonarpedia:
+        implemented_rules[lang] = []
+    for filename in os.listdir(path):
+        if filename.endswith(".json") and "profile" not in filename:
+            rule = load_json(os.path.join(path, filename))
+            rule_id = get_rule_id(filename)
+            for language in compatible_languages(rule, languages_from_sonarpedia):
+                if language not in implemented_rules:
+                    implemented_rules[language] = []
+                implemented_rules[language].append(rule_id)
+        else:
+            continue
+    return implemented_rules
+
 
 def canonicalize(language):
-  if language in CANONICAL_NAMES:
-    return CANONICAL_NAMES[language]
-  return language
+    if language in CANONICAL_NAMES:
+        return CANONICAL_NAMES[language]
+    return language
+
 
 def read_all_alternative_keys(metadata):
-  ret = []
-  if 'sqKey' in metadata:
-    ret.append(metadata['sqKey'])
-  if 'ruleSpecification' in metadata:
-    ret.append(metadata['ruleSpecification'])
-  if 'extra' in metadata and 'legacyKeys' in metadata['extra']:
-    ret.extend(metadata['extra']['legacyKeys'])
-  return ret
+    ret = []
+    if "sqKey" in metadata:
+        ret.append(metadata["sqKey"])
+    if "ruleSpecification" in metadata:
+        ret.append(metadata["ruleSpecification"])
+    if "extra" in metadata and "legacyKeys" in metadata["extra"]:
+        ret.extend(metadata["extra"]["legacyKeys"])
+    return ret
+
 
 def read_canonical_rule_ids(rules_dir):
-  '''
-  Map all the keys identifying a rule to its modern key (which is also its directory name).
-  '''
-  print('Collecting the rule-id synonyms from ' + str(rules_dir))
-  canonical_id = {}
-  rule_dirs = [entry for entry in os.scandir(rules_dir) if entry.is_dir()]
-  for rule_dir in rule_dirs:
-    for metadata_path in Path(rule_dir).rglob('metadata.json'):
-      for alternative_key in read_all_alternative_keys(load_json(metadata_path)):
-        canonical_id[alternative_key] = rule_dir.name
-  return canonical_id
+    """
+    Map all the keys identifying a rule to its modern key (which is also its directory name).
+    """
+    print("Collecting the rule-id synonyms from " + str(rules_dir))
+    canonical_id = {}
+    rule_dirs = [entry for entry in os.scandir(rules_dir) if entry.is_dir()]
+    for rule_dir in rule_dirs:
+        for metadata_path in Path(rule_dir).rglob("metadata.json"):
+            for alternative_key in read_all_alternative_keys(load_json(metadata_path)):
+                canonical_id[alternative_key] = rule_dir.name
+    return canonical_id
+
 
 class Coverage:
-  '''Keep and update the coverage DB: lang*rule_id -> analyzer version'''
-  def __init__(self, filename, rules_dir):
-    self.rules = {}
-    self.canonical_ids = read_canonical_rule_ids(rules_dir)
-    if os.path.exists(filename):
-      self.rules = load_json(filename)
+    """Keep and update the coverage DB: lang*rule_id -> analyzer version"""
 
-  def save_to_file(self, filename):
-    with open(filename, 'w') as outfile:
-      json.dump(self.rules, outfile, indent=2, sort_keys=True)
+    def __init__(self, filename, rules_dir):
+        self.rules = {}
+        self.canonical_ids = read_canonical_rule_ids(rules_dir)
+        if os.path.exists(filename):
+            self.rules = load_json(filename)
 
-  def _rule_implemented_for_intermediate_version(self, rule_id, language, repo_and_version):
-    if rule_id not in self.rules[language]:
-      self.rules[language][rule_id] = {'since': repo_and_version, 'until': repo_and_version}
-    elif type(self.rules[language][rule_id]) == dict:
-      self.rules[language][rule_id]['until'] = repo_and_version
-    else:
-      self.rules[language][rule_id] = {'since': self.rules[language][rule_id], 'until': repo_and_version}
+    def save_to_file(self, filename):
+        with open(filename, "w") as outfile:
+            json.dump(self.rules, outfile, indent=2, sort_keys=True)
 
-  def _rule_implemented_for_last_version(self, rule_id, language, repo_and_version):
-    if rule_id not in self.rules[language]:
-      self.rules[language][rule_id] = repo_and_version
-    elif type(self.rules[language][rule_id]) == dict:
-      self.rules[language][rule_id] = self.rules[language][rule_id]['since']
+    def _rule_implemented_for_intermediate_version(
+        self, rule_id, language, repo_and_version
+    ):
+        if rule_id not in self.rules[language]:
+            self.rules[language][rule_id] = {
+                "since": repo_and_version,
+                "until": repo_and_version,
+            }
+        elif type(self.rules[language][rule_id]) == dict:
+            self.rules[language][rule_id]["until"] = repo_and_version
+        else:
+            self.rules[language][rule_id] = {
+                "since": self.rules[language][rule_id],
+                "until": repo_and_version,
+            }
 
-  def rule_implemented(self, rule_id, language, analyzer, version):
-    repo_and_version = analyzer + ' ' + version
-    language = canonicalize(language)
-    if rule_id in self.canonical_ids:
-      rule_id = self.canonical_ids[rule_id]
+    def _rule_implemented_for_last_version(self, rule_id, language, repo_and_version):
+        if rule_id not in self.rules[language]:
+            self.rules[language][rule_id] = repo_and_version
+        elif type(self.rules[language][rule_id]) == dict:
+            self.rules[language][rule_id] = self.rules[language][rule_id]["since"]
 
-    if language not in self.rules:
-      print(f"Create entry for {language}")
-      self.rules[language] = {}
+    def rule_implemented(self, rule_id, language, analyzer, version):
+        repo_and_version = analyzer + " " + version
+        language = canonicalize(language)
+        if rule_id in self.canonical_ids:
+            rule_id = self.canonical_ids[rule_id]
 
-    if version == 'master':
-      self._rule_implemented_for_last_version(rule_id, language, repo_and_version)
-    else:
-      self._rule_implemented_for_intermediate_version(rule_id, language, repo_and_version)
+        if language not in self.rules:
+            print(f"Create entry for {language}")
+            self.rules[language] = {}
 
-  # analyzer+version uniquely identifies the analyzer and version implementing
-  # the rule for the given languages.
-  # Rule implementations for some languages are spread across multiple repositories
-  # for example sonar-java and sonar-security for Java.
-  # We use analyzer+version to avoid confusion between versions of different analyzers.
-  def add_analyzer_version(self, analyzer, version, implemented_rules_per_language):
-    for language in implemented_rules_per_language:
-      for rule_id in implemented_rules_per_language[language]:
-        self.rule_implemented(rule_id, language, analyzer, version)
+        if version == "master":
+            self._rule_implemented_for_last_version(rule_id, language, repo_and_version)
+        else:
+            self._rule_implemented_for_intermediate_version(
+                rule_id, language, repo_and_version
+            )
+
+    # analyzer+version uniquely identifies the analyzer and version implementing
+    # the rule for the given languages.
+    # Rule implementations for some languages are spread across multiple repositories
+    # for example sonar-java and sonar-security for Java.
+    # We use analyzer+version to avoid confusion between versions of different analyzers.
+    def add_analyzer_version(self, analyzer, version, implemented_rules_per_language):
+        for language in implemented_rules_per_language:
+            for rule_id in implemented_rules_per_language[language]:
+                self.rule_implemented(rule_id, language, analyzer, version)
+
 
 def all_implemented_rules():
-  implemented_rules = collections.defaultdict(list)
-  for sp_file in Path('.').rglob('sonarpedia.json'):
-    print(sp_file)
-    sonarpedia_path=sp_file.parents[0]
-    try:
-      sonarpedia = load_json(sp_file)
-      path = str(sonarpedia_path) + '/' + sonarpedia['rules-metadata-path'].replace('\\', '/')
-      languages = sonarpedia['languages']
+    implemented_rules = collections.defaultdict(list)
+    for sp_file in Path(".").rglob("sonarpedia.json"):
+        print(sp_file)
+        sonarpedia_path = sp_file.parents[0]
+        try:
+            sonarpedia = load_json(sp_file)
+            path = (
+                str(sonarpedia_path)
+                + "/"
+                + sonarpedia["rules-metadata-path"].replace("\\", "/")
+            )
+            languages = sonarpedia["languages"]
 
-      implemented_rules_in_path = get_implemented_rules(path, languages)
-      for lang, rules in implemented_rules_in_path.items():
-        implemented_rules[lang] += rules
-    except Exception as e:
-      print(f"failed to collect implemented rules for {sp_file}: {e}")
-      continue
-  return implemented_rules
+            implemented_rules_in_path = get_implemented_rules(path, languages)
+            for lang, rules in implemented_rules_in_path.items():
+                implemented_rules[lang] += rules
+        except Exception as e:
+            print(f"failed to collect implemented rules for {sp_file}: {e}")
+            continue
+    return implemented_rules
+
 
 def checkout_repo(repo):
-  git_url=f"https://github.com/SonarSource/{repo}"
-  token=os.getenv('GITHUB_TOKEN')
-  if token:
-    git_url=f"https://oauth2:{token}@github.com/SonarSource/{repo}"
-  if not os.path.exists(repo):
-    return Repo.clone_from(git_url, repo)
-  else:
-    return Repo(repo)
+    git_url = f"https://github.com/SonarSource/{repo}"
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        git_url = f"https://oauth2:{token}@github.com/SonarSource/{repo}"
+    if not os.path.exists(repo):
+        return Repo.clone_from(git_url, repo)
+    else:
+        return Repo(repo)
 
 
-VERSION_RE = re.compile(r'\d[\d\.]+')
+VERSION_RE = re.compile(r"\d[\d\.]+")
+
+
 def is_version_tag(name):
-  return bool(re.fullmatch(VERSION_RE, name))
+    return bool(re.fullmatch(VERSION_RE, name))
 
 
 def comparable_version(key):
-  if not is_version_tag(key):
-    return [0]
-  return list(map(int, key.split('.')))
+    if not is_version_tag(key):
+        return [0]
+    return list(map(int, key.split(".")))
 
 
 def collect_coverage_for_all_versions(repo, coverage):
-  git_repo = checkout_repo(repo)
-  tags = git_repo.tags
-  versions = [tag.name for tag in tags if is_version_tag(tag.name)]
-  versions.sort(key = comparable_version)
-  for version in versions:
-    collect_coverage_for_version(repo, git_repo, version, coverage)
-  collect_coverage_for_version(repo, git_repo, 'master', coverage)
+    git_repo = checkout_repo(repo)
+    tags = git_repo.tags
+    versions = [tag.name for tag in tags if is_version_tag(tag.name)]
+    versions.sort(key=comparable_version)
+    for version in versions:
+        collect_coverage_for_version(repo, git_repo, version, coverage)
+    collect_coverage_for_version(repo, git_repo, "master", coverage)
+
 
 def collect_coverage_for_version(repo_name, git_repo, version, coverage):
-  g = Git(git_repo)
-  print(f"{repo_name} {version}")
-  repo_dir = git_repo.working_tree_dir
-  try:
-    with pushd(repo_dir):
-      git_repo.head.reference = git_repo.commit(version)
-      git_repo.head.reset(index=True, working_tree=True)
-      g.checkout(version)
-      implemented_rules = all_implemented_rules()
-      coverage.add_analyzer_version(repo_name, version, implemented_rules)
-  except Exception as e:
-    print(f"{repo_name} {version} checkout failed: {e}")
-    raise
+    g = Git(git_repo)
+    print(f"{repo_name} {version}")
+    repo_dir = git_repo.working_tree_dir
+    try:
+        with pushd(repo_dir):
+            git_repo.head.reference = git_repo.commit(version)
+            git_repo.head.reset(index=True, working_tree=True)
+            g.checkout(version)
+            implemented_rules = all_implemented_rules()
+            coverage.add_analyzer_version(repo_name, version, implemented_rules)
+    except Exception as e:
+        print(f"{repo_name} {version} checkout failed: {e}")
+        raise
+
 
 def update_coverage_for_all_repos(rules_dir):
-  print(f"batch mode for {REPOS}")
-  coverage = Coverage(RULES_FILENAME, rules_dir)
-  for repo in REPOS:
-    collect_coverage_for_all_versions(repo, coverage)
-  coverage.save_to_file(RULES_FILENAME)
+    print(f"batch mode for {REPOS}")
+    coverage = Coverage(RULES_FILENAME, rules_dir)
+    for repo in REPOS:
+        collect_coverage_for_all_versions(repo, coverage)
+    coverage.save_to_file(RULES_FILENAME)
+
 
 def update_coverage_for_repo(repo, rules_dir):
-  print(f"batch mode for {repo}")
-  coverage = Coverage(RULES_FILENAME, rules_dir)
-  collect_coverage_for_all_versions(repo, coverage)
-  coverage.save_to_file(RULES_FILENAME)
+    print(f"batch mode for {repo}")
+    coverage = Coverage(RULES_FILENAME, rules_dir)
+    collect_coverage_for_all_versions(repo, coverage)
+    coverage.save_to_file(RULES_FILENAME)
+
 
 def update_coverage_for_repo_version(repo, version, rules_dir):
-  print(f"checking {repo} version {version}")
-  coverage = Coverage(RULES_FILENAME, rules_dir)
-  git_repo = checkout_repo(repo)
-  collect_coverage_for_version(repo, git_repo, version, coverage)
-  coverage.save_to_file(RULES_FILENAME)
-
+    print(f"checking {repo} version {version}")
+    coverage = Coverage(RULES_FILENAME, rules_dir)
+    git_repo = checkout_repo(repo)
+    collect_coverage_for_version(repo, git_repo, version, coverage)
+    coverage.save_to_file(RULES_FILENAME)

--- a/rspec-tools/rspec_tools/create_rule.py
+++ b/rspec-tools/rspec_tools/create_rule.py
@@ -8,145 +8,194 @@ from github.PullRequest import PullRequest
 
 from rspec_tools.errors import InvalidArgumentError
 from rspec_tools.repo import RspecRepo, tmp_rspec_repo
-from rspec_tools.utils import (LANG_TO_SOURCE, copy_directory_content,
-                               get_label_for_language,
-                               get_labels_for_languages, is_empty_metadata,
-                               parse_and_validate_language_list, resolve_rule,
-                               swap_metadata_files)
+from rspec_tools.utils import (
+    copy_directory_content,
+    get_label_for_language,
+    get_labels_for_languages,
+    is_empty_metadata,
+    LANG_TO_SOURCE,
+    parse_and_validate_language_list,
+    resolve_rule,
+    swap_metadata_files,
+)
 
 
 @contextmanager
 def _rule_creator(token: str, user: Optional[str]):
-  with tmp_rspec_repo(token, user) as repo:
-    yield RuleCreator(repo)
+    with tmp_rspec_repo(token, user) as repo:
+        yield RuleCreator(repo)
 
 
 def create_new_rule(languages: str, token: str, user: Optional[str]):
-  lang_list = parse_and_validate_language_list(languages)
-  label_list = get_labels_for_languages(lang_list)
-  with _rule_creator(token, user) as rule_creator:
-    rule_number = rule_creator.rspec_repo.reserve_rule_number()
-    rule_creator.create_new_rule_pull_request(token, rule_number, lang_list, label_list, user)
+    lang_list = parse_and_validate_language_list(languages)
+    label_list = get_labels_for_languages(lang_list)
+    with _rule_creator(token, user) as rule_creator:
+        rule_number = rule_creator.rspec_repo.reserve_rule_number()
+        rule_creator.create_new_rule_pull_request(
+            token, rule_number, lang_list, label_list, user
+        )
 
 
 def add_language_to_rule(language: str, rule: str, token: str, user: Optional[str]):
-  label = get_label_for_language(language)
-  rule_number = resolve_rule(rule)
-  with _rule_creator(token, user) as rule_creator:
-    rule_creator.add_language_pull_request(token, rule_number, language, label, user)
+    label = get_label_for_language(language)
+    rule_number = resolve_rule(rule)
+    with _rule_creator(token, user) as rule_creator:
+        rule_creator.add_language_pull_request(
+            token, rule_number, language, label, user
+        )
 
 
 class RuleCreator:
-  '''Create a new Rule in a repository following the official Github 'rspec' repository structure.'''
-  TEMPLATE_PATH: Final[Path] = Path(__file__).parent.parent.joinpath('rspec_template')
-  PR_TEMPLATE_PATH: Final[Path] = Path(__file__).parent.parent.parent.joinpath('.github/pull_request_template.md')
+    """Create a new Rule in a repository following the official Github 'rspec' repository structure."""
 
-  def __init__(self, rspec_repo: RspecRepo):
-    self.rspec_repo = rspec_repo
-    self.repo_dir = Path(self.rspec_repo.repository.working_dir)
-
-  def add_language_branch(self, rule_number: int, language: str) -> str:
-    '''Create and move files to add a new language to an existing rule.'''
-    branch_name = f'rule/S{rule_number}-add-{language}'
-    with self.rspec_repo.checkout_branch(self.rspec_repo.MASTER_BRANCH, branch_name):
-      rule_dir = self.repo_dir / 'rules' / f'S{rule_number}'
-      if not rule_dir.is_dir():
-        raise InvalidArgumentError(f"Rule \"S{rule_number}\" does not exist.")
-      lang_dir = rule_dir / language
-      if lang_dir.is_dir():
-        lang_url = f"https://github.com/SonarSource/rspec/tree/master/rules/S{rule_number}/{language}"
-        raise InvalidArgumentError(f"Rule \"S{rule_number}\" is already defined for language {language}. Modify the definition here: {lang_url}")
-      lang_dirs = [d for d in rule_dir.glob('*/') if d.is_dir()]
-      if 1 == len(list(lang_dirs)) and is_empty_metadata(rule_dir):
-        swap_metadata_files(rule_dir, lang_dirs[0])
-      lang_dir.mkdir()
-
-      lang_specific_template = self.TEMPLATE_PATH / 'multi_language' / 'language_specific'
-      copy_directory_content(lang_specific_template, lang_dir)
-      self._fill_in_the_blanks_in_the_template(lang_dir, rule_number)
-      self._fill_language_name_in_the_template(lang_dir, language)
-      self.rspec_repo.commit_all_and_push(f'Add {language} to rule S{rule_number}')
-    return branch_name
-
-  def create_new_rule_branch(self, rule_number: int, languages: Iterable[str]) -> str:
-    '''Create all the files required for a new rule.'''
-    branch_name = f'rule/add-RSPEC-S{rule_number}'
-    with self.rspec_repo.checkout_branch(self.rspec_repo.MASTER_BRANCH, branch_name):
-      rule_dir = self.repo_dir / 'rules' / f'S{rule_number}'
-      rule_dir.mkdir()
-      lang_count = sum(1 for _ in languages)
-      if lang_count > 1:
-        self._fill_multi_lang_template_files(rule_dir, rule_number, languages)
-      else:
-        self._fill_single_lang_template_files(rule_dir, rule_number, next(iter(languages)))
-      self.rspec_repo.commit_all_and_push(f'Create rule S{rule_number}')
-
-    return branch_name
-
-  def _fill_in_the_blanks_in_the_template(self, rule_dir: Path, rule_number: int):
-    for rule_item in rule_dir.glob('**/*'):
-      if rule_item.is_file():
-        template_content = rule_item.read_text()
-        final_content = template_content.replace('${RSPEC_ID}', str(rule_number))
-        rule_item.write_text(final_content)
-
-  def _fill_language_name_in_the_template(self, lang_dir: Path, language: str):
-    for rule_item in lang_dir.glob('*.adoc'):
-      if rule_item.is_file():
-        template_content = rule_item.read_text()
-        lang = LANG_TO_SOURCE[language]
-        final_content = template_content.replace('[source,text', f'[source,{lang}')
-        rule_item.write_text(final_content)
-
-  def _fill_multi_lang_template_files(self, rule_dir: Path, rule_number: int, languages: Iterable[str]):
-    common_template = self.TEMPLATE_PATH / 'multi_language' / 'common'
-    lang_specific_template = self.TEMPLATE_PATH / 'multi_language' / 'language_specific'
-    copy_directory_content(common_template, rule_dir)
-
-    for lang in languages:
-      lang_dir = rule_dir / lang
-      lang_dir.mkdir()
-      copy_directory_content(lang_specific_template, lang_dir)
-      self._fill_language_name_in_the_template(lang_dir, lang)
-
-    self._fill_in_the_blanks_in_the_template(rule_dir, rule_number)
-
-  def _fill_single_lang_template_files(self, rule_dir: Path, rule_number: int, language: str):
-    common_template = self.TEMPLATE_PATH / 'single_language' / 'common'
-    lang_specific_template = self.TEMPLATE_PATH / 'single_language' / language
-    if not Path(lang_specific_template).exists():
-      lang_specific_template = self.TEMPLATE_PATH / 'single_language' / 'language_specific'
-    copy_directory_content(common_template, rule_dir)
-
-    lang_dir = rule_dir /language
-    lang_dir.mkdir()
-    copy_directory_content(lang_specific_template, lang_dir)
-
-    self._fill_in_the_blanks_in_the_template(rule_dir, rule_number)
-    self._fill_language_name_in_the_template(lang_dir, language)
-
-  def add_language_pull_request(self, token: str, rule_number: int, language: str, label: str, user: Optional[str]):
-    branch_name = self.add_language_branch(rule_number, language)
-    click.echo(f'Created rule branch {branch_name}')
-    return self.rspec_repo.create_pull_request(
-      token,
-      branch_name,
-      f'Create rule S{rule_number}',
-      f'You can preview this rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{language}) (updated a few minutes after each push).\n\n{self.PR_TEMPLATE_PATH.read_text()}',
-      [label],
-      user
+    TEMPLATE_PATH: Final[Path] = Path(__file__).parent.parent.joinpath("rspec_template")
+    PR_TEMPLATE_PATH: Final[Path] = Path(__file__).parent.parent.parent.joinpath(
+        ".github/pull_request_template.md"
     )
 
-  def create_new_rule_pull_request(self, token: str, rule_number: int, languages: Iterable[str], labels: Iterable[str], user: Optional[str]) -> PullRequest:
-    branch_name = self.create_new_rule_branch(rule_number, languages)
-    click.echo(f'Created rule branch {branch_name}')
-    first_lang = next(iter(languages))
-    return self.rspec_repo.create_pull_request(
-      token,
-      branch_name,
-      f'Create rule S{rule_number}',
-      f'You can preview this rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{first_lang}) (updated a few minutes after each push).\n\n{self.PR_TEMPLATE_PATH.read_text()}',
-      labels,
-      user
-    )
+    def __init__(self, rspec_repo: RspecRepo):
+        self.rspec_repo = rspec_repo
+        self.repo_dir = Path(self.rspec_repo.repository.working_dir)
 
+    def add_language_branch(self, rule_number: int, language: str) -> str:
+        """Create and move files to add a new language to an existing rule."""
+        branch_name = f"rule/S{rule_number}-add-{language}"
+        with self.rspec_repo.checkout_branch(
+            self.rspec_repo.MASTER_BRANCH, branch_name
+        ):
+            rule_dir = self.repo_dir / "rules" / f"S{rule_number}"
+            if not rule_dir.is_dir():
+                raise InvalidArgumentError(f'Rule "S{rule_number}" does not exist.')
+            lang_dir = rule_dir / language
+            if lang_dir.is_dir():
+                lang_url = f"https://github.com/SonarSource/rspec/tree/master/rules/S{rule_number}/{language}"
+                raise InvalidArgumentError(
+                    f'Rule "S{rule_number}" is already defined for language {language}. Modify the definition here: {lang_url}'
+                )
+            lang_dirs = [d for d in rule_dir.glob("*/") if d.is_dir()]
+            if 1 == len(list(lang_dirs)) and is_empty_metadata(rule_dir):
+                swap_metadata_files(rule_dir, lang_dirs[0])
+            lang_dir.mkdir()
+
+            lang_specific_template = (
+                self.TEMPLATE_PATH / "multi_language" / "language_specific"
+            )
+            copy_directory_content(lang_specific_template, lang_dir)
+            self._fill_in_the_blanks_in_the_template(lang_dir, rule_number)
+            self._fill_language_name_in_the_template(lang_dir, language)
+            self.rspec_repo.commit_all_and_push(
+                f"Add {language} to rule S{rule_number}"
+            )
+        return branch_name
+
+    def create_new_rule_branch(self, rule_number: int, languages: Iterable[str]) -> str:
+        """Create all the files required for a new rule."""
+        branch_name = f"rule/add-RSPEC-S{rule_number}"
+        with self.rspec_repo.checkout_branch(
+            self.rspec_repo.MASTER_BRANCH, branch_name
+        ):
+            rule_dir = self.repo_dir / "rules" / f"S{rule_number}"
+            rule_dir.mkdir()
+            lang_count = sum(1 for _ in languages)
+            if lang_count > 1:
+                self._fill_multi_lang_template_files(rule_dir, rule_number, languages)
+            else:
+                self._fill_single_lang_template_files(
+                    rule_dir, rule_number, next(iter(languages))
+                )
+            self.rspec_repo.commit_all_and_push(f"Create rule S{rule_number}")
+
+        return branch_name
+
+    def _fill_in_the_blanks_in_the_template(self, rule_dir: Path, rule_number: int):
+        for rule_item in rule_dir.glob("**/*"):
+            if rule_item.is_file():
+                template_content = rule_item.read_text()
+                final_content = template_content.replace(
+                    "${RSPEC_ID}", str(rule_number)
+                )
+                rule_item.write_text(final_content)
+
+    def _fill_language_name_in_the_template(self, lang_dir: Path, language: str):
+        for rule_item in lang_dir.glob("*.adoc"):
+            if rule_item.is_file():
+                template_content = rule_item.read_text()
+                lang = LANG_TO_SOURCE[language]
+                final_content = template_content.replace(
+                    "[source,text", f"[source,{lang}"
+                )
+                rule_item.write_text(final_content)
+
+    def _fill_multi_lang_template_files(
+        self, rule_dir: Path, rule_number: int, languages: Iterable[str]
+    ):
+        common_template = self.TEMPLATE_PATH / "multi_language" / "common"
+        lang_specific_template = (
+            self.TEMPLATE_PATH / "multi_language" / "language_specific"
+        )
+        copy_directory_content(common_template, rule_dir)
+
+        for lang in languages:
+            lang_dir = rule_dir / lang
+            lang_dir.mkdir()
+            copy_directory_content(lang_specific_template, lang_dir)
+            self._fill_language_name_in_the_template(lang_dir, lang)
+
+        self._fill_in_the_blanks_in_the_template(rule_dir, rule_number)
+
+    def _fill_single_lang_template_files(
+        self, rule_dir: Path, rule_number: int, language: str
+    ):
+        common_template = self.TEMPLATE_PATH / "single_language" / "common"
+        lang_specific_template = self.TEMPLATE_PATH / "single_language" / language
+        if not Path(lang_specific_template).exists():
+            lang_specific_template = (
+                self.TEMPLATE_PATH / "single_language" / "language_specific"
+            )
+        copy_directory_content(common_template, rule_dir)
+
+        lang_dir = rule_dir / language
+        lang_dir.mkdir()
+        copy_directory_content(lang_specific_template, lang_dir)
+
+        self._fill_in_the_blanks_in_the_template(rule_dir, rule_number)
+        self._fill_language_name_in_the_template(lang_dir, language)
+
+    def add_language_pull_request(
+        self,
+        token: str,
+        rule_number: int,
+        language: str,
+        label: str,
+        user: Optional[str],
+    ):
+        branch_name = self.add_language_branch(rule_number, language)
+        click.echo(f"Created rule branch {branch_name}")
+        return self.rspec_repo.create_pull_request(
+            token,
+            branch_name,
+            f"Create rule S{rule_number}",
+            f"You can preview this rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{language}) (updated a few minutes after each push).\n\n{self.PR_TEMPLATE_PATH.read_text()}",
+            [label],
+            user,
+        )
+
+    def create_new_rule_pull_request(
+        self,
+        token: str,
+        rule_number: int,
+        languages: Iterable[str],
+        labels: Iterable[str],
+        user: Optional[str],
+    ) -> PullRequest:
+        branch_name = self.create_new_rule_branch(rule_number, languages)
+        click.echo(f"Created rule branch {branch_name}")
+        first_lang = next(iter(languages))
+        return self.rspec_repo.create_pull_request(
+            token,
+            branch_name,
+            f"Create rule S{rule_number}",
+            f"You can preview this rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{first_lang}) (updated a few minutes after each push).\n\n{self.PR_TEMPLATE_PATH.read_text()}",
+            labels,
+            user,
+        )

--- a/rspec-tools/rspec_tools/errors.py
+++ b/rspec-tools/rspec_tools/errors.py
@@ -2,20 +2,21 @@ from click import ClickException
 
 
 class InvalidArgumentError(ClickException):
-    '''Exception raised when an invalid argument is given to a CLI command.'''
+    """Exception raised when an invalid argument is given to a CLI command."""
 
     def __init__(self, message):
         super().__init__(message)
 
 
 class RuleValidationError(ClickException):
-    '''Exception raised when a rule did not pass validation.'''
+    """Exception raised when a rule did not pass validation."""
 
     def __init__(self, message):
         super().__init__(message)
 
+
 class RuleNotFoundError(ClickException):
-    '''Exception raised when a rule does not exist in the repository.'''
+    """Exception raised when a rule does not exist in the repository."""
 
     def __init__(self, message):
         super().__init__(message)

--- a/rspec-tools/rspec_tools/modify_rule.py
+++ b/rspec-tools/rspec_tools/modify_rule.py
@@ -1,9 +1,10 @@
-from contextlib import contextmanager
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
 import click
+
 from rspec_tools.errors import InvalidArgumentError
 
 from rspec_tools.repo import RspecRepo, tmp_rspec_repo
@@ -12,67 +13,93 @@ from rspec_tools.utils import get_label_for_language, resolve_rule
 
 @contextmanager
 def _rule_editor(token: str, user: Optional[str]):
-  with tmp_rspec_repo(token, user) as repo:
-    yield RuleEditor(repo)
+    with tmp_rspec_repo(token, user) as repo:
+        yield RuleEditor(repo)
 
 
-def update_rule_quickfix_status(language: str, rule: str, status: str, token: str, user: Optional[str]):
-  label = get_label_for_language(language)
-  rule_number = resolve_rule(rule)
-  with _rule_editor(token, user) as editor:
-    editor.update_quickfix_status_pull_request(token, rule_number, language, status, label, user)
+def update_rule_quickfix_status(
+    language: str, rule: str, status: str, token: str, user: Optional[str]
+):
+    label = get_label_for_language(language)
+    rule_number = resolve_rule(rule)
+    with _rule_editor(token, user) as editor:
+        editor.update_quickfix_status_pull_request(
+            token, rule_number, language, status, label, user
+        )
 
 
 class RuleEditor:
-  '''Modify an existing Rule in a repository following the official Github 'rspec' repository structure.'''
+    """Modify an existing Rule in a repository following the official Github 'rspec' repository structure."""
 
-  def __init__(self, rspec_repo: RspecRepo):
-    self.rspec_repo = rspec_repo
-    self.repo_dir = Path(self.rspec_repo.repository.working_dir)
+    def __init__(self, rspec_repo: RspecRepo):
+        self.rspec_repo = rspec_repo
+        self.repo_dir = Path(self.rspec_repo.repository.working_dir)
 
-  def update_quickfix_status_branch(self, title: str, rule_number: int, language: str, status: str) -> str:
-    '''Update the given rule/language quick fix metadata field.'''
-    branch_name = f'rule/S{rule_number}-{language}-quickfix'
-    with self.rspec_repo.checkout_branch(self.rspec_repo.MASTER_BRANCH, branch_name):
-      self._update_quickfix_status(rule_number, language, status)
-      self.rspec_repo.commit_all_and_push(title)
+    def update_quickfix_status_branch(
+        self, title: str, rule_number: int, language: str, status: str
+    ) -> str:
+        """Update the given rule/language quick fix metadata field."""
+        branch_name = f"rule/S{rule_number}-{language}-quickfix"
+        with self.rspec_repo.checkout_branch(
+            self.rspec_repo.MASTER_BRANCH, branch_name
+        ):
+            self._update_quickfix_status(rule_number, language, status)
+            self.rspec_repo.commit_all_and_push(title)
 
-    return branch_name
+        return branch_name
 
-  def update_quickfix_status_pull_request(self, token: str, rule_number: int, language: str, status: str, label: str, user: Optional[str]):
-    title = f'Modify rule S{rule_number}: mark quick fix as "{status}"'
-    branch_name = self.update_quickfix_status_branch(title, rule_number, language, status)
-    click.echo(f'Created rule branch {branch_name}')
-    return self.rspec_repo.create_pull_request(
-      token,
-      branch_name,
-      title,
-      f'''See the original rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{language}).
+    def update_quickfix_status_pull_request(
+        self,
+        token: str,
+        rule_number: int,
+        language: str,
+        status: str,
+        label: str,
+        user: Optional[str],
+    ):
+        title = f'Modify rule S{rule_number}: mark quick fix as "{status}"'
+        branch_name = self.update_quickfix_status_branch(
+            title, rule_number, language, status
+        )
+        click.echo(f"Created rule branch {branch_name}")
+        return self.rspec_repo.create_pull_request(
+            token,
+            branch_name,
+            title,
+            f"""See the original rule [here](https://sonarsource.github.io/rspec/#/rspec/S{rule_number}/{language}).
 
-The rule won't be updated until this PR is merged, see [RULEAPI-655](https://jira.sonarsource.com/browse/RULEAPI-655)''',
-      [label],
-      user
-    )
+The rule won't be updated until this PR is merged, see [RULEAPI-655](https://jira.sonarsource.com/browse/RULEAPI-655)""",
+            [label],
+            user,
+        )
 
-  def _get_generic_quickfix_status(self, rule_number: int):
-    DEFAULT = 'unknown'
-    generic_metadata_path = self.repo_dir / 'rules' / f'S{rule_number}' / 'metadata.json'
-    if not generic_metadata_path.is_file():
-      return DEFAULT
-    generic_metadata = json.loads(generic_metadata_path.read_text())
-    return generic_metadata.get('quickfix', DEFAULT)
+    def _get_generic_quickfix_status(self, rule_number: int):
+        DEFAULT = "unknown"
+        generic_metadata_path = (
+            self.repo_dir / "rules" / f"S{rule_number}" / "metadata.json"
+        )
+        if not generic_metadata_path.is_file():
+            return DEFAULT
+        generic_metadata = json.loads(generic_metadata_path.read_text())
+        return generic_metadata.get("quickfix", DEFAULT)
 
-  def _update_quickfix_status(self, rule_number: int, language: str, status: str):
-    metadata_path = self.repo_dir / 'rules' / f'S{rule_number}' / language / 'metadata.json'
-    if not metadata_path.is_file():
-      raise InvalidArgumentError(f'{metadata_path} does not exist or is not a file')
+    def _update_quickfix_status(self, rule_number: int, language: str, status: str):
+        metadata_path = (
+            self.repo_dir / "rules" / f"S{rule_number}" / language / "metadata.json"
+        )
+        if not metadata_path.is_file():
+            raise InvalidArgumentError(
+                f"{metadata_path} does not exist or is not a file"
+            )
 
-    metadata = json.loads(metadata_path.read_text())
-    generic_status = self._get_generic_quickfix_status(rule_number)
-    if status == metadata.get('quickfix', generic_status):
-      raise InvalidArgumentError(f'{metadata_path} has already the same status {status}')
+        metadata = json.loads(metadata_path.read_text())
+        generic_status = self._get_generic_quickfix_status(rule_number)
+        if status == metadata.get("quickfix", generic_status):
+            raise InvalidArgumentError(
+                f"{metadata_path} has already the same status {status}"
+            )
 
-    metadata['quickfix'] = status
-    # When generating the JSON, ensure forward slashes are escaped. See RULEAPI-750.
-    json_string = json.dumps(metadata, indent=2).replace("/", "\\/")
-    metadata_path.write_text(json_string)
+        metadata["quickfix"] = status
+        # When generating the JSON, ensure forward slashes are escaped. See RULEAPI-750.
+        json_string = json.dumps(metadata, indent=2).replace("/", "\\/")
+        metadata_path.write_text(json_string)

--- a/rspec-tools/rspec_tools/notify_failure_on_slack.py
+++ b/rspec-tools/rspec_tools/notify_failure_on_slack.py
@@ -1,14 +1,14 @@
 import os
+
 from slack import WebClient
 from slack.errors import SlackApiError
 
+
 def notify_slack(msg, slack_channel):
-  slack_token=os.environ.get('SLACK_API_TOKEN','no slack token in env')
-  slack_client=WebClient(slack_token)
-  if slack_channel is not None:
-    try:
-      return slack_client.chat_postMessage(
-        channel=slack_channel,
-        text=msg)
-    except SlackApiError as e:
-      print(f"Could not notify slack: {e.response['error']}")
+    slack_token = os.environ.get("SLACK_API_TOKEN", "no slack token in env")
+    slack_client = WebClient(slack_token)
+    if slack_channel is not None:
+        try:
+            return slack_client.chat_postMessage(channel=slack_channel, text=msg)
+        except SlackApiError as e:
+            print(f"Could not notify slack: {e.response['error']}")

--- a/rspec-tools/rspec_tools/repo.py
+++ b/rspec-tools/rspec_tools/repo.py
@@ -10,121 +10,137 @@ from github import Github
 
 
 def _auto_github(token: str) -> Callable[[Optional[str]], Github]:
-  def ret(user: Optional[str]):
-    if user:
-      return Github(user, token)
-    else:
-      return Github(token)
-  return ret
+    def ret(user: Optional[str]):
+        if user:
+            return Github(user, token)
+        else:
+            return Github(token)
+
+    return ret
 
 
 class RspecRepo:
-  '''Provide operations on a git repository for rule specifications.'''
-  MASTER_BRANCH: Final[str] = 'master'
-  ID_COUNTER_BRANCH: Final[str] = 'rspec-id-counter'
-  ID_COUNTER_FILENAME: Final[str] = 'next_rspec_id.txt'
+    """Provide operations on a git repository for rule specifications."""
 
-  repository: Final[Repo]
-  origin_url: Final[str]
+    MASTER_BRANCH: Final[str] = "master"
+    ID_COUNTER_BRANCH: Final[str] = "rspec-id-counter"
+    ID_COUNTER_FILENAME: Final[str] = "next_rspec_id.txt"
 
-  def __init__(self, origin_url: str, clone_directory: str, configuration: dict[str, str]):
-    self.repository = Repo.clone_from(origin_url, clone_directory)
-    self.origin_url = origin_url
+    repository: Final[Repo]
+    origin_url: Final[str]
 
-    # Create local branches tracking remote ones
-    for branch in [self.MASTER_BRANCH, self.ID_COUNTER_BRANCH]:
-      self.repository.remote().fetch(branch)
-      self.repository.git.checkout('-B', branch, f'origin/{branch}')
+    def __init__(
+        self, origin_url: str, clone_directory: str, configuration: dict[str, str]
+    ):
+        self.repository = Repo.clone_from(origin_url, clone_directory)
+        self.origin_url = origin_url
 
-    # Update repository config
-    with self.repository.config_writer() as config_writer:
-      for key, value in configuration.items():
-        split_key = key.split('.')
-        config_writer.set_value(*split_key, value)
+        # Create local branches tracking remote ones
+        for branch in [self.MASTER_BRANCH, self.ID_COUNTER_BRANCH]:
+            self.repository.remote().fetch(branch)
+            self.repository.git.checkout("-B", branch, f"origin/{branch}")
 
-  def get_repository_name(self):
-    url_end = self.origin_url.split('/')[-2:]
-    return '/'.join(url_end).removesuffix('.git')
+        # Update repository config
+        with self.repository.config_writer() as config_writer:
+            for key, value in configuration.items():
+                split_key = key.split(".")
+                config_writer.set_value(*split_key, value)
 
-  @contextmanager
-  def checkout_branch(self, base_branch: str, new_branch: Optional[str] = None):
-    '''Checkout a given branch before yielding, then revert to the previous branch.'''
-    past_branch = self.repository.active_branch
-    try:
-      self.repository.git.checkout(base_branch)
-      origin = self.repository.remote(name='origin')
-      origin.pull()
-      if new_branch is not None:
-        self.repository.git.checkout('-B', new_branch)
-      yield
-    finally:
-      self.repository.git.checkout(past_branch)
+    def get_repository_name(self):
+        url_end = self.origin_url.split("/")[-2:]
+        return "/".join(url_end).removesuffix(".git")
 
-  def commit_all_and_push(self, message: str):
-    self.repository.git.add('--all')
-    self.repository.index.commit(message)
-    self.repository.git.push('origin', self.repository.active_branch)
+    @contextmanager
+    def checkout_branch(self, base_branch: str, new_branch: Optional[str] = None):
+        """Checkout a given branch before yielding, then revert to the previous branch."""
+        past_branch = self.repository.active_branch
+        try:
+            self.repository.git.checkout(base_branch)
+            origin = self.repository.remote(name="origin")
+            origin.pull()
+            if new_branch is not None:
+                self.repository.git.checkout("-B", new_branch)
+            yield
+        finally:
+            self.repository.git.checkout(past_branch)
 
-  def create_pull_request(self, token: str, branch_name: str, title: str, body: str, labels: Iterable[str], user: Optional[str]):
-    '''Create a pull request from the given branch.'''
-    repository_url = self.get_repository_name()
-    github_api = _auto_github(token)
-    github = github_api(user)
-    github_repo = github.get_repo(repository_url)
-    pull_request = github_repo.create_pull(
-      title=title,
-      body=body,
-      head=branch_name, base=self.MASTER_BRANCH,
-      draft=True, maintainer_can_modify=True
-    )
-    click.echo(f'Created rule Pull Request {pull_request.html_url}')
+    def commit_all_and_push(self, message: str):
+        self.repository.git.add("--all")
+        self.repository.index.commit(message)
+        self.repository.git.push("origin", self.repository.active_branch)
 
-    # Note: It is not possible to get the authenticated user using get_user() from a github action.
-    login = user if user else github.get_user().login
-    pull_request.add_to_assignees(login)
-    pull_request.add_to_labels(*labels)
-    click.echo(f'Pull request assigned to {login}')
-    return pull_request
+    def create_pull_request(
+        self,
+        token: str,
+        branch_name: str,
+        title: str,
+        body: str,
+        labels: Iterable[str],
+        user: Optional[str],
+    ):
+        """Create a pull request from the given branch."""
+        repository_url = self.get_repository_name()
+        github_api = _auto_github(token)
+        github = github_api(user)
+        github_repo = github.get_repo(repository_url)
+        pull_request = github_repo.create_pull(
+            title=title,
+            body=body,
+            head=branch_name,
+            base=self.MASTER_BRANCH,
+            draft=True,
+            maintainer_can_modify=True,
+        )
+        click.echo(f"Created rule Pull Request {pull_request.html_url}")
 
-  def reserve_rule_number(self) -> int:
-    '''Reserve an id on the id counter branch of the repository.'''
-    with self.checkout_branch(self.ID_COUNTER_BRANCH):
-      counter_file_path = Path(self.repository.working_dir, self.ID_COUNTER_FILENAME)
-      counter = int(counter_file_path.read_text())
-      counter_file_path.write_text(str(counter + 1))
+        # Note: It is not possible to get the authenticated user using get_user() from a github action.
+        login = user if user else github.get_user().login
+        pull_request.add_to_assignees(login)
+        pull_request.add_to_labels(*labels)
+        click.echo(f"Pull request assigned to {login}")
+        return pull_request
 
-      self.repository.index.add([str(counter_file_path)])
-      self.repository.index.commit('Increment RSPEC ID counter')
+    def reserve_rule_number(self) -> int:
+        """Reserve an id on the id counter branch of the repository."""
+        with self.checkout_branch(self.ID_COUNTER_BRANCH):
+            counter_file_path = Path(
+                self.repository.working_dir, self.ID_COUNTER_FILENAME
+            )
+            counter = int(counter_file_path.read_text())
+            counter_file_path.write_text(str(counter + 1))
 
-    origin = self.repository.remote(name='origin')
-    origin.push()
+            self.repository.index.add([str(counter_file_path)])
+            self.repository.index.commit("Increment RSPEC ID counter")
 
-    click.echo(f'Reserved Rule ID S{counter}')
-    return counter
+        origin = self.repository.remote(name="origin")
+        origin.push()
+
+        click.echo(f"Reserved Rule ID S{counter}")
+        return counter
 
 
 def _build_github_repository_url(token: str, user: Optional[str]):
-  '''Builds the rspec repository url'''
-  repo = os.environ.get('GITHUB_REPOSITORY', 'SonarSource/rspec')
-  if user:
-    return f'https://{user}:{token}@github.com/{repo}.git'
-  else:
-    return f'https://{token}@github.com/{repo}.git'
+    """Builds the rspec repository url"""
+    repo = os.environ.get("GITHUB_REPOSITORY", "SonarSource/rspec")
+    if user:
+        return f"https://{user}:{token}@github.com/{repo}.git"
+    else:
+        return f"https://{token}@github.com/{repo}.git"
 
 
 def _get_url_and_config(token: str, user: Optional[str]):
-  url = _build_github_repository_url(token, user)
-  config = {}
-  if user:
-    config['user.name'] = user
-    config['user.email'] = f'{user}@users.noreply.github.com'
+    url = _build_github_repository_url(token, user)
+    config = {}
+    if user:
+        config["user.name"] = user
+        config["user.email"] = f"{user}@users.noreply.github.com"
 
-  return url, config
+    return url, config
 
 
 @contextmanager
 def tmp_rspec_repo(token: str, user: Optional[str]):
-  '''Yield a temporary repository'''
-  url, config = _get_url_and_config(token, user)
-  with tempfile.TemporaryDirectory() as tmpdirname:
-    yield RspecRepo(url, tmpdirname, config)
+    """Yield a temporary repository"""
+    url, config = _get_url_and_config(token, user)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield RspecRepo(url, tmpdirname, config)

--- a/rspec-tools/rspec_tools/rules.py
+++ b/rspec-tools/rspec_tools/rules.py
@@ -1,112 +1,124 @@
-
 import json
 from pathlib import Path
 from typing import Final, Generator, Iterable, Optional
+
 from bs4 import BeautifulSoup
+
 from rspec_tools.errors import RuleNotFoundError
 from rspec_tools.utils import load_valid_languages
 
 
-METADATA_FILE_NAME: Final[str] = 'metadata.json'
-DESCRIPTION_FILE_NAME: Final[str] = 'rule.html'
+METADATA_FILE_NAME: Final[str] = "metadata.json"
+DESCRIPTION_FILE_NAME: Final[str] = "rule.html"
+
 
 def load_metadata_contents(metadata_path):
-  try:
-    # Make sure the metadata file contains only ASCII.
-    # Even though python is fine with Unicode, it might
-    # break other tools such as the TypeScript deployment script.
-    return metadata_path.read_text(encoding='ascii')
-  except:
-    print('ERROR: Non-ASCII characters in ', metadata_path)
-    print('The metadata files must contain only ASCII characters.\n\n')
-    raise
+    try:
+        # Make sure the metadata file contains only ASCII.
+        # Even though python is fine with Unicode, it might
+        # break other tools such as the TypeScript deployment script.
+        return metadata_path.read_text(encoding="ascii")
+    except:
+        print("ERROR: Non-ASCII characters in ", metadata_path)
+        print("The metadata files must contain only ASCII characters.\n\n")
+        raise
 
 
 class LanguageSpecificRule:
-  language_path: Final[Path]
-  rule: 'GenericRule'
-  __metadata: Optional[dict] = None
-  __description: Optional[object] = None
+    language_path: Final[Path]
+    rule: "GenericRule"
+    __metadata: Optional[dict] = None
+    __description: Optional[object] = None
 
-  def __init__(self, language_path: Path, rule: 'GenericRule'):
-    self.language_path = language_path
-    self.rule = rule
+    def __init__(self, language_path: Path, rule: "GenericRule"):
+        self.language_path = language_path
+        self.rule = rule
 
-  @property
-  def language(self):
-    return self.language_path.name
+    @property
+    def language(self):
+        return self.language_path.name
 
-  @property
-  def id(self):
-    return f'{self.language}:{self.rule.id}'
+    @property
+    def id(self):
+        return f"{self.language}:{self.rule.id}"
 
-  @property
-  def metadata(self):
-    if self.__metadata is not None:
-      return self.__metadata
-    metadata_path = self.language_path.joinpath(METADATA_FILE_NAME)
-    metadata_contents = load_metadata_contents(metadata_path)
-    try:
-      lang_metadata = json.loads(metadata_contents)
-    except:
-      print('ERROR: Failed to parse ', metadata_path)
-      raise
+    @property
+    def metadata(self):
+        if self.__metadata is not None:
+            return self.__metadata
+        metadata_path = self.language_path.joinpath(METADATA_FILE_NAME)
+        metadata_contents = load_metadata_contents(metadata_path)
+        try:
+            lang_metadata = json.loads(metadata_contents)
+        except:
+            print("ERROR: Failed to parse ", metadata_path)
+            raise
 
-    self.__metadata = self.rule.generic_metadata | lang_metadata
-    return self.__metadata
+        self.__metadata = self.rule.generic_metadata | lang_metadata
+        return self.__metadata
 
-  @property
-  def description(self):
-    if self.__description is not None:
-      return self.__description
-    description_path = self.language_path.joinpath(DESCRIPTION_FILE_NAME)
-    soup = BeautifulSoup(description_path.read_bytes(),features="html.parser")
-    self.__description = soup
-    return self.__description
+    @property
+    def description(self):
+        if self.__description is not None:
+            return self.__description
+        description_path = self.language_path.joinpath(DESCRIPTION_FILE_NAME)
+        soup = BeautifulSoup(description_path.read_bytes(), features="html.parser")
+        self.__description = soup
+        return self.__description
+
 
 class GenericRule:
-  rule_path: Final[Path]
-  __generic_metadata: Optional[dict] = None
+    rule_path: Final[Path]
+    __generic_metadata: Optional[dict] = None
 
-  def __init__(self, rule_path: Path):
-    self.rule_path = rule_path
+    def __init__(self, rule_path: Path):
+        self.rule_path = rule_path
 
-  @property
-  def id(self) -> str:
-    return self.rule_path.name
+    @property
+    def id(self) -> str:
+        return self.rule_path.name
 
-  @property
-  def specializations(self) -> Generator[LanguageSpecificRule, None, None]:
-    return (LanguageSpecificRule(child, self) for child in self.rule_path.iterdir() if
-            child.is_dir() and child.name in load_valid_languages())
-  
-  def get_language(self, language: str) -> LanguageSpecificRule:
-    return LanguageSpecificRule(self.rule_path.joinpath(language), self)
+    @property
+    def specializations(self) -> Generator[LanguageSpecificRule, None, None]:
+        return (
+            LanguageSpecificRule(child, self)
+            for child in self.rule_path.iterdir()
+            if child.is_dir() and child.name in load_valid_languages()
+        )
 
-  @property
-  def generic_metadata(self):
-    if self.__generic_metadata is not None:
-      return self.__generic_metadata
-    metadata_path = self.rule_path.joinpath(METADATA_FILE_NAME)
-    metadata_contents = load_metadata_contents(metadata_path)
-    self.__generic_metadata = json.loads(metadata_contents)
-    return self.__generic_metadata
+    def get_language(self, language: str) -> LanguageSpecificRule:
+        return LanguageSpecificRule(self.rule_path.joinpath(language), self)
+
+    @property
+    def generic_metadata(self):
+        if self.__generic_metadata is not None:
+            return self.__generic_metadata
+        metadata_path = self.rule_path.joinpath(METADATA_FILE_NAME)
+        metadata_contents = load_metadata_contents(metadata_path)
+        self.__generic_metadata = json.loads(metadata_contents)
+        return self.__generic_metadata
 
 
 class RulesRepository:
-  DEFAULT_RULES_PATH: Final[Path] = Path(__file__).parent.parent.parent.joinpath('rules')
+    DEFAULT_RULES_PATH: Final[Path] = Path(__file__).parent.parent.parent.joinpath(
+        "rules"
+    )
 
-  rules_path: Final[Path]
+    rules_path: Final[Path]
 
-  def __init__(self, rules_path: Path=DEFAULT_RULES_PATH):
-    self.rules_path = rules_path
+    def __init__(self, rules_path: Path = DEFAULT_RULES_PATH):
+        self.rules_path = rules_path
 
-  @property
-  def rules(self) -> Generator[GenericRule, None, None]:
-    return (GenericRule(child) for child in self.rules_path.glob('S*') if child.is_dir())
-    
-  def get_rule(self, ruleid: str):
-    rulepath = self.rules_path.joinpath(ruleid)
-    if not rulepath.is_dir():
-      raise RuleNotFoundError('Cannot find rule ' + ruleid + ' in ' + str(self.rules_path))
-    return GenericRule(rulepath)
+    @property
+    def rules(self) -> Generator[GenericRule, None, None]:
+        return (
+            GenericRule(child) for child in self.rules_path.glob("S*") if child.is_dir()
+        )
+
+    def get_rule(self, ruleid: str):
+        rulepath = self.rules_path.joinpath(ruleid)
+        if not rulepath.is_dir():
+            raise RuleNotFoundError(
+                "Cannot find rule " + ruleid + " in " + str(self.rules_path)
+            )
+        return GenericRule(rulepath)

--- a/rspec-tools/rspec_tools/utils.py
+++ b/rspec-tools/rspec_tools/utils.py
@@ -1,173 +1,196 @@
-from pathlib import Path
-from typing import List
-from contextlib import contextmanager
-import shutil
-import re
-import tempfile
 import json
 import os
+import re
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import List
+
 from rspec_tools.errors import InvalidArgumentError
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-SUPPORTED_LANGUAGES_FILENAME = REPO_ROOT / 'supported_languages.adoc'
-LANG_TO_LABEL = {'abap': 'abap',
-                 'apex': 'slang',
-                 'azureresourcemanager': 'iac',
-                 'cfamily': 'cfamily',
-                 'cobol': 'cobol',
-                 'csharp': 'dotnet',
-                 'css': 'css',
-                 'dart': 'dart',
-                 'docker': 'iac',
-                 'flex': 'flex',
-                 'go': 'go',
-                 'html': 'html',
-                 'java': 'java',
-                 'javascript': 'jsts',
-                 'jcl': 'jcl',
-                 'kotlin': 'kotlin',
-                 'php': 'php',
-                 'pli': 'pli',
-                 'plsql': 'plsql',
-                 'python': 'python',
-                 'rpg': 'rpg',
-                 'ruby': 'slang',
-                 'rust': 'rust',
-                 'scala': 'slang',
-                 'secrets': 'secrets',
-                 'solidity': 'solidity',
-                 'swift': 'swift',
-                 'text': 'text',
-                 'tsql': 'tsql',
-                 'vb6': 'vb6',
-                 'vbnet': 'dotnet',
-                 'ansible': 'iac',
-                 'cloudformation': 'iac',
-                 'terraform': 'iac',
-                 'kubernetes': 'iac',
-                 'xml': 'xml',
+SUPPORTED_LANGUAGES_FILENAME = REPO_ROOT / "supported_languages.adoc"
+LANG_TO_LABEL = {
+    "abap": "abap",
+    "apex": "slang",
+    "azureresourcemanager": "iac",
+    "cfamily": "cfamily",
+    "cobol": "cobol",
+    "csharp": "dotnet",
+    "css": "css",
+    "dart": "dart",
+    "docker": "iac",
+    "flex": "flex",
+    "go": "go",
+    "html": "html",
+    "java": "java",
+    "javascript": "jsts",
+    "jcl": "jcl",
+    "kotlin": "kotlin",
+    "php": "php",
+    "pli": "pli",
+    "plsql": "plsql",
+    "python": "python",
+    "rpg": "rpg",
+    "ruby": "slang",
+    "rust": "rust",
+    "scala": "slang",
+    "secrets": "secrets",
+    "solidity": "solidity",
+    "swift": "swift",
+    "text": "text",
+    "tsql": "tsql",
+    "vb6": "vb6",
+    "vbnet": "dotnet",
+    "ansible": "iac",
+    "cloudformation": "iac",
+    "terraform": "iac",
+    "kubernetes": "iac",
+    "xml": "xml",
 }
 
 LANG_TO_SOURCE = {
     # languages with syntax coloring in highlight.js
-    'abap': 'abap',
-    'cfamily': 'cpp',
-    'cloudformation': 'yaml',
-    'csharp': 'csharp',
-    'css': 'css',
-    'dart': 'dart',
-    'docker': 'docker',
-    'go': 'go',
-    'html': 'html',
-    'java': 'java',
-    'jcl': 'jcl',
-    'javascript': 'javascript',
-    'json': 'json',
-    'kotlin': 'kotlin',
-    'kubernetes': 'yaml',
-    'php': 'php',
-    'plsql': 'sql',
-    'python': 'python',
-    'ruby': 'ruby',
-    'rust': 'rust',
-    'scala': 'scala',
-    'swift': 'swift',
-    'tsql': 'sql',
-    'vbnet': 'vbnet',
-    'xml': 'xml',
-    'c': 'c',
-    'objectivec': 'objectivec',
-    'vb': 'vb',
-    'ansible': 'yaml',
+    "abap": "abap",
+    "cfamily": "cpp",
+    "cloudformation": "yaml",
+    "csharp": "csharp",
+    "css": "css",
+    "dart": "dart",
+    "docker": "docker",
+    "go": "go",
+    "html": "html",
+    "java": "java",
+    "jcl": "jcl",
+    "javascript": "javascript",
+    "json": "json",
+    "kotlin": "kotlin",
+    "kubernetes": "yaml",
+    "php": "php",
+    "plsql": "sql",
+    "python": "python",
+    "ruby": "ruby",
+    "rust": "rust",
+    "scala": "scala",
+    "swift": "swift",
+    "tsql": "sql",
+    "vbnet": "vbnet",
+    "xml": "xml",
+    "c": "c",
+    "objectivec": "objectivec",
+    "vb": "vb",
+    "ansible": "yaml",
     # these languages are not supported by highlight.js as the moment:
-    'apex': 'apex',
-    'azureresourcemanager': 'bicep',
-    'cobol': 'cobol',
-    'flex': 'flex',
-    'pli': 'pli',
-    'rpg': 'rpg',
-    'secrets': 'secrets',
-    'terraform': 'terraform',
-    'text': 'text',
-    'vb6': 'vb6'
+    "apex": "apex",
+    "azureresourcemanager": "bicep",
+    "cobol": "cobol",
+    "flex": "flex",
+    "pli": "pli",
+    "rpg": "rpg",
+    "secrets": "secrets",
+    "terraform": "terraform",
+    "text": "text",
+    "vb6": "vb6",
 }
 
-METADATA_FILE = 'metadata.json'
+METADATA_FILE = "metadata.json"
 
-def copy_directory_content(src:Path, dest:Path):
-  for item in src.iterdir():
-    if (item.is_dir()):
-      shutil.copytree(item, dest)
-    else:
-      shutil.copy2(item, dest)
 
-def swap_metadata_files(dir1:Path, dir2:Path):
-  meta1 = dir1.joinpath(METADATA_FILE)
-  meta2 = dir2.joinpath(METADATA_FILE)
-  with tempfile.TemporaryDirectory() as tmpdir:
-    tmp = Path(tmpdir).joinpath(METADATA_FILE)
-    shutil.copy2(meta1, tmp)
-    shutil.copy2(meta2, meta1)
-    shutil.copy2(tmp, meta2)
+def copy_directory_content(src: Path, dest: Path):
+    for item in src.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
 
-def is_empty_metadata(rule_dir:Path):
-  with open(rule_dir.joinpath(METADATA_FILE), 'r', encoding='utf8') as meta:
-    return not json.load(meta)
+
+def swap_metadata_files(dir1: Path, dir2: Path):
+    meta1 = dir1.joinpath(METADATA_FILE)
+    meta2 = dir2.joinpath(METADATA_FILE)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir).joinpath(METADATA_FILE)
+        shutil.copy2(meta1, tmp)
+        shutil.copy2(meta2, meta1)
+        shutil.copy2(tmp, meta2)
+
+
+def is_empty_metadata(rule_dir: Path):
+    with open(rule_dir.joinpath(METADATA_FILE), "r", encoding="utf8") as meta:
+        return not json.load(meta)
+
 
 def load_valid_languages():
-  with open(SUPPORTED_LANGUAGES_FILENAME, 'r', encoding='utf8') as supported_langs_file:
-    supported_langs = supported_langs_file.read()
-    supported_langs = supported_langs.replace(' or', '')
-    supported_langs = supported_langs.replace('`', '')
-    supported_langs = supported_langs.replace(' ', '')
-    supported_langs = supported_langs.replace('\n', '')
-    return supported_langs.split(',')
+    with open(
+        SUPPORTED_LANGUAGES_FILENAME, "r", encoding="utf8"
+    ) as supported_langs_file:
+        supported_langs = supported_langs_file.read()
+        supported_langs = supported_langs.replace(" or", "")
+        supported_langs = supported_langs.replace("`", "")
+        supported_langs = supported_langs.replace(" ", "")
+        supported_langs = supported_langs.replace("\n", "")
+        return supported_langs.split(",")
+
 
 def get_mapped_languages():
-  '''Get all the languages we have a label for.
-  Necessary to make sure all valid languages are mapped (see test_utils.py).'''
-  return LANG_TO_LABEL.keys();
+    """Get all the languages we have a label for.
+    Necessary to make sure all valid languages are mapped (see test_utils.py)."""
+    return LANG_TO_LABEL.keys()
+
 
 def _validate_languages(languages: List[str]):
-  valid_langs = load_valid_languages()
-  for lang in languages:
-    if lang not in valid_langs:
-      raise InvalidArgumentError(f"Unsupported language: \"{lang}\". See {SUPPORTED_LANGUAGES_FILENAME} for the list of supported languages.")
+    valid_langs = load_valid_languages()
+    for lang in languages:
+        if lang not in valid_langs:
+            raise InvalidArgumentError(
+                f'Unsupported language: "{lang}". See {SUPPORTED_LANGUAGES_FILENAME} for the list of supported languages.'
+            )
+
 
 def parse_and_validate_language_list(languages):
-  lang_list = [lang.strip() for lang in languages.split(',')]
-  if len(languages.strip()) == 0 or len(lang_list) == 0:
-    raise InvalidArgumentError('Invalid argument for "languages". At least one language should be provided.')
-  _validate_languages(lang_list)
-  return lang_list
+    lang_list = [lang.strip() for lang in languages.split(",")]
+    if len(languages.strip()) == 0 or len(lang_list) == 0:
+        raise InvalidArgumentError(
+            'Invalid argument for "languages". At least one language should be provided.'
+        )
+    _validate_languages(lang_list)
+    return lang_list
+
 
 def _validate_language(language):
-  _validate_languages([language])
+    _validate_languages([language])
+
 
 def get_labels_for_languages(lang_list):
-  labels = [LANG_TO_LABEL[lang] for lang in lang_list]
-  return list(set(labels))
+    labels = [LANG_TO_LABEL[lang] for lang in lang_list]
+    return list(set(labels))
+
 
 def get_label_for_language(language: str) -> str:
-  _validate_language(language)
-  return LANG_TO_LABEL[language]
+    _validate_language(language)
+    return LANG_TO_LABEL[language]
+
 
 def resolve_rule(rule_id: str) -> int:
-  m = re.search(r'^S(\d{3,4})$', rule_id)
-  if not m:
-    raise InvalidArgumentError(f"Unrecognized rule id format: \"{rule_id}\". Rule id must start with an \"S\" followed by 3 or 4 digits.")
-  else:
-    return int(m.group(1))
+    m = re.search(r"^S(\d{3,4})$", rule_id)
+    if not m:
+        raise InvalidArgumentError(
+            f'Unrecognized rule id format: "{rule_id}". Rule id must start with an "S" followed by 3 or 4 digits.'
+        )
+    else:
+        return int(m.group(1))
+
 
 def load_json(file):
-  with open(file, encoding='utf8') as json_file:
-    return json.load(json_file)
+    with open(file, encoding="utf8") as json_file:
+        return json.load(json_file)
+
 
 @contextmanager
 def pushd(new_dir):
-  previous_dir = os.getcwd()
-  os.chdir(new_dir)
-  try:
-    yield
-  finally:
-    os.chdir(previous_dir)
+    previous_dir = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(previous_dir)

--- a/rspec-tools/rspec_tools/validation/description.py
+++ b/rspec-tools/rspec_tools/validation/description.py
@@ -3,47 +3,51 @@ from pathlib import Path
 from typing import Dict, Final, List, Union
 
 from bs4 import BeautifulSoup
+
 from rspec_tools.errors import RuleValidationError
 from rspec_tools.rules import LanguageSpecificRule
 from rspec_tools.utils import LANG_TO_SOURCE
 
 
 def read_file(path):
-  section_names_path = Path(__file__).parent.parent.parent.parent.joinpath(path)
-  return section_names_path.read_text(encoding='utf-8').split('\n')
+    section_names_path = Path(__file__).parent.parent.parent.parent.joinpath(path)
+    return section_names_path.read_text(encoding="utf-8").split("\n")
+
 
 def parse_names(path):
-  section_names_path = read_file(path)
-  return [s.replace('* ', '').strip() for s in section_names_path if s.strip()]
+    section_names_path = read_file(path)
+    return [s.replace("* ", "").strip() for s in section_names_path if s.strip()]
+
 
 def parse_security_standard_links(descr):
-  link_nodes = descr.find_all('a')
-  security_standards_links: Dict[str, List] = {}
-  for node in link_nodes:
-    href = node.attrs['href']
-    for standard_key in SECURITY_STANDARD_URL:
-      standard = SECURITY_STANDARD_URL[standard_key]
-      url_pattern = standard["url_pattern"]
-      result = re.match(url_pattern, href)
-      if result is not None:
-        convert = standard["convert_id"]
-        category = convert(result[1])
-        if standard_key not in security_standards_links.keys():
-          security_standards_links[standard_key] = []
-        security_standards_links[standard_key].append(category)
-  return security_standards_links
+    link_nodes = descr.find_all("a")
+    security_standards_links: Dict[str, List] = {}
+    for node in link_nodes:
+        href = node.attrs["href"]
+        for standard_key in SECURITY_STANDARD_URL:
+            standard = SECURITY_STANDARD_URL[standard_key]
+            url_pattern = standard["url_pattern"]
+            result = re.match(url_pattern, href)
+            if result is not None:
+                convert = standard["convert_id"]
+                category = convert(result[1])
+                if standard_key not in security_standards_links.keys():
+                    security_standards_links[standard_key] = []
+                security_standards_links[standard_key].append(category)
+    return security_standards_links
 
-HOW_TO_FIX_IT = 'How to fix it'
+
+HOW_TO_FIX_IT = "How to fix it"
 HOW_TO_FIX_IT_REGEX = re.compile(HOW_TO_FIX_IT)
 SECURITY_STANDARD_URL = {
-  "OWASP": {
-    "url_pattern": r"https://(?:www\.)?owasp\.org/www-project-top-ten/2017/A(10|[1-9])_2017-",
-    "convert_id": lambda value: f"A{value.lstrip('0')}",
-  },
-  "OWASP Top 10 2021": {
-    "url_pattern": r"https://(?:www\.)?owasp\.org/Top10/A(10|0[1-9])_2021-",
-    "convert_id": lambda value: f"A{value.lstrip('0')}",
-  },
+    "OWASP": {
+        "url_pattern": r"https://(?:www\.)?owasp\.org/www-project-top-ten/2017/A(10|[1-9])_2017-",
+        "convert_id": lambda value: f"A{value.lstrip('0')}",
+    },
+    "OWASP Top 10 2021": {
+        "url_pattern": r"https://(?:www\.)?owasp\.org/Top10/A(10|0[1-9])_2021-",
+        "convert_id": lambda value: f"A{value.lstrip('0')}",
+    },
 }
 
 # The list of all the sections currently accepted by the script.
@@ -51,211 +55,327 @@ SECURITY_STANDARD_URL = {
 # in the migrated RSPECs.
 # Further work required to shorten the list by renaming the sections in some RSPECS
 # to keep only on version for each title.
-HOTSPOT_SECTION_NAMES: Final[list[str]] = parse_names('docs/header_names/hotspot_section_names.adoc')
+HOTSPOT_SECTION_NAMES: Final[list[str]] = parse_names(
+    "docs/header_names/hotspot_section_names.adoc"
+)
 # The list of all the framework names currently accepted by the script.
-ACCEPTED_FRAMEWORK_NAMES: Final[list[str]] = parse_names('docs/header_names/allowed_framework_names.adoc')
+ACCEPTED_FRAMEWORK_NAMES: Final[list[str]] = parse_names(
+    "docs/header_names/allowed_framework_names.adoc"
+)
 
 # This needs to be kept in sync with the [headers list in docs/descriptions.adoc](https://github.com/SonarSource/rspec/blob/master/docs/description.adoc#2-education-format)
-MANDATORY_SECTIONS = ['Why is this an issue?']
-CODE_EXAMPLES='Code examples'
+MANDATORY_SECTIONS = ["Why is this an issue?"]
+CODE_EXAMPLES = "Code examples"
 OPTIONAL_SECTIONS = {
-  # Also covers 'How to fix it in {Framework Display Name}'
-  HOW_TO_FIX_IT: [], # Empty list because we now accept anything as sub-section
-  'Resources': ['Documentation', 'Articles & blog posts', 'Conference presentations', 'Standards', 'External coding guidelines', 'Benchmarks', 'Related rules']
+    # Also covers 'How to fix it in {Framework Display Name}'
+    HOW_TO_FIX_IT: [],  # Empty list because we now accept anything as sub-section
+    "Resources": [
+        "Documentation",
+        "Articles & blog posts",
+        "Conference presentations",
+        "Standards",
+        "External coding guidelines",
+        "Benchmarks",
+        "Related rules",
+    ],
 }
-SUBSECTIONS = {
-  CODE_EXAMPLES: ['Noncompliant code example', 'Compliant solution']
-}
+SUBSECTIONS = {CODE_EXAMPLES: ["Noncompliant code example", "Compliant solution"]}
+
 
 def validate_duplications(h2_titles, rule_language):
-  as_set = set(h2_titles)
-  if len(as_set) != len(h2_titles):
-    duplicates = [x for x in h2_titles if h2_titles.count(x) > 1]
-    raise RuleValidationError(f'Rule {rule_language.id} has duplicated {set(duplicates)} sections')
+    as_set = set(h2_titles)
+    if len(as_set) != len(h2_titles):
+        duplicates = [x for x in h2_titles if h2_titles.count(x) > 1]
+        raise RuleValidationError(
+            f"Rule {rule_language.id} has duplicated {set(duplicates)} sections"
+        )
+
 
 def intersection(list1, list2):
-  return list(set(list1).intersection(list2))
-def difference(list1, list2):
-  return list(set(list1) - set(list2))
+    return list(set(list1).intersection(list2))
 
-def validate_titles_are_not_misclassified_as_subtitles(rule_language: LanguageSpecificRule, subtitles: list[str], allowed_h2_sections: list[str]):
-  # TODO This does not validate "How to fix it" section for frameworks as the section names are a bit special.
-  misclassified = intersection(subtitles, allowed_h2_sections)
-  if misclassified:
-    misclassified.sort()
-    misclassified_str = ', '.join(misclassified)
-    raise RuleValidationError(f'Rule {rule_language.id} has some sections misclassified. Ensure there are not too many `=` in the asciidoc file for: {misclassified_str}')
+
+def difference(list1, list2):
+    return list(set(list1) - set(list2))
+
+
+def validate_titles_are_not_misclassified_as_subtitles(
+    rule_language: LanguageSpecificRule,
+    subtitles: list[str],
+    allowed_h2_sections: list[str],
+):
+    # TODO This does not validate "How to fix it" section for frameworks as the section names are a bit special.
+    misclassified = intersection(subtitles, allowed_h2_sections)
+    if misclassified:
+        misclassified.sort()
+        misclassified_str = ", ".join(misclassified)
+        raise RuleValidationError(
+            f"Rule {rule_language.id} has some sections misclassified. Ensure there are not too many `=` in the asciidoc file for: {misclassified_str}"
+        )
+
 
 def validate_section_names(rule_language: LanguageSpecificRule):
-  """Validates all h2-level section names"""
-  def get_titles(level: Union[str, list[str]]) -> list[str]:
-    return list(map(lambda x: x.text.strip(), rule_language.description.find_all(level)))
+    """Validates all h2-level section names"""
 
-  h2_titles = get_titles('h2')
-  subtitles = get_titles(['h3', 'h4', 'h5', 'h6'])
-  allowed_h2_sections = list(MANDATORY_SECTIONS) + list(OPTIONAL_SECTIONS.keys())
-  validate_titles_are_not_misclassified_as_subtitles(rule_language, subtitles, allowed_h2_sections)
-  validate_duplications(h2_titles, rule_language)
+    def get_titles(level: Union[str, list[str]]) -> list[str]:
+        return list(
+            map(lambda x: x.text.strip(), rule_language.description.find_all(level))
+        )
 
-  education_titles = intersection(h2_titles, allowed_h2_sections)
-  if education_titles:
-    # Using the education format.
-    validate_how_to_fix_it_sections_names(rule_language, h2_titles)
-    missing_titles = difference(list(MANDATORY_SECTIONS), education_titles)
-    if missing_titles:
-      # All mandatory titles have to be present in the rule description.
-      raise RuleValidationError(f'Rule {rule_language.id} is missing the "{missing_titles[0]}" section')
-  else:
-    # Using the hotspot format.
-    for title in h2_titles:
-      if title not in HOTSPOT_SECTION_NAMES:
-        raise RuleValidationError(f'Rule {rule_language.id} has an unconventional header "{title}"')
+    h2_titles = get_titles("h2")
+    subtitles = get_titles(["h3", "h4", "h5", "h6"])
+    allowed_h2_sections = list(MANDATORY_SECTIONS) + list(OPTIONAL_SECTIONS.keys())
+    validate_titles_are_not_misclassified_as_subtitles(
+        rule_language, subtitles, allowed_h2_sections
+    )
+    validate_duplications(h2_titles, rule_language)
 
-def validate_how_to_fix_it_sections_names(rule_language: LanguageSpecificRule, h2_titles: list[str]):
-  how_to_fix_it_sections = [ s for s in h2_titles if HOW_TO_FIX_IT_REGEX.match(s) ]
-  if not how_to_fix_it_sections:
-    # No 'How to fix it' section for the rule.
-    return
-  if len(how_to_fix_it_sections) > 6:
-    raise RuleValidationError(f'Rule {rule_language.id} has more than 6 "{HOW_TO_FIX_IT}" sections. Please ensure this limit can be increased with PM/UX teams')
+    education_titles = intersection(h2_titles, allowed_h2_sections)
+    if education_titles:
+        # Using the education format.
+        validate_how_to_fix_it_sections_names(rule_language, h2_titles)
+        missing_titles = difference(list(MANDATORY_SECTIONS), education_titles)
+        if missing_titles:
+            # All mandatory titles have to be present in the rule description.
+            raise RuleValidationError(
+                f'Rule {rule_language.id} is missing the "{missing_titles[0]}" section'
+            )
+    else:
+        # Using the hotspot format.
+        for title in h2_titles:
+            if title not in HOTSPOT_SECTION_NAMES:
+                raise RuleValidationError(
+                    f'Rule {rule_language.id} has an unconventional header "{title}"'
+                )
 
-  if HOW_TO_FIX_IT in how_to_fix_it_sections and len(how_to_fix_it_sections) > 1:
-    raise RuleValidationError(f'Rule {rule_language.id} is mixing "{HOW_TO_FIX_IT}" with "How to fix it in FRAMEWORK NAME" sections. Either use a single "{HOW_TO_FIX_IT}" or one or more "How to fix it in FRAMEWORK"')
-  for section_name in how_to_fix_it_sections:
-    validate_how_to_fix_it_framework(section_name, rule_language)
+
+def validate_how_to_fix_it_sections_names(
+    rule_language: LanguageSpecificRule, h2_titles: list[str]
+):
+    how_to_fix_it_sections = [s for s in h2_titles if HOW_TO_FIX_IT_REGEX.match(s)]
+    if not how_to_fix_it_sections:
+        # No 'How to fix it' section for the rule.
+        return
+    if len(how_to_fix_it_sections) > 6:
+        raise RuleValidationError(
+            f'Rule {rule_language.id} has more than 6 "{HOW_TO_FIX_IT}" sections. Please ensure this limit can be increased with PM/UX teams'
+        )
+
+    if HOW_TO_FIX_IT in how_to_fix_it_sections and len(how_to_fix_it_sections) > 1:
+        raise RuleValidationError(
+            f'Rule {rule_language.id} is mixing "{HOW_TO_FIX_IT}" with "How to fix it in FRAMEWORK NAME" sections. Either use a single "{HOW_TO_FIX_IT}" or one or more "How to fix it in FRAMEWORK"'
+        )
+    for section_name in how_to_fix_it_sections:
+        validate_how_to_fix_it_framework(section_name, rule_language)
+
 
 def validate_how_to_fix_it_framework(section_name, rule_language):
-  result = re.search('How to fix it in (?:(?:an|a|the)\\s)?(.*)', section_name)
-  if result is not None:
-    current_framework = result.group(1)
-    if current_framework not in ACCEPTED_FRAMEWORK_NAMES:
-      raise RuleValidationError(f'Rule {rule_language.id} has a "{HOW_TO_FIX_IT}" section for an unsupported framework: "{result.group(1)}"')
-  elif section_name != HOW_TO_FIX_IT:
-    raise RuleValidationError(f'Rule {rule_language.id} has a "{HOW_TO_FIX_IT}" section with an unsupported format: "{section_name}". Either use "{HOW_TO_FIX_IT}" or "How to fix it in FRAMEWORK NAME"')
+    result = re.search("How to fix it in (?:(?:an|a|the)\\s)?(.*)", section_name)
+    if result is not None:
+        current_framework = result.group(1)
+        if current_framework not in ACCEPTED_FRAMEWORK_NAMES:
+            raise RuleValidationError(
+                f'Rule {rule_language.id} has a "{HOW_TO_FIX_IT}" section for an unsupported framework: "{result.group(1)}"'
+            )
+    elif section_name != HOW_TO_FIX_IT:
+        raise RuleValidationError(
+            f'Rule {rule_language.id} has a "{HOW_TO_FIX_IT}" section with an unsupported format: "{section_name}". Either use "{HOW_TO_FIX_IT}" or "How to fix it in FRAMEWORK NAME"'
+        )
+
 
 def collect_titles(node, level):
-  """Collects all the titles of a given level starting from the provided node
+    """Collects all the titles of a given level starting from the provided node
 
-  The goal of this function is to extract titles from the extra HTML tags
-  that are produced when the HTML file is produced from the ASCIIdoc.
-  The titles are collected in the order in which they appear.
+    The goal of this function is to extract titles from the extra HTML tags
+    that are produced when the HTML file is produced from the ASCIIdoc.
+    The titles are collected in the order in which they appear.
 
-  Args:
-      node (BeautifulSoup): BeautifulSoup object
-      level (int): the level of title we are looking for
+    Args:
+        node (BeautifulSoup): BeautifulSoup object
+        level (int): the level of title we are looking for
 
-  Returns:
-      list[BeautifulSoup]: List of nodes that were found.
-  """
+    Returns:
+        list[BeautifulSoup]: List of nodes that were found.
+    """
 
-  current = node.next_sibling
-  nodes = []
-  while(current is not None):
-    if hasattr(current, 'find_all'):
-      nodes = nodes + current.find_all(f'h{level}')
-    current = current.next_sibling
-  return nodes
+    current = node.next_sibling
+    nodes = []
+    while current is not None:
+        if hasattr(current, "find_all"):
+            nodes = nodes + current.find_all(f"h{level}")
+        current = current.next_sibling
+    return nodes
+
 
 def validate_section_levels(rule_language: LanguageSpecificRule):
-  h1 = rule_language.description.find('h1')
-  if h1 is not None:
-    name = h1.text.strip()
-    raise RuleValidationError(f'Rule {rule_language.id} has level-0 header "{name}"')
+    h1 = rule_language.description.find("h1")
+    if h1 is not None:
+        name = h1.text.strip()
+        raise RuleValidationError(
+            f'Rule {rule_language.id} has level-0 header "{name}"'
+        )
+
 
 def validate_one_parameter(child, id):
-  if child.name != 'div' or child['class'][0] != 'sidebarblock':
-    raise RuleValidationError(f'Rule {id} should use `****` blocks for each parameter')
-  for div_child in child.children:
-    if div_child.name is not None:
-      if div_child['class'][0] != 'content':
-        raise RuleValidationError(f'Rule {id} should use `****` blocks for each parameter')
-      if div_child.p is None:
-        raise RuleValidationError(f'Rule {id} should have a description for each parameter')
-      if div_child.find('div', 'title') is None:
-        raise RuleValidationError(f'Rule {id} should have a parameter name declared with `.name` before the bock, for each parameter')
+    if child.name != "div" or child["class"][0] != "sidebarblock":
+        raise RuleValidationError(
+            f"Rule {id} should use `****` blocks for each parameter"
+        )
+    for div_child in child.children:
+        if div_child.name is not None:
+            if div_child["class"][0] != "content":
+                raise RuleValidationError(
+                    f"Rule {id} should use `****` blocks for each parameter"
+                )
+            if div_child.p is None:
+                raise RuleValidationError(
+                    f"Rule {id} should have a description for each parameter"
+                )
+            if div_child.find("div", "title") is None:
+                raise RuleValidationError(
+                    f"Rule {id} should have a parameter name declared with `.name` before the bock, for each parameter"
+                )
+
 
 def validate_parameters(rule_language: LanguageSpecificRule):
-  for h3 in rule_language.description.find_all('h3'):
-    name = h3.text.strip()
-    if name == 'Parameters':
-      for child in h3.parent.children:
-        if child.name is None or child == h3 or child.name == 'hr':
-          continue
-        validate_one_parameter(child, rule_language.id)
+    for h3 in rule_language.description.find_all("h3"):
+        name = h3.text.strip()
+        if name == "Parameters":
+            for child in h3.parent.children:
+                if child.name is None or child == h3 or child.name == "hr":
+                    continue
+                validate_one_parameter(child, rule_language.id)
+
 
 def highlight_name(rule_language: LanguageSpecificRule):
-  if (rule_language.language in LANG_TO_SOURCE):
-    return LANG_TO_SOURCE[rule_language.language]
-  return rule_language.language
+    if rule_language.language in LANG_TO_SOURCE:
+        return LANG_TO_SOURCE[rule_language.language]
+    return rule_language.language
+
 
 def known_highlight(language):
-  return language in LANG_TO_SOURCE.values()
+    return language in LANG_TO_SOURCE.values()
+
 
 def validate_source_language(rule_language: LanguageSpecificRule):
-  descr = rule_language.description
-  for h2 in descr.find_all('h2'):
-    name = h2.text.strip()
-    if name.startswith('Compliant') or name.startswith('Noncompliant'):
-      for pre in h2.parent.find_all('pre'):
-        if not pre.has_attr('class') or pre['class'][0] != u'highlight' or not pre.code or not pre.code.has_attr('data-lang'):
-          raise RuleValidationError(f'''Rule {rule_language.id} has non highlighted code example in section "{name}".
-Use [source,{highlight_name(rule_language)}] or [source,text] before the opening '----'.''')
-        elif not known_highlight(pre.code['data-lang']):
-          raise RuleValidationError(f'''Rule {rule_language.id} has unknown language "{pre.code['data-lang']}" in code example in section "{name}".
-Are you looking for "{highlight_name(rule_language)}"?''')
+    descr = rule_language.description
+    for h2 in descr.find_all("h2"):
+        name = h2.text.strip()
+        if name.startswith("Compliant") or name.startswith("Noncompliant"):
+            for pre in h2.parent.find_all("pre"):
+                if (
+                    not pre.has_attr("class")
+                    or pre["class"][0] != "highlight"
+                    or not pre.code
+                    or not pre.code.has_attr("data-lang")
+                ):
+                    raise RuleValidationError(
+                        f"""Rule {rule_language.id} has non highlighted code example in section "{name}".
+Use [source,{highlight_name(rule_language)}] or [source,text] before the opening '----'."""
+                    )
+                elif not known_highlight(pre.code["data-lang"]):
+                    raise RuleValidationError(
+                        f"""Rule {rule_language.id} has unknown language "{pre.code['data-lang']}" in code example in section "{name}".
+Are you looking for "{highlight_name(rule_language)}"?"""
+                    )
+
 
 def validate_subsections(rule_language: LanguageSpecificRule):
-  for optional_section in list(OPTIONAL_SECTIONS.keys()):
-    if optional_section == HOW_TO_FIX_IT:
-      validate_subsections_for_section(rule_language, optional_section, OPTIONAL_SECTIONS[optional_section], section_regex=HOW_TO_FIX_IT_REGEX)
-    else:
-      validate_subsections_for_section(rule_language, optional_section, OPTIONAL_SECTIONS[optional_section])
-  for subsection_with_sub_subsection in list(SUBSECTIONS.keys()):
-    if subsection_with_sub_subsection == CODE_EXAMPLES:
-      validate_subsections_for_section(rule_language, subsection_with_sub_subsection, SUBSECTIONS[subsection_with_sub_subsection], level=4, is_duplicate_allowed=True)
-    else:
-      validate_subsections_for_section(rule_language, subsection_with_sub_subsection, SUBSECTIONS[subsection_with_sub_subsection], level=4)
+    for optional_section in list(OPTIONAL_SECTIONS.keys()):
+        if optional_section == HOW_TO_FIX_IT:
+            validate_subsections_for_section(
+                rule_language,
+                optional_section,
+                OPTIONAL_SECTIONS[optional_section],
+                section_regex=HOW_TO_FIX_IT_REGEX,
+            )
+        else:
+            validate_subsections_for_section(
+                rule_language, optional_section, OPTIONAL_SECTIONS[optional_section]
+            )
+    for subsection_with_sub_subsection in list(SUBSECTIONS.keys()):
+        if subsection_with_sub_subsection == CODE_EXAMPLES:
+            validate_subsections_for_section(
+                rule_language,
+                subsection_with_sub_subsection,
+                SUBSECTIONS[subsection_with_sub_subsection],
+                level=4,
+                is_duplicate_allowed=True,
+            )
+        else:
+            validate_subsections_for_section(
+                rule_language,
+                subsection_with_sub_subsection,
+                SUBSECTIONS[subsection_with_sub_subsection],
+                level=4,
+            )
 
-def validate_subsections_for_section(rule_language: LanguageSpecificRule, section_name: str, allowed_subsections: set[str], **options):
 
-  # Handle options
-  level = options['level'] if 'level' in options else 3
-  section_regex = options['section_regex'] if 'section_regex' in options else section_name
-  is_duplicate_allowed = options['is_duplicate_allowed'] if 'is_duplicate_allowed' in options else False
+def validate_subsections_for_section(
+    rule_language: LanguageSpecificRule,
+    section_name: str,
+    allowed_subsections: set[str],
+    **options,
+):
 
-  descr = rule_language.description
-  top_level_section = descr.find(f'h{level-1}', string=section_regex)
-  if top_level_section is not None:
-    titles = collect_titles(top_level_section, level)
-    subsections_seen = set()
-    for title in titles:
-      name = title.text.strip()
-      if allowed_subsections and name not in allowed_subsections:
-        raise RuleValidationError(f'Rule {rule_language.id} has a "{section_name}" subsection with an unallowed name: "{name}"')
-      if name in subsections_seen and not is_duplicate_allowed:
-        raise RuleValidationError(f'Rule {rule_language.id} has duplicate "{section_name}" subsections. There are 2 occurences of "{name}"')
-      subsections_seen.add(name)
+    # Handle options
+    level = options["level"] if "level" in options else 3
+    section_regex = (
+        options["section_regex"] if "section_regex" in options else section_name
+    )
+    is_duplicate_allowed = (
+        options["is_duplicate_allowed"] if "is_duplicate_allowed" in options else False
+    )
+
+    descr = rule_language.description
+    top_level_section = descr.find(f"h{level-1}", string=section_regex)
+    if top_level_section is not None:
+        titles = collect_titles(top_level_section, level)
+        subsections_seen = set()
+        for title in titles:
+            name = title.text.strip()
+            if allowed_subsections and name not in allowed_subsections:
+                raise RuleValidationError(
+                    f'Rule {rule_language.id} has a "{section_name}" subsection with an unallowed name: "{name}"'
+                )
+            if name in subsections_seen and not is_duplicate_allowed:
+                raise RuleValidationError(
+                    f'Rule {rule_language.id} has duplicate "{section_name}" subsections. There are 2 occurences of "{name}"'
+                )
+            subsections_seen.add(name)
 
 
 def validate_security_standard_links(rule_language: LanguageSpecificRule):
-  descr = rule_language.description
-  security_standards_links = parse_security_standard_links(descr)
-  metadata = rule_language.metadata
+    descr = rule_language.description
+    security_standards_links = parse_security_standard_links(descr)
+    metadata = rule_language.metadata
 
-  # Avoid raising mismatch issues on deprecated or closed rules
-  if metadata.get('status') != 'ready':
-    return
+    # Avoid raising mismatch issues on deprecated or closed rules
+    if metadata.get("status") != "ready":
+        return
 
-  security_standards_metadata = metadata.get('securityStandards', {})
-  for standard in SECURITY_STANDARD_URL.keys():
+    security_standards_metadata = metadata.get("securityStandards", {})
+    for standard in SECURITY_STANDARD_URL.keys():
 
-    metadata_mapping = security_standards_metadata[standard] if standard in security_standards_metadata.keys() else []
-    links_mapping = security_standards_links[standard] if standard in security_standards_links.keys() else []
+        metadata_mapping = (
+            security_standards_metadata[standard]
+            if standard in security_standards_metadata.keys()
+            else []
+        )
+        links_mapping = (
+            security_standards_links[standard]
+            if standard in security_standards_links.keys()
+            else []
+        )
 
-    extra_links = difference(links_mapping, metadata_mapping)
-    if len(extra_links) > 0:
-      raise RuleValidationError(f'Rule {rule_language.id} has a mismatch for the {standard} security standards. Remove links from the Resources/See section ({extra_links}) or fix the rule metadata')
+        extra_links = difference(links_mapping, metadata_mapping)
+        if len(extra_links) > 0:
+            raise RuleValidationError(
+                f"Rule {rule_language.id} has a mismatch for the {standard} security standards. Remove links from the Resources/See section ({extra_links}) or fix the rule metadata"
+            )
 
-    missing_links = difference(metadata_mapping, links_mapping)
-    if len(missing_links) > 0:
-      raise RuleValidationError(f'Rule {rule_language.id} has a mismatch for the {standard} security standards. Add links to the Resources/See section ({missing_links}) or fix the rule metadata')
+        missing_links = difference(metadata_mapping, links_mapping)
+        if len(missing_links) > 0:
+            raise RuleValidationError(
+                f"Rule {rule_language.id} has a mismatch for the {standard} security standards. Add links to the Resources/See section ({missing_links}) or fix the rule metadata"
+            )

--- a/rspec-tools/rspec_tools/validation/metadata.py
+++ b/rspec-tools/rspec_tools/validation/metadata.py
@@ -1,7 +1,7 @@
 import json
+from functools import cache
 from pathlib import Path
 from typing import Final, List
-from functools import cache
 
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
@@ -9,154 +9,175 @@ from jsonschema.exceptions import ValidationError
 from rspec_tools.errors import RuleValidationError
 from rspec_tools.rules import GenericRule, LanguageSpecificRule
 
-DEFAULT_SCHEMA_PATH: Final[Path] = Path(__file__).parent.joinpath('rule-metadata-schema.json')
+DEFAULT_SCHEMA_PATH: Final[Path] = Path(__file__).parent.joinpath(
+    "rule-metadata-schema.json"
+)
 
 # Closed rules with no languages were imported when the migration from Jira was done.
 # These rules are allowed to have no language specialization in order to keep them for posterity.
 RULES_WITH_NO_LANGUAGES = [
-  'S137',
-  'S501',
-  'S502',
-  'S502',
-  'S788',
-  'S789',
-  'S857',
-  'S866',
-  'S882',
-  'S908',
-  'S911',
-  'S913',
-  'S914',
-  'S918',
-  'S921',
-  'S974',
-  'S975',
-  'S1076',
-  'S1078',
-  'S1127',
-  'S1173',
-  'S1212',
-  'S1230',
-  'S1294',
-  'S1318',
-  'S1513',
-  'S1518',
-  'S1519',
-  'S1520',
-  'S1521',
-  'S1538',
-  'S1646',
-  'S1701',
-  'S1724',
-  'S1730',
-  'S1746',
-  'S1802',
-  'S1815',
-  'S1825',
-  'S1826',
-  'S1847',
-  'S1873',
-  'S1924',
-  'S1925',
-  'S1956',
-  'S2098',
-  'S2128',
-  'S2192',
-  'S2215',
-  'S2336',
-  'S2337',
-  'S2338',
-  'S2341',
-  'S2371',
-  'S2385',
-  'S2732',
-  'S2735',
-  'S2736',
-  'S2848',
-  'S2916',
-  'S2987',
-  'S2988',
-  'S2998',
-  'S3223',
-  'S3354',
-  'S3746',
-  'S4805',
+    "S137",
+    "S501",
+    "S502",
+    "S502",
+    "S788",
+    "S789",
+    "S857",
+    "S866",
+    "S882",
+    "S908",
+    "S911",
+    "S913",
+    "S914",
+    "S918",
+    "S921",
+    "S974",
+    "S975",
+    "S1076",
+    "S1078",
+    "S1127",
+    "S1173",
+    "S1212",
+    "S1230",
+    "S1294",
+    "S1318",
+    "S1513",
+    "S1518",
+    "S1519",
+    "S1520",
+    "S1521",
+    "S1538",
+    "S1646",
+    "S1701",
+    "S1724",
+    "S1730",
+    "S1746",
+    "S1802",
+    "S1815",
+    "S1825",
+    "S1826",
+    "S1847",
+    "S1873",
+    "S1924",
+    "S1925",
+    "S1956",
+    "S2098",
+    "S2128",
+    "S2192",
+    "S2215",
+    "S2336",
+    "S2337",
+    "S2338",
+    "S2341",
+    "S2371",
+    "S2385",
+    "S2732",
+    "S2735",
+    "S2736",
+    "S2848",
+    "S2916",
+    "S2987",
+    "S2988",
+    "S2998",
+    "S3223",
+    "S3354",
+    "S3746",
+    "S4805",
 ]
+
 
 @cache
 def get_json_schema():
-  return json.loads(DEFAULT_SCHEMA_PATH.read_bytes())
+    return json.loads(DEFAULT_SCHEMA_PATH.read_bytes())
 
 
 def validate_rule_specialization_metadata(rule_language: LanguageSpecificRule):
-  validate_schema(rule_language)
-  validate_status(rule_language)
-  validate_security_standards(rule_language)
+    validate_schema(rule_language)
+    validate_status(rule_language)
+    validate_security_standards(rule_language)
 
 
 def validate_rule_metadata(rule: GenericRule):
-  '''In addition to the test carried out by validate_metadata for each language specification,
-     a rule must have at least one language (unless it is part of the list of exception).
-  '''
-  specializations = list(rule.specializations)
-  if rule.id in RULES_WITH_NO_LANGUAGES:
-    if specializations:
-      # When this triggers, ask yourself whether the rule should be removed from RULES_WITH_NO_LANGUAGES
-      raise RuleValidationError(f'Rule {rule.id} should have no specializations. Forgot to remove it from the list?')
+    """In addition to the test carried out by validate_metadata for each language specification,
+    a rule must have at least one language (unless it is part of the list of exception).
+    """
+    specializations = list(rule.specializations)
+    if rule.id in RULES_WITH_NO_LANGUAGES:
+        if specializations:
+            # When this triggers, ask yourself whether the rule should be removed from RULES_WITH_NO_LANGUAGES
+            raise RuleValidationError(
+                f"Rule {rule.id} should have no specializations. Forgot to remove it from the list?"
+            )
 
-    if rule.generic_metadata.get('status', None) not in ['closed', 'deprecated']:
-      raise RuleValidationError(f'Rule {rule.id} should be closed or deprecated')
+        if rule.generic_metadata.get("status", None) not in ["closed", "deprecated"]:
+            raise RuleValidationError(f"Rule {rule.id} should be closed or deprecated")
 
-    # Nothing else to do.
-    return
+        # Nothing else to do.
+        return
 
-  if not specializations:
-    raise RuleValidationError(f'Rule {rule.id} has no language-specific data')
+    if not specializations:
+        raise RuleValidationError(f"Rule {rule.id} has no language-specific data")
 
-  errors: List[str] = []
-  for language_rule in specializations:
-    try:
-      validate_rule_specialization_metadata(language_rule)
-    except RuleValidationError as e:
-      errors.append(str(e))
+    errors: List[str] = []
+    for language_rule in specializations:
+        try:
+            validate_rule_specialization_metadata(language_rule)
+        except RuleValidationError as e:
+            errors.append(str(e))
 
-  if errors:
-    raise RuleValidationError(f'Rule {rule.id} failed validation for these reasons:\n - ' + '\n - '.join(errors))
+    if errors:
+        raise RuleValidationError(
+            f"Rule {rule.id} failed validation for these reasons:\n - "
+            + "\n - ".join(errors)
+        )
 
 
 def validate_schema(rule_language: LanguageSpecificRule):
-  schema = get_json_schema()
-  try:
-    validate(instance=rule_language.metadata, schema=schema)
-  except ValidationError as e:
-    path = f'in {e.path[-1]}' if e.path else ''
-    raise RuleValidationError(f'Rule {rule_language.id} has invalid metadata {path}: {e.message}') from e
+    schema = get_json_schema()
+    try:
+        validate(instance=rule_language.metadata, schema=schema)
+    except ValidationError as e:
+        path = f"in {e.path[-1]}" if e.path else ""
+        raise RuleValidationError(
+            f"Rule {rule_language.id} has invalid metadata {path}: {e.message}"
+        ) from e
+
 
 def validate_status(rule_language: LanguageSpecificRule):
-  status = rule_language.metadata.get('status')
-  if has_replacement_rules(rule_language) and status in ["beta", "ready"]:
-    raise RuleValidationError(f'Rule {rule_language.id} has invalid metadata:'
-      f' status can\'t be "{status}" for a rule with replacement rule(s)')
+    status = rule_language.metadata.get("status")
+    if has_replacement_rules(rule_language) and status in ["beta", "ready"]:
+        raise RuleValidationError(
+            f"Rule {rule_language.id} has invalid metadata:"
+            f' status can\'t be "{status}" for a rule with replacement rule(s)'
+        )
 
 
 def validate_security_standards(rule_language: LanguageSpecificRule):
-  rule = rule_language.rule
-  if 'securityStandards' in rule.generic_metadata.keys() and 'securityStandards' in rule_language.metadata:
-    missing_standards = []
-    rule_language_standards = rule_language.metadata['securityStandards']
-    for standard in rule.generic_metadata['securityStandards'].keys():
-      if standard not in rule_language_standards:
-        missing_standards.append(standard)
-    
-    if len(missing_standards) > 0:
-      raise RuleValidationError(f'Rule {rule_language.id} has invalid metadata:'
-        f' securityStandard should contain {missing_standards}')
-      
+    rule = rule_language.rule
+    if (
+        "securityStandards" in rule.generic_metadata.keys()
+        and "securityStandards" in rule_language.metadata
+    ):
+        missing_standards = []
+        rule_language_standards = rule_language.metadata["securityStandards"]
+        for standard in rule.generic_metadata["securityStandards"].keys():
+            if standard not in rule_language_standards:
+                missing_standards.append(standard)
 
+        if len(missing_standards) > 0:
+            raise RuleValidationError(
+                f"Rule {rule_language.id} has invalid metadata:"
+                f" securityStandard should contain {missing_standards}"
+            )
 
 
 def has_replacement_rules(rule_language: LanguageSpecificRule):
-  meta = rule_language.metadata
-  return 'extra' in meta and 'replacementRules' in meta.get('extra') and len(meta.get('extra').get('replacementRules')) > 0
+    meta = rule_language.metadata
+    return (
+        "extra" in meta
+        and "replacementRules" in meta.get("extra")
+        and len(meta.get("extra").get("replacementRules")) > 0
+    )
 
-__all__=['validate_rule_specialization_metadata']
+
+__all__ = ["validate_rule_specialization_metadata"]

--- a/rspec-tools/rspec_tools/validation/sanitize_asciidoc.py
+++ b/rspec-tools/rspec_tools/validation/sanitize_asciidoc.py
@@ -1,4 +1,4 @@
-""" Ensure the asciidoc code for a rule description follows best practices
+"""Ensure the asciidoc code for a rule description follows best practices
 
 Checks are:
 * "ifdef"/"endif" blocks should be well-formed for RSPEC

--- a/rspec-tools/tests/conftest.py
+++ b/rspec-tools/tests/conftest.py
@@ -10,82 +10,80 @@ from rspec_tools.repo import RspecRepo
 
 @pytest.fixture
 def mockrules():
-  '''Provides a path to test rules resources.'''
-  return Path(__file__).parent.joinpath('resources', 'rules')
+    """Provides a path to test rules resources."""
+    return Path(__file__).parent.joinpath("resources", "rules")
 
 
 @pytest.fixture
 def mockinvalidrules():
-  '''Provides a path to test rules resources.'''
-  return Path(__file__).parent.joinpath('resources', 'invalid-rules')
+    """Provides a path to test rules resources."""
+    return Path(__file__).parent.joinpath("resources", "invalid-rules")
 
 
 @pytest.fixture
 def mockinvalidasciidoc():
-  '''Provides a path to test asciidoc resources.'''
-  return Path(__file__).parent.joinpath('resources', 'invalid-asciidoc')
+    """Provides a path to test asciidoc resources."""
+    return Path(__file__).parent.joinpath("resources", "invalid-asciidoc")
 
 
 @pytest.fixture
 def mockasciidoc():
-  '''Provides a path to test asciidoc resources.'''
-  return Path(__file__).parent.joinpath('resources', 'asciidoc')
+    """Provides a path to test asciidoc resources."""
+    return Path(__file__).parent.joinpath("resources", "asciidoc")
+
 
 @pytest.fixture
 def git_config():
-  '''Create a mock git configuration.'''
-  return {
-    'user.name': 'testuser',
-    'user.email': 'testuser@mock.mock'
-  }
+    """Create a mock git configuration."""
+    return {"user.name": "testuser", "user.email": "testuser@mock.mock"}
 
 
 @pytest.fixture
 def mock_git_rspec_repo(tmpdir, mockrules: Path):
-  repo_dir = tmpdir.mkdir("mock_rspec")
-  repo = Repo.init(str(repo_dir), b='master')
-  rules_dir = repo_dir.join('rules')
-  shutil.copytree(mockrules, rules_dir)
+    repo_dir = tmpdir.mkdir("mock_rspec")
+    repo = Repo.init(str(repo_dir), b="master")
+    rules_dir = repo_dir.join("rules")
+    shutil.copytree(mockrules, rules_dir)
 
-  with repo.config_writer() as config_writer:
-    config_writer.set_value('user', 'name', 'originuser')
-    config_writer.set_value('user', 'email', 'originuser@mock.mock')
+    with repo.config_writer() as config_writer:
+        config_writer.set_value("user", "name", "originuser")
+        config_writer.set_value("user", "email", "originuser@mock.mock")
 
-  repo.git.add('--all')
-  repo.index.commit('init rules')
+    repo.git.add("--all")
+    repo.index.commit("init rules")
 
-  # Create the id counter branch. Note that it is an orphan branch.
-  repo.head.reference = Head(repo, f'refs/heads/{RspecRepo.ID_COUNTER_BRANCH}')
-  repo.git.reset('--hard')
-  counter_file = repo_dir.join(RspecRepo.ID_COUNTER_FILENAME)
-  counter_file.write('0')
-  repo.index.add([str(counter_file)])
-  commit = repo.index.commit('init counter', parent_commits=None)
+    # Create the id counter branch. Note that it is an orphan branch.
+    repo.head.reference = Head(repo, f"refs/heads/{RspecRepo.ID_COUNTER_BRANCH}")
+    repo.git.reset("--hard")
+    counter_file = repo_dir.join(RspecRepo.ID_COUNTER_FILENAME)
+    counter_file.write("0")
+    repo.index.add([str(counter_file)])
+    commit = repo.index.commit("init counter", parent_commits=None)
 
-  # Checkout a specific commit so that the repo can be pushed to without
-  # making the index and work tree inconsistent.
-  repo.git.checkout(commit.hexsha)
+    # Checkout a specific commit so that the repo can be pushed to without
+    # making the index and work tree inconsistent.
+    repo.git.checkout(commit.hexsha)
 
-  return repo
+    return repo
 
 
 @pytest.fixture
 def rspec_repo(tmpdir, mock_git_rspec_repo: Repo, git_config: dict[str, str]):
-  cloned_repo = tmpdir.mkdir("cloned_repo")
-  return RspecRepo(mock_git_rspec_repo.working_dir, str(cloned_repo), git_config)
+    cloned_repo = tmpdir.mkdir("cloned_repo")
+    return RspecRepo(mock_git_rspec_repo.working_dir, str(cloned_repo), git_config)
 
 
 @contextmanager
 def mock_github():
-  token = 'TOKEN'
-  user = 'testuser'
-  mock_repo = Mock()
-  mock_github = Mock()
-  mock_github.get_repo = Mock(return_value=mock_repo)
-  mock_github_api = Mock(return_value=mock_github)
-  mock_auto_github = Mock(return_value=mock_github_api)
-  with patch('rspec_tools.repo._auto_github', mock_auto_github):
-    yield (token, user, mock_repo)
-    mock_auto_github.assert_called_once_with(token)
-    mock_github_api.assert_called_once_with(user)
-    mock_github.get_repo.assert_called_once()
+    token = "TOKEN"
+    user = "testuser"
+    mock_repo = Mock()
+    mock_github = Mock()
+    mock_github.get_repo = Mock(return_value=mock_repo)
+    mock_github_api = Mock(return_value=mock_github)
+    mock_auto_github = Mock(return_value=mock_github_api)
+    with patch("rspec_tools.repo._auto_github", mock_auto_github):
+        yield (token, user, mock_repo)
+        mock_auto_github.assert_called_once_with(token)
+        mock_github_api.assert_called_once_with(user)
+        mock_github.get_repo.assert_called_once()

--- a/rspec-tools/tests/links/test_links.py
+++ b/rspec-tools/tests/links/test_links.py
@@ -1,46 +1,61 @@
-from click.testing import CliRunner
-from rspec_tools import cli
-from rspec_tools import checklinks
 from pathlib import Path
+
+from click.testing import CliRunner
+from rspec_tools import checklinks, cli
 
 FILE_DIR = Path(__file__).resolve().parent
 
+
 def test_find_urls():
-  urls={}
-  checklinks.findurl_in_html(FILE_DIR / "404/S100/java/rule.html",urls)
-  assert urls == {'https://www.google.com/404': [FILE_DIR / '404/S100/java/rule.html']}
-  assert len(urls) == 1
+    urls = {}
+    checklinks.findurl_in_html(FILE_DIR / "404/S100/java/rule.html", urls)
+    assert urls == {
+        "https://www.google.com/404": [FILE_DIR / "404/S100/java/rule.html"]
+    }
+    assert len(urls) == 1
+
 
 def test_live():
-  assert checklinks.live_url("https://www.google.com")
+    assert checklinks.live_url("https://www.google.com")
+
 
 def test_live():
-  assert not checklinks.live_url("https://ww.nothing")
+    assert not checklinks.live_url("https://ww.nothing")
+
 
 def test_404():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / '404'])
-  print(result.output)
-  assert result.exit_code == 1
-  assert "1/1 links are dead, see above ^^ the list and the related files" in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ["check-links", "--d", FILE_DIR / "404"])
+    print(result.output)
+    assert result.exit_code == 1
+    assert (
+        "1/1 links are dead, see above ^^ the list and the related files"
+        in result.output
+    )
+
 
 def test_url():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'URL'])
-  print(result.output)
-  assert result.exit_code == 1
-  assert "1/1 links are dead, see above ^^ the list and the related files" in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ["check-links", "--d", FILE_DIR / "URL"])
+    print(result.output)
+    assert result.exit_code == 1
+    assert (
+        "1/1 links are dead, see above ^^ the list and the related files"
+        in result.output
+    )
+
 
 def test_ok():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'OK'])
-  print(result.output)
-  assert result.exit_code == 0
-  assert "All 1 links are good" in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ["check-links", "--d", FILE_DIR / "OK"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert "All 1 links are good" in result.output
+
 
 def test_deprecated():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['check-links', '--d', FILE_DIR / 'deprecated'])
-  print(result.output)
-  assert result.exit_code == 0
-  assert "All 1 links are good" in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ["check-links", "--d", FILE_DIR / "deprecated"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert "All 1 links are good" in result.output

--- a/rspec-tools/tests/test_cli.py
+++ b/rspec-tools/tests/test_cli.py
@@ -10,92 +10,109 @@ from rspec_tools.rules import RulesRepository
 
 
 class TestCLIUpdateQuickfixStatus:
-  '''Unit test for quickfix status update through Command Line Interface.'''
+    """Unit test for quickfix status update through Command Line Interface."""
 
-  @patch.dict(os.environ, {'GITHUB_TOKEN': 'TOKEN'})
-  @patch('rspec_tools.modify_rule.update_rule_quickfix_status')
-  def test_basic_cli_usage(self, mock):
-    arguments = [
-      'update-quickfix-status',
-      '--language', 'langA',
-      '--rule', 'ruleX',
-      '--status', 'myStatus',
-      '--user', 'bob',
-    ]
-    CliRunner().invoke(cli, arguments)
-    mock.assert_called_once_with('langA', 'ruleX', 'myStatus', 'TOKEN', 'bob')
+    @patch.dict(os.environ, {"GITHUB_TOKEN": "TOKEN"})
+    @patch("rspec_tools.modify_rule.update_rule_quickfix_status")
+    def test_basic_cli_usage(self, mock):
+        arguments = [
+            "update-quickfix-status",
+            "--language",
+            "langA",
+            "--rule",
+            "ruleX",
+            "--status",
+            "myStatus",
+            "--user",
+            "bob",
+        ]
+        CliRunner().invoke(cli, arguments)
+        mock.assert_called_once_with("langA", "ruleX", "myStatus", "TOKEN", "bob")
 
 
 class TestCLIValidateRulesMetadata:
-  '''Unit tests for metadata validation through Command Line Interface.'''
+    """Unit tests for metadata validation through Command Line Interface."""
 
-  def _run(self, rules: List[str]):
-    runner = CliRunner()
-    arguments = ['validate-rules-metadata'] + rules
-    return runner.invoke(cli, arguments)
+    def _run(self, rules: List[str]):
+        runner = CliRunner()
+        arguments = ["validate-rules-metadata"] + rules
+        return runner.invoke(cli, arguments)
 
-  def _mock_rule_ressources(self):
-    mock_path = Path(__file__).parent.joinpath('resources', 'invalid-rules')
-    return patch.object(RulesRepository.__init__, '__defaults__', (mock_path,))
+    def _mock_rule_ressources(self):
+        mock_path = Path(__file__).parent.joinpath("resources", "invalid-rules")
+        return patch.object(RulesRepository.__init__, "__defaults__", (mock_path,))
 
-  def test_missing_parameters(self):
-    result = self._run([])
-    assert 'Missing argument \'RULES...\'' in result.output
-    assert result.exit_code == 2
+    def test_missing_parameters(self):
+        result = self._run([])
+        assert "Missing argument 'RULES...'" in result.output
+        assert result.exit_code == 2
 
-  def test_valid_rule(self):
-    '''This test uses the actual rules data, not the mock resources.'''
-    result = self._run(['S100'])
-    assert result.output == ''
-    assert result.exit_code == 0
+    def test_valid_rule(self):
+        """This test uses the actual rules data, not the mock resources."""
+        result = self._run(["S100"])
+        assert result.output == ""
+        assert result.exit_code == 0
 
-  @patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', ['S501'])
-  def test_invalid_rule_in_allow_list(self):
-    with self._mock_rule_ressources():
-      result = self._run(['S501'])
-      assert result.output == ''
-      assert result.exit_code == 0
+    @patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", ["S501"])
+    def test_invalid_rule_in_allow_list(self):
+        with self._mock_rule_ressources():
+            result = self._run(["S501"])
+            assert result.output == ""
+            assert result.exit_code == 0
 
-  @patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', [])
-  def test_invalid_rule(self):
-    with self._mock_rule_ressources():
-      result = self._run(['S501'])
-      assert 'Rule S501 has no language-specific data' in result.output
-      assert 'Validation failed due to 1 errors out of 1 analyzed rules' in result.output
-      assert result.exit_code == 1
+    @patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", [])
+    def test_invalid_rule(self):
+        with self._mock_rule_ressources():
+            result = self._run(["S501"])
+            assert "Rule S501 has no language-specific data" in result.output
+            assert (
+                "Validation failed due to 1 errors out of 1 analyzed rules"
+                in result.output
+            )
+            assert result.exit_code == 1
 
-  @patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', [])
-  def test_invalid_rules(self):
-    with self._mock_rule_ressources():
-      result = self._run(['S501', 'S502'])
-      assert 'Rule S501 has no language-specific data' in result.output
-      assert 'Rule S502 failed validation for these reasons:' in result.output
-      assert 'Rule scala:S502 has invalid metadata : \'remediation\' is a required property' in result.output
-      assert 'Validation failed due to 2 errors out of 2 analyzed rules' in result.output
-      assert result.exit_code == 1
+    @patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", [])
+    def test_invalid_rules(self):
+        with self._mock_rule_ressources():
+            result = self._run(["S501", "S502"])
+            assert "Rule S501 has no language-specific data" in result.output
+            assert "Rule S502 failed validation for these reasons:" in result.output
+            assert (
+                "Rule scala:S502 has invalid metadata : 'remediation' is a required property"
+                in result.output
+            )
+            assert (
+                "Validation failed due to 2 errors out of 2 analyzed rules"
+                in result.output
+            )
+            assert result.exit_code == 1
 
 
 class TestCLIValidateDescription:
-  '''Unit tests for description validation through Command Line Interface.'''
+    """Unit tests for description validation through Command Line Interface."""
 
-  def _run(self, rules: List[str]):
-    runner = CliRunner()
-    mock_path = os.path.realpath(Path(__file__).parent.joinpath('resources', 'rules'))
-    arguments = ['check-description', '--d', mock_path] + rules
-    return runner.invoke(cli, arguments)
+    def _run(self, rules: List[str]):
+        runner = CliRunner()
+        mock_path = os.path.realpath(
+            Path(__file__).parent.joinpath("resources", "rules")
+        )
+        arguments = ["check-description", "--d", mock_path] + rules
+        return runner.invoke(cli, arguments)
 
-  def _run_invalid(self, rules: List[str]):
-    runner = CliRunner()
-    mock_path = os.path.realpath(Path(__file__).parent.joinpath('resources', 'invalid-rules'))
-    arguments = ['check-description', '--d', mock_path] + rules
-    return runner.invoke(cli, arguments)
+    def _run_invalid(self, rules: List[str]):
+        runner = CliRunner()
+        mock_path = os.path.realpath(
+            Path(__file__).parent.joinpath("resources", "invalid-rules")
+        )
+        arguments = ["check-description", "--d", mock_path] + rules
+        return runner.invoke(cli, arguments)
 
-  def test_valid_rule(self):
-    result = self._run(['S3649'])
-    assert result.output == ''
-    assert result.exit_code == 0
+    def test_valid_rule(self):
+        result = self._run(["S3649"])
+        assert result.output == ""
+        assert result.exit_code == 0
 
-  def test_invalid_rule(self):
-    result = self._run_invalid(['S100'])
-    assert re.search(r'Validation failed due to \d+ errors', result.output)
-    assert result.exit_code == 1
+    def test_invalid_rule(self):
+        result = self._run_invalid(["S100"])
+        assert re.search(r"Validation failed due to \d+ errors", result.output)
+        assert result.exit_code == 1

--- a/rspec-tools/tests/test_coverage.py
+++ b/rspec-tools/tests/test_coverage.py
@@ -1,201 +1,294 @@
 import os
 import shutil
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch, PropertyMock
+
 import pytest
 from git import Repo
-from pathlib import Path
-from datetime import datetime
-from unittest.mock import (patch, PropertyMock)
-from contextlib import contextmanager
 
-from rspec_tools.coverage import (update_coverage_for_all_repos,
-                                  update_coverage_for_repo,
-                                  update_coverage_for_repo_version)
-from rspec_tools.utils import (load_json, pushd)
+from rspec_tools.coverage import (
+    update_coverage_for_all_repos,
+    update_coverage_for_repo,
+    update_coverage_for_repo_version,
+)
+from rspec_tools.utils import load_json, pushd
+
 
 def clear_working_dir(repo_dir):
-  for f in os.listdir(repo_dir):
-    if f != '.git':
-      if os.path.isdir(repo_dir / f):
-        shutil.rmtree(repo_dir / f)
-      else:
-        os.remove(repo_dir / f)
+    for f in os.listdir(repo_dir):
+        if f != ".git":
+            if os.path.isdir(repo_dir / f):
+                shutil.rmtree(repo_dir / f)
+            else:
+                os.remove(repo_dir / f)
+
 
 @pytest.fixture
 def rules_dir():
-  return Path(__file__).parent.joinpath('resources', 'rules')
+    return Path(__file__).parent.joinpath("resources", "rules")
 
-JSTS_SONARPEDIA='{"rules-metadata-path": "rules", "languages":["JS", "TS"]}'
-MOCK_REPOS=[{'name':'SonarJS',
-             'versions': [
-               {'name': '3.3.0.5702',
-                'date': '2020-03-03 10:00:00',
-                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
-                          ['rules/Sonar_way_profile.json', '{}'],
-                          # MethodName is a lagacy key for S100
-                          ['rules/MethodName.json', '{}'], ['rules/S1145.json', '{}'],
-                          # not in the rules directory, so not a rule:
-                          ['S200.json', '{}']]},
-               {'name': '5.0.0.6962',
-                'date': '2020-05-01 10:00:00',
-                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
-                          ['rules/Sonar_way_profile.json', '{}'],
-                          ['rules/S100.json', '{}'], ['rules/S1145.json', '{}'], ['rules/S1192.json', '{}']]},
-               {'name': '6.7.0.14237',
-                'date': '2020-06-07 10:00:00',
-                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
-                          ['rules/Sonar_way_profile.json', '{}'],
-                          ['rules/S100.json', '{}'], ['rules/S1145.json', '{}'], ['rules/S1192.json', '{}']]},
-               {'name': '7.0.0.14528',
-                'date': '2020-07-01 10:00:00',
-                'files': [['sonarpedia.json', JSTS_SONARPEDIA],
-                          ['rules/Sonar_way_profile.json', '{}'],
-                          ['rules/S100.json', '{}'], ['rules/S1192.json', '{}'],
-                          # add a CSS analyzer in this version
-                          ['css-plugin/sonarpedia.json', '{"rules-metadata-path":"cssr", "languages":["CSS"]}'],
-                          ['css-plugin/cssr/S100.json', '{}'],
-                          # add a XML analyzer here too
-                          ['xml/sonarpedia.json', '{"rules-metadata-path":"r", "languages":["XML"]}'],
-                          ['xml/r/S1000.json', '{}']]},
-             ]},
-            {'name':'sonar-xml',
-             'versions': [
-               {'name': '1.2.0.1342',
-                'date': '2020-01-02 10:00:00',
-                'files': [['rules/Sonar_way_profile.json', '{}'],
-                          ['sonarpedia.json', '{"rules-metadata-path": "rules", "languages":["XML"]}'],
-                          ['rules/S103.json', '{}']]}
-             ]},
-            {'name':'sonar-java',
-             'versions': [
-               {'name': '1.2.0.123',
-                'date': '2020-01-02 10:00:00',
-                'files': [['module1/rules/Sonar_way_profile.json', '{}'],
-                          ['module1/sonarpedia.json', '{"rules-metadata-path": "rules", "languages":["JAVA"]}'],
-                          ['module1/rules/S100.json', '{}'],
-                          ['module2/rules/Sonar_way_profile.json', '{}'],
-                          ['module2/sonarpedia.json', '{"rules-metadata-path": "rules", "languages":["JAVA"]}'],
-                          ['module2/rules/S101.json', '{}']]}
-             ]},
-            {'name':'broken',
-             'versions': [
-               {'name': 'v1',
-                'date': '2020-01-01 01:01:01',
-                'files': [['sonarpedia.json', 'non-json'], # sonarpedia is non-json
-                          ['rules/S100.json', '{}']]}
-             ]}]
+
+JSTS_SONARPEDIA = '{"rules-metadata-path": "rules", "languages":["JS", "TS"]}'
+MOCK_REPOS = [
+    {
+        "name": "SonarJS",
+        "versions": [
+            {
+                "name": "3.3.0.5702",
+                "date": "2020-03-03 10:00:00",
+                "files": [
+                    ["sonarpedia.json", JSTS_SONARPEDIA],
+                    ["rules/Sonar_way_profile.json", "{}"],
+                    # MethodName is a lagacy key for S100
+                    ["rules/MethodName.json", "{}"],
+                    ["rules/S1145.json", "{}"],
+                    # not in the rules directory, so not a rule:
+                    ["S200.json", "{}"],
+                ],
+            },
+            {
+                "name": "5.0.0.6962",
+                "date": "2020-05-01 10:00:00",
+                "files": [
+                    ["sonarpedia.json", JSTS_SONARPEDIA],
+                    ["rules/Sonar_way_profile.json", "{}"],
+                    ["rules/S100.json", "{}"],
+                    ["rules/S1145.json", "{}"],
+                    ["rules/S1192.json", "{}"],
+                ],
+            },
+            {
+                "name": "6.7.0.14237",
+                "date": "2020-06-07 10:00:00",
+                "files": [
+                    ["sonarpedia.json", JSTS_SONARPEDIA],
+                    ["rules/Sonar_way_profile.json", "{}"],
+                    ["rules/S100.json", "{}"],
+                    ["rules/S1145.json", "{}"],
+                    ["rules/S1192.json", "{}"],
+                ],
+            },
+            {
+                "name": "7.0.0.14528",
+                "date": "2020-07-01 10:00:00",
+                "files": [
+                    ["sonarpedia.json", JSTS_SONARPEDIA],
+                    ["rules/Sonar_way_profile.json", "{}"],
+                    ["rules/S100.json", "{}"],
+                    ["rules/S1192.json", "{}"],
+                    # add a CSS analyzer in this version
+                    [
+                        "css-plugin/sonarpedia.json",
+                        '{"rules-metadata-path":"cssr", "languages":["CSS"]}',
+                    ],
+                    ["css-plugin/cssr/S100.json", "{}"],
+                    # add a XML analyzer here too
+                    [
+                        "xml/sonarpedia.json",
+                        '{"rules-metadata-path":"r", "languages":["XML"]}',
+                    ],
+                    ["xml/r/S1000.json", "{}"],
+                ],
+            },
+        ],
+    },
+    {
+        "name": "sonar-xml",
+        "versions": [
+            {
+                "name": "1.2.0.1342",
+                "date": "2020-01-02 10:00:00",
+                "files": [
+                    ["rules/Sonar_way_profile.json", "{}"],
+                    [
+                        "sonarpedia.json",
+                        '{"rules-metadata-path": "rules", "languages":["XML"]}',
+                    ],
+                    ["rules/S103.json", "{}"],
+                ],
+            }
+        ],
+    },
+    {
+        "name": "sonar-java",
+        "versions": [
+            {
+                "name": "1.2.0.123",
+                "date": "2020-01-02 10:00:00",
+                "files": [
+                    ["module1/rules/Sonar_way_profile.json", "{}"],
+                    [
+                        "module1/sonarpedia.json",
+                        '{"rules-metadata-path": "rules", "languages":["JAVA"]}',
+                    ],
+                    ["module1/rules/S100.json", "{}"],
+                    ["module2/rules/Sonar_way_profile.json", "{}"],
+                    [
+                        "module2/sonarpedia.json",
+                        '{"rules-metadata-path": "rules", "languages":["JAVA"]}',
+                    ],
+                    ["module2/rules/S101.json", "{}"],
+                ],
+            }
+        ],
+    },
+    {
+        "name": "broken",
+        "versions": [
+            {
+                "name": "v1",
+                "date": "2020-01-01 01:01:01",
+                "files": [
+                    ["sonarpedia.json", "non-json"],  # sonarpedia is non-json
+                    ["rules/S100.json", "{}"],
+                ],
+            }
+        ],
+    },
+]
+
 
 def test_mock_tags_are_sorted_chronologically():
-  for mock_spec in MOCK_REPOS:
-    prev_date = datetime.strptime('1970-01-01 00:00:01', '%Y-%m-%d %H:%M:%S')
-    for tag in mock_spec['versions']:
-      cur_date = datetime.strptime(tag['date'], '%Y-%m-%d %H:%M:%S')
-      assert prev_date < cur_date
-      prev_date = cur_date
+    for mock_spec in MOCK_REPOS:
+        prev_date = datetime.strptime("1970-01-01 00:00:01", "%Y-%m-%d %H:%M:%S")
+        for tag in mock_spec["versions"]:
+            cur_date = datetime.strptime(tag["date"], "%Y-%m-%d %H:%M:%S")
+            assert prev_date < cur_date
+            prev_date = cur_date
+
 
 @pytest.fixture
 def mock_git_analyzer_repos(tmpdir):
-  mocked_repos = {};
-  for mock_spec in MOCK_REPOS:
-    repo_name = mock_spec['name']
-    repo_dir = tmpdir.mkdir('mock-' + repo_name)
-    repo = Repo.init(str(repo_dir), b='master')
-    with repo.config_writer() as config_writer:
-      config_writer.set_value('user', 'name', 'originuser')
-      config_writer.set_value('user', 'email', 'originuser@mock.mock')
-    for tag in mock_spec['versions']:
-      clear_working_dir(repo_dir)
-      for fname, contents in tag['files']:
-        path = Path(repo_dir / fname)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, 'x') as f:
-          f.write(contents)
-      repo.git.add('--all')
-      repo.index.commit(f"adding version {tag['name']}", commit_date=tag['date'], author_date=tag['date'])
-      repo.create_tag(tag['name'])
-    mocked_repos[repo_name] = repo
-  def mock_clone_repo(repo_url, repo_name):
-    return mocked_repos[repo_url.split('/')[-1]]
-  def precloned_repo(x):
-    Repo(x)
-  mock=PropertyMock(side_effect=precloned_repo)
-  mock.clone_from=PropertyMock(side_effect=mock_clone_repo)
-  return mock
+    mocked_repos = {}
+    for mock_spec in MOCK_REPOS:
+        repo_name = mock_spec["name"]
+        repo_dir = tmpdir.mkdir("mock-" + repo_name)
+        repo = Repo.init(str(repo_dir), b="master")
+        with repo.config_writer() as config_writer:
+            config_writer.set_value("user", "name", "originuser")
+            config_writer.set_value("user", "email", "originuser@mock.mock")
+        for tag in mock_spec["versions"]:
+            clear_working_dir(repo_dir)
+            for fname, contents in tag["files"]:
+                path = Path(repo_dir / fname)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with open(path, "x") as f:
+                    f.write(contents)
+            repo.git.add("--all")
+            repo.index.commit(
+                f"adding version {tag['name']}",
+                commit_date=tag["date"],
+                author_date=tag["date"],
+            )
+            repo.create_tag(tag["name"])
+        mocked_repos[repo_name] = repo
 
-def test_update_coverage_for_repo_version(tmpdir, rules_dir: Path, mock_git_analyzer_repos):
-  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
-    VER = '3.3.0.5702'
-    REPO = 'SonarJS'
-    update_coverage_for_repo_version(REPO, VER, rules_dir)
-    coverage = tmpdir.join('covered_rules.json')
-    assert coverage.exists()
-    cov = load_json(coverage)
-    assert 'js' in cov
-    assert 'S100' in cov['js']
-    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
-    assert 'S200' not in cov['js'] # S200.json is not in the rules directory in mock
-    assert cov['js']['S100'] == {'since': REPO + ' ' + VER, 'until': REPO + ' ' + VER}
+    def mock_clone_repo(repo_url, repo_name):
+        return mocked_repos[repo_url.split("/")[-1]]
 
-    # Running it again changes nothing
-    update_coverage_for_repo_version(REPO, VER, rules_dir)
-    assert cov == load_json(coverage)
+    def precloned_repo(x):
+        Repo(x)
 
-    # Running it for a newer version doesn't change when the rules are first implemented
-    VER2 = '5.0.0.6962'
-    update_coverage_for_repo_version(REPO, VER2, rules_dir)
-    cov_new = load_json(coverage)
-    assert set(cov['js'].keys()).issubset(set(cov_new['js'].keys()))
-    assert cov_new['js']['S100']['since'] == REPO + ' ' + VER
-    assert cov_new['js']['S100']['until'] == REPO + ' ' + VER2
-    assert cov_new['js']['S1192']['since'] == REPO + ' ' + VER2
-    assert cov_new['js']['S1192']['until'] == REPO + ' ' + VER2
+    mock = PropertyMock(side_effect=precloned_repo)
+    mock.clone_from = PropertyMock(side_effect=mock_clone_repo)
+    return mock
 
-    # For rules supported on master only the 'since' part is kept
-    update_coverage_for_repo_version(REPO, 'master', rules_dir)
-    assert load_json(coverage)['js']['S100'] == REPO + ' ' + VER
+
+def test_update_coverage_for_repo_version(
+    tmpdir, rules_dir: Path, mock_git_analyzer_repos
+):
+    with pushd(tmpdir), patch("rspec_tools.coverage.Repo", mock_git_analyzer_repos):
+        VER = "3.3.0.5702"
+        REPO = "SonarJS"
+        update_coverage_for_repo_version(REPO, VER, rules_dir)
+        coverage = tmpdir.join("covered_rules.json")
+        assert coverage.exists()
+        cov = load_json(coverage)
+        assert "js" in cov
+        assert "S100" in cov["js"]
+        assert "MethodName" not in cov["js"]  # MethodName is a legacy key for S100
+        assert (
+            "S200" not in cov["js"]
+        )  # S200.json is not in the rules directory in mock
+        assert cov["js"]["S100"] == {
+            "since": REPO + " " + VER,
+            "until": REPO + " " + VER,
+        }
+
+        # Running it again changes nothing
+        update_coverage_for_repo_version(REPO, VER, rules_dir)
+        assert cov == load_json(coverage)
+
+        # Running it for a newer version doesn't change when the rules are first implemented
+        VER2 = "5.0.0.6962"
+        update_coverage_for_repo_version(REPO, VER2, rules_dir)
+        cov_new = load_json(coverage)
+        assert set(cov["js"].keys()).issubset(set(cov_new["js"].keys()))
+        assert cov_new["js"]["S100"]["since"] == REPO + " " + VER
+        assert cov_new["js"]["S100"]["until"] == REPO + " " + VER2
+        assert cov_new["js"]["S1192"]["since"] == REPO + " " + VER2
+        assert cov_new["js"]["S1192"]["until"] == REPO + " " + VER2
+
+        # For rules supported on master only the 'since' part is kept
+        update_coverage_for_repo_version(REPO, "master", rules_dir)
+        assert load_json(coverage)["js"]["S100"] == REPO + " " + VER
 
 
 def test_update_coverage_for_repo(tmpdir, rules_dir: Path, mock_git_analyzer_repos):
-  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
-    REPO = 'SonarJS'
-    update_coverage_for_repo(REPO, rules_dir)
-    coverage = tmpdir.join('covered_rules.json')
-    assert coverage.exists()
-    cov = load_json(coverage)
-    assert 'js' in cov
-    assert 'ts' in cov
-    assert 'S100' in cov['js']
-    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
-    assert cov['js']['S100'] == REPO + ' 3.3.0.5702'
-    assert 'S1145' in cov['js']
-    assert cov['js']['S1145'] == {'since': REPO + ' 3.3.0.5702', 'until': REPO + ' 6.7.0.14237'}
+    with pushd(tmpdir), patch("rspec_tools.coverage.Repo", mock_git_analyzer_repos):
+        REPO = "SonarJS"
+        update_coverage_for_repo(REPO, rules_dir)
+        coverage = tmpdir.join("covered_rules.json")
+        assert coverage.exists()
+        cov = load_json(coverage)
+        assert "js" in cov
+        assert "ts" in cov
+        assert "S100" in cov["js"]
+        assert "MethodName" not in cov["js"]  # MethodName is a legacy key for S100
+        assert cov["js"]["S100"] == REPO + " 3.3.0.5702"
+        assert "S1145" in cov["js"]
+        assert cov["js"]["S1145"] == {
+            "since": REPO + " 3.3.0.5702",
+            "until": REPO + " 6.7.0.14237",
+        }
 
 
-@patch('rspec_tools.coverage.REPOS', ['SonarJS', 'sonar-xml', 'sonar-java'])
-def test_update_coverage_for_all_repos(tmpdir, rules_dir: Path, mock_git_analyzer_repos):
-  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
-    update_coverage_for_all_repos(rules_dir)
-    coverage = tmpdir.join('covered_rules.json')
-    assert coverage.exists()
-    cov = load_json(coverage)
-    assert {'js', 'ts', 'XML', 'CSS', 'JAVA'} == set(cov.keys())
-    assert 'S100' in cov['js']
-    assert 'MethodName' not in cov['js'] # MethodName is a legacy key for S100
-    assert {'S100'} == set(cov['CSS'].keys())
-    assert {'S103', 'S1000'} == set(cov['XML'].keys())
-    assert cov['XML']['S1000'] == 'SonarJS 7.0.0.14528'
-    assert {'S100', 'S101'} == set(cov['JAVA'].keys())
+@patch("rspec_tools.coverage.REPOS", ["SonarJS", "sonar-xml", "sonar-java"])
+def test_update_coverage_for_all_repos(
+    tmpdir, rules_dir: Path, mock_git_analyzer_repos
+):
+    with pushd(tmpdir), patch("rspec_tools.coverage.Repo", mock_git_analyzer_repos):
+        update_coverage_for_all_repos(rules_dir)
+        coverage = tmpdir.join("covered_rules.json")
+        assert coverage.exists()
+        cov = load_json(coverage)
+        assert {"js", "ts", "XML", "CSS", "JAVA"} == set(cov.keys())
+        assert "S100" in cov["js"]
+        assert "MethodName" not in cov["js"]  # MethodName is a legacy key for S100
+        assert {"S100"} == set(cov["CSS"].keys())
+        assert {"S103", "S1000"} == set(cov["XML"].keys())
+        assert cov["XML"]["S1000"] == "SonarJS 7.0.0.14528"
+        assert {"S100", "S101"} == set(cov["JAVA"].keys())
 
-def test_update_coverage_no_sonarpedia(tmpdir, rules_dir: Path, mock_git_analyzer_repos, capsys):
-  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
-    update_coverage_for_repo_version('broken', 'v1', rules_dir)
-    assert 'failed to collect implemented rules for' in capsys.readouterr().out
-    coverage = tmpdir.join('covered_rules.json')
-    assert coverage.exists()
-    cov = load_json(coverage)
-    assert cov == {}
 
-def test_update_coverage_nonexisting_versio(tmpdir, rules_dir: Path, mock_git_analyzer_repos, capsys):
-  with pushd(tmpdir), patch('rspec_tools.coverage.Repo', mock_git_analyzer_repos):
-    with pytest.raises(Exception):
-      update_coverage_for_repo_version('broken', 'non-existing', rules_dir)
-    assert 'checkout failed' in capsys.readouterr().out
+def test_update_coverage_no_sonarpedia(
+    tmpdir, rules_dir: Path, mock_git_analyzer_repos, capsys
+):
+    with pushd(tmpdir), patch("rspec_tools.coverage.Repo", mock_git_analyzer_repos):
+        update_coverage_for_repo_version("broken", "v1", rules_dir)
+        assert "failed to collect implemented rules for" in capsys.readouterr().out
+        coverage = tmpdir.join("covered_rules.json")
+        assert coverage.exists()
+        cov = load_json(coverage)
+        assert cov == {}
+
+
+def test_update_coverage_nonexisting_versio(
+    tmpdir, rules_dir: Path, mock_git_analyzer_repos, capsys
+):
+    with pushd(tmpdir), patch("rspec_tools.coverage.Repo", mock_git_analyzer_repos):
+        with pytest.raises(Exception):
+            update_coverage_for_repo_version("broken", "non-existing", rules_dir)
+        assert "checkout failed" in capsys.readouterr().out

--- a/rspec-tools/tests/test_create_rule.py
+++ b/rspec-tools/tests/test_create_rule.py
@@ -4,244 +4,309 @@ from unittest.mock import Mock, patch
 
 import pytest
 from git import Repo
-from rspec_tools.create_rule import (RuleCreator, add_language_to_rule,
-                                     create_new_rule)
+from rspec_tools.create_rule import add_language_to_rule, create_new_rule, RuleCreator
 from rspec_tools.errors import InvalidArgumentError
 from rspec_tools.repo import RspecRepo
-from rspec_tools.utils import LANG_TO_SOURCE, is_empty_metadata
+from rspec_tools.utils import is_empty_metadata, LANG_TO_SOURCE
 
 from tests.conftest import mock_github
 
 
 @pytest.fixture
 def rule_creator(rspec_repo: RspecRepo):
-  return RuleCreator(rspec_repo)
+    return RuleCreator(rspec_repo)
 
 
-def test_create_new_multi_lang_rule_branch(rule_creator: RuleCreator, mock_git_rspec_repo: Repo):
-  '''Test create_new_rule_branch for a multi-language rule.'''
-  rule_number = rule_creator.rspec_repo.reserve_rule_number()
+def test_create_new_multi_lang_rule_branch(
+    rule_creator: RuleCreator, mock_git_rspec_repo: Repo
+):
+    """Test create_new_rule_branch for a multi-language rule."""
+    rule_number = rule_creator.rspec_repo.reserve_rule_number()
 
-  languages = ['java', 'javascript']
-  branch = rule_creator.create_new_rule_branch(rule_number, languages)
+    languages = ["java", "javascript"]
+    branch = rule_creator.create_new_rule_branch(rule_number, languages)
 
-  # Check that the branch was pushed successfully to the origin
-  mock_git_rspec_repo.git.checkout(branch)
-  rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert rule_dir.exists()
+    # Check that the branch was pushed successfully to the origin
+    mock_git_rspec_repo.git.checkout(branch)
+    rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert rule_dir.exists()
 
-  common_root = rule_creator.TEMPLATE_PATH.joinpath('multi_language', 'common')
-  for common_item in common_root.glob('**/*'):
-    if common_item.is_file():
-      expected_content = common_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-      relative_path = common_item.relative_to(common_root)
-      actual_content = rule_dir.joinpath(relative_path).read_text()
-      assert actual_content == expected_content
+    common_root = rule_creator.TEMPLATE_PATH.joinpath("multi_language", "common")
+    for common_item in common_root.glob("**/*"):
+        if common_item.is_file():
+            expected_content = common_item.read_text().replace(
+                "${RSPEC_ID}", str(rule_number)
+            )
+            relative_path = common_item.relative_to(common_root)
+            actual_content = rule_dir.joinpath(relative_path).read_text()
+            assert actual_content == expected_content
 
-  lang_root = rule_creator.TEMPLATE_PATH.joinpath('multi_language', 'language_specific')
-  for lang in languages:
-    for lang_item in lang_root.glob('**/*'):
-      if lang_item.is_file():
-        expected_content = lang_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-        expected_content = expected_content.replace('[source,text', f'[source,{LANG_TO_SOURCE[os.path.basename(lang)]}')
-        relative_path = lang_item.relative_to(lang_root)
-        actual_content = rule_dir.joinpath(lang, relative_path).read_text()
-        assert actual_content == expected_content
-        if lang_item.suffix == '.adoc':
-          assert 'source,text' not in actual_content
-          assert LANG_TO_SOURCE[os.path.basename(lang)] in actual_content
+    lang_root = rule_creator.TEMPLATE_PATH.joinpath(
+        "multi_language", "language_specific"
+    )
+    for lang in languages:
+        for lang_item in lang_root.glob("**/*"):
+            if lang_item.is_file():
+                expected_content = lang_item.read_text().replace(
+                    "${RSPEC_ID}", str(rule_number)
+                )
+                expected_content = expected_content.replace(
+                    "[source,text", f"[source,{LANG_TO_SOURCE[os.path.basename(lang)]}"
+                )
+                relative_path = lang_item.relative_to(lang_root)
+                actual_content = rule_dir.joinpath(lang, relative_path).read_text()
+                assert actual_content == expected_content
+                if lang_item.suffix == ".adoc":
+                    assert "source,text" not in actual_content
+                    assert LANG_TO_SOURCE[os.path.basename(lang)] in actual_content
 
 
-def test_create_new_single_lang_rule_branch(rule_creator: RuleCreator, mock_git_rspec_repo: Repo):
-  '''Test create_new_rule_branch for a single-language rule.'''
-  rule_number = rule_creator.rspec_repo.reserve_rule_number()
+def test_create_new_single_lang_rule_branch(
+    rule_creator: RuleCreator, mock_git_rspec_repo: Repo
+):
+    """Test create_new_rule_branch for a single-language rule."""
+    rule_number = rule_creator.rspec_repo.reserve_rule_number()
 
-  languages = ['cfamily']
-  branch = rule_creator.create_new_rule_branch(rule_number, languages)
+    languages = ["cfamily"]
+    branch = rule_creator.create_new_rule_branch(rule_number, languages)
 
-  # Check that the branch was pushed successfully to the origin
-  mock_git_rspec_repo.git.checkout(branch)
-  rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert rule_dir.exists()
+    # Check that the branch was pushed successfully to the origin
+    mock_git_rspec_repo.git.checkout(branch)
+    rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert rule_dir.exists()
 
-  common_root = rule_creator.TEMPLATE_PATH.joinpath('single_language', 'common')
-  for common_item in common_root.glob('**/*'):
-    if common_item.is_file():
-      expected_content = common_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-      relative_path = common_item.relative_to(common_root)
-      actual_content = rule_dir.joinpath(relative_path).read_text()
-      assert actual_content == expected_content
+    common_root = rule_creator.TEMPLATE_PATH.joinpath("single_language", "common")
+    for common_item in common_root.glob("**/*"):
+        if common_item.is_file():
+            expected_content = common_item.read_text().replace(
+                "${RSPEC_ID}", str(rule_number)
+            )
+            relative_path = common_item.relative_to(common_root)
+            actual_content = rule_dir.joinpath(relative_path).read_text()
+            assert actual_content == expected_content
 
-  lang_root = rule_creator.TEMPLATE_PATH.joinpath('single_language', 'language_specific')
-  for lang in languages:
-    for lang_item in lang_root.glob('**/*'):
-      if lang_item.is_file():
-        expected_content = lang_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-        dir_name = os.path.basename(lang)
-        expected_content = expected_content.replace('[source,text', f'[source,{LANG_TO_SOURCE[dir_name]}')
-        relative_path = lang_item.relative_to(lang_root)
-        actual_content = rule_dir.joinpath(lang, relative_path).read_text()
-        assert actual_content == expected_content
-        if lang_item.suffix == '.adoc':
-          assert 'source,text' not in actual_content
-          assert LANG_TO_SOURCE[dir_name] in actual_content
+    lang_root = rule_creator.TEMPLATE_PATH.joinpath(
+        "single_language", "language_specific"
+    )
+    for lang in languages:
+        for lang_item in lang_root.glob("**/*"):
+            if lang_item.is_file():
+                expected_content = lang_item.read_text().replace(
+                    "${RSPEC_ID}", str(rule_number)
+                )
+                dir_name = os.path.basename(lang)
+                expected_content = expected_content.replace(
+                    "[source,text", f"[source,{LANG_TO_SOURCE[dir_name]}"
+                )
+                relative_path = lang_item.relative_to(lang_root)
+                actual_content = rule_dir.joinpath(lang, relative_path).read_text()
+                assert actual_content == expected_content
+                if lang_item.suffix == ".adoc":
+                    assert "source,text" not in actual_content
+                    assert LANG_TO_SOURCE[dir_name] in actual_content
 
 
 def test_create_new_rule_pull_request(rule_creator: RuleCreator):
-  '''Test create_new_rule_branch adds the right user and labels.'''
-  rule_number = rule_creator.rspec_repo.reserve_rule_number()
-  languages = ['cfamily']
+    """Test create_new_rule_branch adds the right user and labels."""
+    rule_number = rule_creator.rspec_repo.reserve_rule_number()
+    languages = ["cfamily"]
 
-  with mock_github() as (token, user, mock_repo):
-    rule_creator.create_new_rule_pull_request(token, rule_number, languages, ['mylab', 'other-lab'], user)
+    with mock_github() as (token, user, mock_repo):
+        rule_creator.create_new_rule_pull_request(
+            token, rule_number, languages, ["mylab", "other-lab"], user
+        )
 
-    mock_repo.create_pull.assert_called_once();
-    assert mock_repo.create_pull.call_args.kwargs['title'].startswith('Create rule S')
-    mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user);
-    mock_repo.create_pull.return_value.add_to_labels.assert_called_with('mylab', 'other-lab');
+        mock_repo.create_pull.assert_called_once()
+        assert mock_repo.create_pull.call_args.kwargs["title"].startswith(
+            "Create rule S"
+        )
+        mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user)
+        mock_repo.create_pull.return_value.add_to_labels.assert_called_with(
+            "mylab", "other-lab"
+        )
 
 
-@patch('rspec_tools.create_rule.tmp_rspec_repo')
-@patch('rspec_tools.create_rule.RuleCreator')
+@patch("rspec_tools.create_rule.tmp_rspec_repo")
+@patch("rspec_tools.create_rule.RuleCreator")
 def test_create_new_rule(mockRuleCreator, mock_tmp_rspec_repo):
-  prMock = mockRuleCreator.return_value.create_new_rule_pull_request
-  create_new_rule('cfamily,php', 'my token', 'testuser')
-  prMock.assert_called_once()
-  assert set(prMock.call_args.args[2]) == set(['cfamily', 'php'])
-  assert set(prMock.call_args.args[3]) == set(['cfamily', 'php'])
+    prMock = mockRuleCreator.return_value.create_new_rule_pull_request
+    create_new_rule("cfamily,php", "my token", "testuser")
+    prMock.assert_called_once()
+    assert set(prMock.call_args.args[2]) == set(["cfamily", "php"])
+    assert set(prMock.call_args.args[3]) == set(["cfamily", "php"])
 
 
-@patch('rspec_tools.create_rule.RuleCreator')
+@patch("rspec_tools.create_rule.RuleCreator")
 def test_create_new_rule_unsupported_language(mockRuleCreator):
-  with pytest.raises(InvalidArgumentError):
-    create_new_rule('russian,php', 'my token', 'testuser')
+    with pytest.raises(InvalidArgumentError):
+        create_new_rule("russian,php", "my token", "testuser")
 
 
-def test_add_lang_singlelang_nonconventional_rule_create_branch(rule_creator: RuleCreator, mock_git_rspec_repo: Repo):
-  '''Test add_language_branch for a single-language rule with metadata lifted to the generic rule level.'''
-  rule_number = 4727
-  language = 'php'
+def test_add_lang_singlelang_nonconventional_rule_create_branch(
+    rule_creator: RuleCreator, mock_git_rspec_repo: Repo
+):
+    """Test add_language_branch for a single-language rule with metadata lifted to the generic rule level."""
+    rule_number = 4727
+    language = "php"
 
-  mock_git_rspec_repo.git.checkout('master')
-  orig_rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert(not is_empty_metadata(orig_rule_dir)) # nonconventional: singlelang rule with metadata on the upper level
-  assert(is_empty_metadata(orig_rule_dir.joinpath('cobol')))
-  original_metadata = orig_rule_dir.joinpath('metadata.json').read_text()
+    mock_git_rspec_repo.git.checkout("master")
+    orig_rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert not is_empty_metadata(
+        orig_rule_dir
+    )  # nonconventional: singlelang rule with metadata on the upper level
+    assert is_empty_metadata(orig_rule_dir.joinpath("cobol"))
+    original_metadata = orig_rule_dir.joinpath("metadata.json").read_text()
 
-  branch = rule_creator.add_language_branch(rule_number, language)
+    branch = rule_creator.add_language_branch(rule_number, language)
 
-  # Check that the branch was pushed successfully to the origin
-  mock_git_rspec_repo.git.checkout(branch)
-  rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert rule_dir.exists()
-  lang_dir = rule_dir.joinpath(f'{language}')
-  assert lang_dir.exists()
+    # Check that the branch was pushed successfully to the origin
+    mock_git_rspec_repo.git.checkout(branch)
+    rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert rule_dir.exists()
+    lang_dir = rule_dir.joinpath(f"{language}")
+    assert lang_dir.exists()
 
-  assert rule_dir.joinpath('metadata.json').read_text() == original_metadata
-  assert(is_empty_metadata(rule_dir.joinpath('cobol')))
+    assert rule_dir.joinpath("metadata.json").read_text() == original_metadata
+    assert is_empty_metadata(rule_dir.joinpath("cobol"))
 
-  lang_root = rule_creator.TEMPLATE_PATH.joinpath('multi_language', 'language_specific')
-  for lang_item in lang_root.glob('**/*'):
-    if lang_item.is_file():
-      expected_content = lang_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-      expected_content = expected_content.replace('[source,text', f'[source,{LANG_TO_SOURCE[language]}')
-      relative_path = lang_item.relative_to(lang_root)
-      actual_content = rule_dir.joinpath(language, relative_path).read_text()
-      assert actual_content == expected_content
-      if lang_item.suffix == '.adoc':
-        assert 'source,text' not in actual_content
-        assert LANG_TO_SOURCE[language] in actual_content
-
-
-def test_add_lang_singlelang_conventional_rule_create_branch(rule_creator: RuleCreator, mock_git_rspec_repo: Repo):
-  '''Test add_language_branch for a regular single language rule.'''
-  rule_number = 1033
-  language = 'php'
-
-  mock_git_rspec_repo.git.checkout('master')
-  orig_rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert(is_empty_metadata(orig_rule_dir)) # conventional: singlelang rule with metadata on the lang-specific level
-  assert(not is_empty_metadata(orig_rule_dir.joinpath('cfamily')))
-  original_lmetadata = orig_rule_dir.joinpath('cfamily', 'metadata.json').read_text()
-
-  branch = rule_creator.add_language_branch(rule_number, language)
-
-  # Check that the branch was pushed successfully to the origin
-  mock_git_rspec_repo.git.checkout(branch)
-  rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert rule_dir.exists()
-  lang_dir = rule_dir.joinpath(f'{language}')
-  assert lang_dir.exists()
-
-  assert rule_dir.joinpath('metadata.json').read_text() == original_lmetadata
-  assert(is_empty_metadata(rule_dir.joinpath('cfamily')))
+    lang_root = rule_creator.TEMPLATE_PATH.joinpath(
+        "multi_language", "language_specific"
+    )
+    for lang_item in lang_root.glob("**/*"):
+        if lang_item.is_file():
+            expected_content = lang_item.read_text().replace(
+                "${RSPEC_ID}", str(rule_number)
+            )
+            expected_content = expected_content.replace(
+                "[source,text", f"[source,{LANG_TO_SOURCE[language]}"
+            )
+            relative_path = lang_item.relative_to(lang_root)
+            actual_content = rule_dir.joinpath(language, relative_path).read_text()
+            assert actual_content == expected_content
+            if lang_item.suffix == ".adoc":
+                assert "source,text" not in actual_content
+                assert LANG_TO_SOURCE[language] in actual_content
 
 
-def test_add_lang_multilang_rule_create_branch(rule_creator: RuleCreator, mock_git_rspec_repo: Repo):
-  '''Test add_language_branch for a multi-language rule.'''
-  rule_number = 120
-  language = 'php'
+def test_add_lang_singlelang_conventional_rule_create_branch(
+    rule_creator: RuleCreator, mock_git_rspec_repo: Repo
+):
+    """Test add_language_branch for a regular single language rule."""
+    rule_number = 1033
+    language = "php"
 
-  branch = rule_creator.add_language_branch(rule_number, language)
+    mock_git_rspec_repo.git.checkout("master")
+    orig_rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert is_empty_metadata(
+        orig_rule_dir
+    )  # conventional: singlelang rule with metadata on the lang-specific level
+    assert not is_empty_metadata(orig_rule_dir.joinpath("cfamily"))
+    original_lmetadata = orig_rule_dir.joinpath("cfamily", "metadata.json").read_text()
 
-  # Check that the branch was pushed successfully to the origin
-  mock_git_rspec_repo.git.checkout(branch)
-  rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath('rules', f'S{rule_number}')
-  assert rule_dir.exists()
-  lang_dir = rule_dir.joinpath(f'{language}')
-  assert lang_dir.exists()
+    branch = rule_creator.add_language_branch(rule_number, language)
 
-  lang_root = rule_creator.TEMPLATE_PATH.joinpath('multi_language', 'language_specific')
-  for lang_item in lang_root.glob('**/*'):
-    if lang_item.is_file():
-      expected_content = lang_item.read_text().replace('${RSPEC_ID}', str(rule_number))
-      expected_content = expected_content.replace('[source,text', f'[source,{LANG_TO_SOURCE[language]}')
-      relative_path = lang_item.relative_to(lang_root)
-      actual_content = rule_dir.joinpath(language, relative_path).read_text()
-      assert actual_content == expected_content
-      if lang_item.suffix == '.adoc':
-        assert 'source,text' not in actual_content
-        assert LANG_TO_SOURCE[language] in actual_content
+    # Check that the branch was pushed successfully to the origin
+    mock_git_rspec_repo.git.checkout(branch)
+    rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert rule_dir.exists()
+    lang_dir = rule_dir.joinpath(f"{language}")
+    assert lang_dir.exists()
+
+    assert rule_dir.joinpath("metadata.json").read_text() == original_lmetadata
+    assert is_empty_metadata(rule_dir.joinpath("cfamily"))
 
 
-@patch('rspec_tools.create_rule.RuleCreator')
+def test_add_lang_multilang_rule_create_branch(
+    rule_creator: RuleCreator, mock_git_rspec_repo: Repo
+):
+    """Test add_language_branch for a multi-language rule."""
+    rule_number = 120
+    language = "php"
+
+    branch = rule_creator.add_language_branch(rule_number, language)
+
+    # Check that the branch was pushed successfully to the origin
+    mock_git_rspec_repo.git.checkout(branch)
+    rule_dir = Path(mock_git_rspec_repo.working_dir).joinpath(
+        "rules", f"S{rule_number}"
+    )
+    assert rule_dir.exists()
+    lang_dir = rule_dir.joinpath(f"{language}")
+    assert lang_dir.exists()
+
+    lang_root = rule_creator.TEMPLATE_PATH.joinpath(
+        "multi_language", "language_specific"
+    )
+    for lang_item in lang_root.glob("**/*"):
+        if lang_item.is_file():
+            expected_content = lang_item.read_text().replace(
+                "${RSPEC_ID}", str(rule_number)
+            )
+            expected_content = expected_content.replace(
+                "[source,text", f"[source,{LANG_TO_SOURCE[language]}"
+            )
+            relative_path = lang_item.relative_to(lang_root)
+            actual_content = rule_dir.joinpath(language, relative_path).read_text()
+            assert actual_content == expected_content
+            if lang_item.suffix == ".adoc":
+                assert "source,text" not in actual_content
+                assert LANG_TO_SOURCE[language] in actual_content
+
+
+@patch("rspec_tools.create_rule.RuleCreator")
 def test_add_unsupported_language(mock):
-  '''Test language validation.'''
-  with pytest.raises(InvalidArgumentError):
-    add_language_to_rule('russian', 'S1033', 'my token', 'testuser')
-  mock.return_value.add_language_pull_request.assert_not_called()
+    """Test language validation."""
+    with pytest.raises(InvalidArgumentError):
+        add_language_to_rule("russian", "S1033", "my token", "testuser")
+    mock.return_value.add_language_pull_request.assert_not_called()
 
 
-@patch('rspec_tools.create_rule.tmp_rspec_repo')
-@patch('rspec_tools.create_rule.RuleCreator')
+@patch("rspec_tools.create_rule.tmp_rspec_repo")
+@patch("rspec_tools.create_rule.RuleCreator")
 def test_add_supported_language(mock, mock_tmp_rspec_repo):
-  '''Test language validation.'''
-  add_language_to_rule('cfamily', 'S1033', 'my token', 'testuser')
-  mock.return_value.add_language_pull_request.assert_called_once()
+    """Test language validation."""
+    add_language_to_rule("cfamily", "S1033", "my token", "testuser")
+    mock.return_value.add_language_pull_request.assert_called_once()
 
 
 def test_add_language_the_rule_is_already_defined_for(rule_creator: RuleCreator):
-  '''Test add_language_branch fails when trying to add a langage already added to the rule.'''
-  with pytest.raises(InvalidArgumentError):
-    rule_creator.add_language_branch(100, 'cfamily')
+    """Test add_language_branch fails when trying to add a langage already added to the rule."""
+    with pytest.raises(InvalidArgumentError):
+        rule_creator.add_language_branch(100, "cfamily")
 
 
 def test_add_language_to_nonexistent_rule(rule_creator: RuleCreator):
-  '''Test add_language_branch correctly fails when invoked for a non-existent rule.'''
-  with pytest.raises(InvalidArgumentError):
-    rule_creator.add_language_branch(105, 'cfamily')
+    """Test add_language_branch correctly fails when invoked for a non-existent rule."""
+    with pytest.raises(InvalidArgumentError):
+        rule_creator.add_language_branch(105, "cfamily")
 
 
 def test_add_language_new_pull_request(rule_creator: RuleCreator):
-  '''Test add_language_pull_request adds the right user and labels.'''
-  rule_number = 120
-  language = 'php'
+    """Test add_language_pull_request adds the right user and labels."""
+    rule_number = 120
+    language = "php"
 
-  with mock_github() as (token, user, mock_repo):
-    rule_creator.add_language_pull_request(token, rule_number, language, 'mylab', user)
+    with mock_github() as (token, user, mock_repo):
+        rule_creator.add_language_pull_request(
+            token, rule_number, language, "mylab", user
+        )
 
-    mock_repo.create_pull.assert_called_once();
-    assert mock_repo.create_pull.call_args.kwargs['title'].startswith(f'Create rule S{rule_number}')
-    assert mock_repo.create_pull.call_args.kwargs['head'].startswith('rule/')
-    mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user)
-    mock_repo.create_pull.return_value.add_to_labels.assert_called_with('mylab')
+        mock_repo.create_pull.assert_called_once()
+        assert mock_repo.create_pull.call_args.kwargs["title"].startswith(
+            f"Create rule S{rule_number}"
+        )
+        assert mock_repo.create_pull.call_args.kwargs["head"].startswith("rule/")
+        mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user)
+        mock_repo.create_pull.return_value.add_to_labels.assert_called_with("mylab")

--- a/rspec-tools/tests/test_modify_rule.py
+++ b/rspec-tools/tests/test_modify_rule.py
@@ -13,111 +13,145 @@ from tests.conftest import mock_github
 
 @pytest.fixture
 def rule_editor(rspec_repo: RspecRepo):
-  return RuleEditor(rspec_repo)
+    return RuleEditor(rspec_repo)
 
 
-def test_update_quickfix_status_branch1(rule_editor: RuleEditor, mock_git_rspec_repo: Repo):
-  '''Test update_quickfix_status_branch when quickfix field is not present in language-specific metadata'''
-  rule_number = 100
-  language = 'cfamily'
+def test_update_quickfix_status_branch1(
+    rule_editor: RuleEditor, mock_git_rspec_repo: Repo
+):
+    """Test update_quickfix_status_branch when quickfix field is not present in language-specific metadata"""
+    rule_number = 100
+    language = "cfamily"
 
-  sub_path = Path('rules', f'S{rule_number}', language, 'metadata.json')
-  metadata_path = Path(mock_git_rspec_repo.working_dir) / sub_path
-  mock_git_rspec_repo.git.checkout('master')
-  initial_metadata = json.loads(metadata_path.read_text())
-  assert 'quickfix' not in initial_metadata # It is in the parent metadata.json file.
+    sub_path = Path("rules", f"S{rule_number}", language, "metadata.json")
+    metadata_path = Path(mock_git_rspec_repo.working_dir) / sub_path
+    mock_git_rspec_repo.git.checkout("master")
+    initial_metadata = json.loads(metadata_path.read_text())
+    assert "quickfix" not in initial_metadata  # It is in the parent metadata.json file.
 
-  branch = rule_editor.update_quickfix_status_branch('Some title', rule_number, language, 'covered')
-  mock_git_rspec_repo.git.checkout(branch)
-  new_metadata = json.loads(metadata_path.read_text())
+    branch = rule_editor.update_quickfix_status_branch(
+        "Some title", rule_number, language, "covered"
+    )
+    mock_git_rspec_repo.git.checkout(branch)
+    new_metadata = json.loads(metadata_path.read_text())
 
-  # Verify that only the quickfix status is introduced.
-  assert len(initial_metadata.keys()) + 1 == len(new_metadata.keys())
-  assert 'quickfix' in new_metadata
-  assert 'covered' == new_metadata['quickfix']
-  for key in initial_metadata:
-    assert initial_metadata[key] == new_metadata[key]
+    # Verify that only the quickfix status is introduced.
+    assert len(initial_metadata.keys()) + 1 == len(new_metadata.keys())
+    assert "quickfix" in new_metadata
+    assert "covered" == new_metadata["quickfix"]
+    for key in initial_metadata:
+        assert initial_metadata[key] == new_metadata[key]
 
-  # Ensure only one file is modified.
-  modified_files = mock_git_rspec_repo.git.diff('master', '--name-only').strip()
-  assert Path(modified_files) == sub_path
-
-
-def test_update_quickfix_status_branch2(rule_editor: RuleEditor, mock_git_rspec_repo: Repo):
-  '''Test update_quickfix_status_branch when quickfix field is already present in language-specific metadata'''
-  rule_number = 100
-  language = 'java'
-
-  sub_path = Path('rules', f'S{rule_number}', language, 'metadata.json')
-  metadata_path = Path(mock_git_rspec_repo.working_dir) / sub_path
-  mock_git_rspec_repo.git.checkout('master')
-  initial_metadata = json.loads(metadata_path.read_text())
-  assert 'quickfix' in initial_metadata
-  assert initial_metadata['quickfix'] == 'targeted'
-
-  branch = rule_editor.update_quickfix_status_branch('Some title', rule_number, language, 'covered')
-  mock_git_rspec_repo.git.checkout(branch)
-  new_metadata = json.loads(metadata_path.read_text())
-
-  # Verify that only the quickfix status is updated.
-  assert len(initial_metadata.keys()) == len(new_metadata.keys())
-  assert 'quickfix' in new_metadata
-  assert 'covered' == new_metadata['quickfix']
-  for key in initial_metadata:
-    if key != 'quickfix':
-      assert initial_metadata[key] == new_metadata[key]
-
-  # Ensure only one file is modified.
-  modified_files = mock_git_rspec_repo.git.diff('master', '--name-only').strip()
-  assert Path(modified_files) == sub_path
+    # Ensure only one file is modified.
+    modified_files = mock_git_rspec_repo.git.diff("master", "--name-only").strip()
+    assert Path(modified_files) == sub_path
 
 
-def test_update_quickfix_status_branch3(rule_editor: RuleEditor, mock_git_rspec_repo: Repo):
-  '''Test update_quickfix_status_branch when new and old quickfix status are the same'''
-  rule_number = 100
-  language = 'java'
+def test_update_quickfix_status_branch2(
+    rule_editor: RuleEditor, mock_git_rspec_repo: Repo
+):
+    """Test update_quickfix_status_branch when quickfix field is already present in language-specific metadata"""
+    rule_number = 100
+    language = "java"
 
-  metadata_path = Path(mock_git_rspec_repo.working_dir, 'rules', f'S{rule_number}', language, 'metadata.json')
-  mock_git_rspec_repo.git.checkout('master')
-  initial_metadata = json.loads(metadata_path.read_text())
-  assert 'quickfix' in initial_metadata
-  assert initial_metadata['quickfix'] == 'targeted'
+    sub_path = Path("rules", f"S{rule_number}", language, "metadata.json")
+    metadata_path = Path(mock_git_rspec_repo.working_dir) / sub_path
+    mock_git_rspec_repo.git.checkout("master")
+    initial_metadata = json.loads(metadata_path.read_text())
+    assert "quickfix" in initial_metadata
+    assert initial_metadata["quickfix"] == "targeted"
 
-  with pytest.raises(InvalidArgumentError):
-    rule_editor.update_quickfix_status_branch('Some title', rule_number, language, 'targeted')
+    branch = rule_editor.update_quickfix_status_branch(
+        "Some title", rule_number, language, "covered"
+    )
+    mock_git_rspec_repo.git.checkout(branch)
+    new_metadata = json.loads(metadata_path.read_text())
+
+    # Verify that only the quickfix status is updated.
+    assert len(initial_metadata.keys()) == len(new_metadata.keys())
+    assert "quickfix" in new_metadata
+    assert "covered" == new_metadata["quickfix"]
+    for key in initial_metadata:
+        if key != "quickfix":
+            assert initial_metadata[key] == new_metadata[key]
+
+    # Ensure only one file is modified.
+    modified_files = mock_git_rspec_repo.git.diff("master", "--name-only").strip()
+    assert Path(modified_files) == sub_path
 
 
-def test_update_quickfix_status_branch4(rule_editor: RuleEditor, mock_git_rspec_repo: Repo):
-  '''Test update_quickfix_status_branch when the rule does not exist'''
-  rule_number = 404
-  language = 'java'
+def test_update_quickfix_status_branch3(
+    rule_editor: RuleEditor, mock_git_rspec_repo: Repo
+):
+    """Test update_quickfix_status_branch when new and old quickfix status are the same"""
+    rule_number = 100
+    language = "java"
 
-  metadata_path = Path(mock_git_rspec_repo.working_dir, 'rules', f'S{rule_number}', language, 'metadata.json')
-  mock_git_rspec_repo.git.checkout('master')
-  assert not metadata_path.exists()
+    metadata_path = Path(
+        mock_git_rspec_repo.working_dir,
+        "rules",
+        f"S{rule_number}",
+        language,
+        "metadata.json",
+    )
+    mock_git_rspec_repo.git.checkout("master")
+    initial_metadata = json.loads(metadata_path.read_text())
+    assert "quickfix" in initial_metadata
+    assert initial_metadata["quickfix"] == "targeted"
 
-  with pytest.raises(InvalidArgumentError):
-    rule_editor.update_quickfix_status_branch('Some title', rule_number, language, 'targeted')
+    with pytest.raises(InvalidArgumentError):
+        rule_editor.update_quickfix_status_branch(
+            "Some title", rule_number, language, "targeted"
+        )
+
+
+def test_update_quickfix_status_branch4(
+    rule_editor: RuleEditor, mock_git_rspec_repo: Repo
+):
+    """Test update_quickfix_status_branch when the rule does not exist"""
+    rule_number = 404
+    language = "java"
+
+    metadata_path = Path(
+        mock_git_rspec_repo.working_dir,
+        "rules",
+        f"S{rule_number}",
+        language,
+        "metadata.json",
+    )
+    mock_git_rspec_repo.git.checkout("master")
+    assert not metadata_path.exists()
+
+    with pytest.raises(InvalidArgumentError):
+        rule_editor.update_quickfix_status_branch(
+            "Some title", rule_number, language, "targeted"
+        )
 
 
 def test_update_quickfix_status_pull_request(rule_editor: RuleEditor):
-  '''Test update_quickfix_status_pull_request adds the right user and label.'''
-  with mock_github() as (token, user, mock_repo):
-    rule_editor.update_quickfix_status_pull_request(token, 100, 'cfamily', 'covered', 'label-fraicheur', user)
-    mock_repo.create_pull.assert_called_once();
-    assert mock_repo.create_pull.call_args.kwargs['title'].startswith('Modify rule S100')
-    mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user)
-    mock_repo.create_pull.return_value.add_to_labels.assert_called_with('label-fraicheur')
+    """Test update_quickfix_status_pull_request adds the right user and label."""
+    with mock_github() as (token, user, mock_repo):
+        rule_editor.update_quickfix_status_pull_request(
+            token, 100, "cfamily", "covered", "label-fraicheur", user
+        )
+        mock_repo.create_pull.assert_called_once()
+        assert mock_repo.create_pull.call_args.kwargs["title"].startswith(
+            "Modify rule S100"
+        )
+        mock_repo.create_pull.return_value.add_to_assignees.assert_called_with(user)
+        mock_repo.create_pull.return_value.add_to_labels.assert_called_with(
+            "label-fraicheur"
+        )
 
 
-@patch('rspec_tools.modify_rule.tmp_rspec_repo')
-@patch('rspec_tools.modify_rule.RuleEditor')
+@patch("rspec_tools.modify_rule.tmp_rspec_repo")
+@patch("rspec_tools.modify_rule.RuleEditor")
 def test_update_rule_quickfix_status(mockRuleEditor, mock_tmp_rspec_repo):
-  '''Test update_rule_quickfix_status uses the expected implementation.'''
-  prMock = mockRuleEditor.return_value.update_quickfix_status_pull_request
-  update_rule_quickfix_status('cfamily', 'S100', 'covered', 'my token', 'testuser')
-  prMock.assert_called_once()
-  assert prMock.call_args.args[1] == 100
-  assert prMock.call_args.args[2] == 'cfamily'
-  assert prMock.call_args.args[3] == 'covered'
-  assert prMock.call_args.args[4] == 'cfamily'
+    """Test update_rule_quickfix_status uses the expected implementation."""
+    prMock = mockRuleEditor.return_value.update_quickfix_status_pull_request
+    update_rule_quickfix_status("cfamily", "S100", "covered", "my token", "testuser")
+    prMock.assert_called_once()
+    assert prMock.call_args.args[1] == 100
+    assert prMock.call_args.args[2] == "cfamily"
+    assert prMock.call_args.args[3] == "covered"
+    assert prMock.call_args.args[4] == "cfamily"

--- a/rspec-tools/tests/test_repo.py
+++ b/rspec-tools/tests/test_repo.py
@@ -6,28 +6,34 @@ from rspec_tools.repo import RspecRepo
 
 
 def _read_counter_file(repo: Repo):
-  '''Reads the counter file from the provided repository and returns its content.'''
-  repo.git.checkout(RspecRepo.ID_COUNTER_BRANCH)
-  counter_path = Path(repo.working_dir, RspecRepo.ID_COUNTER_FILENAME)
-  return counter_path.read_text()
+    """Reads the counter file from the provided repository and returns its content."""
+    repo.git.checkout(RspecRepo.ID_COUNTER_BRANCH)
+    counter_path = Path(repo.working_dir, RspecRepo.ID_COUNTER_FILENAME)
+    return counter_path.read_text()
 
 
 def test_reserve_rule_number_simple(rspec_repo: RspecRepo, mock_git_rspec_repo: Repo):
-  '''Test that RspecRepo.reserve_rule_number() increments the id and returns the old value.'''
-  assert rspec_repo.reserve_rule_number() == 0
+    """Test that RspecRepo.reserve_rule_number() increments the id and returns the old value."""
+    assert rspec_repo.reserve_rule_number() == 0
 
-  assert _read_counter_file(mock_git_rspec_repo) == '1'
+    assert _read_counter_file(mock_git_rspec_repo) == "1"
 
 
-def test_reserve_rule_number_parallel_reservations(tmpdir, mock_git_rspec_repo: Repo, git_config):
-  '''Test that RspecRepo.reserve_rule_number() works when multiple reservations are done in parallel.'''
-  cloned_repo1 = tmpdir.mkdir("cloned_repo1")
-  rule_creator1 = RspecRepo(mock_git_rspec_repo.working_dir, str(cloned_repo1), git_config)
-  cloned_repo2 = tmpdir.mkdir("cloned_repo2")
-  rule_creator2 = RspecRepo(mock_git_rspec_repo.working_dir, str(cloned_repo2), git_config)
+def test_reserve_rule_number_parallel_reservations(
+    tmpdir, mock_git_rspec_repo: Repo, git_config
+):
+    """Test that RspecRepo.reserve_rule_number() works when multiple reservations are done in parallel."""
+    cloned_repo1 = tmpdir.mkdir("cloned_repo1")
+    rule_creator1 = RspecRepo(
+        mock_git_rspec_repo.working_dir, str(cloned_repo1), git_config
+    )
+    cloned_repo2 = tmpdir.mkdir("cloned_repo2")
+    rule_creator2 = RspecRepo(
+        mock_git_rspec_repo.working_dir, str(cloned_repo2), git_config
+    )
 
-  assert rule_creator1.reserve_rule_number() == 0
-  assert rule_creator2.reserve_rule_number() == 1
-  assert rule_creator1.reserve_rule_number() == 2
+    assert rule_creator1.reserve_rule_number() == 0
+    assert rule_creator2.reserve_rule_number() == 1
+    assert rule_creator1.reserve_rule_number() == 2
 
-  assert _read_counter_file(mock_git_rspec_repo) == '3'
+    assert _read_counter_file(mock_git_rspec_repo) == "3"

--- a/rspec-tools/tests/test_rules_repository.py
+++ b/rspec-tools/tests/test_rules_repository.py
@@ -1,37 +1,43 @@
-from pathlib import Path
 import os
+from pathlib import Path
+
 import pytest
-from rspec_tools.rules import RulesRepository
 from rspec_tools.errors import RuleNotFoundError
+from rspec_tools.rules import RulesRepository
+
 
 def test_list_rules(mockrules: Path):
-  '''Check that rules are all listed.'''
-  rules = {rule.id for rule in RulesRepository(rules_path=mockrules).rules}
-  assert rules == {'S100', 'S101', 'S120', 'S200', 'S4727', 'S1033'}
+    """Check that rules are all listed."""
+    rules = {rule.id for rule in RulesRepository(rules_path=mockrules).rules}
+    assert rules == {"S100", "S101", "S120", "S200", "S4727", "S1033"}
 
 
 def test_list_languages(mockrules: Path):
-  '''Check that languages are all listed.'''
-  rule = RulesRepository(rules_path=mockrules).get_rule('S120')
+    """Check that languages are all listed."""
+    rule = RulesRepository(rules_path=mockrules).get_rule("S120")
 
-  languages = {lang.language for lang in rule.specializations}
-  assert languages == {'flex', 'java', 'plsql'}
+    languages = {lang.language for lang in rule.specializations}
+    assert languages == {"flex", "java", "plsql"}
 
-  rulePath = os.path.join(mockrules, 'S120')
-  ruleSubDirs = [subDir for subDir in os.listdir(rulePath) if os.path.isdir(os.path.join(rulePath, subDir))]
-  assert sorted(ruleSubDirs) == ['common', 'flex', 'java', 'plsql']
+    rulePath = os.path.join(mockrules, "S120")
+    ruleSubDirs = [
+        subDir
+        for subDir in os.listdir(rulePath)
+        if os.path.isdir(os.path.join(rulePath, subDir))
+    ]
+    assert sorted(ruleSubDirs) == ["common", "flex", "java", "plsql"]
 
 
 def test_get_metadata(mockrules: Path):
-  '''Check that language metadata are correctly overriden.'''
-  rule = RulesRepository(rules_path=mockrules).get_rule('S120')
-  plsql = rule.get_language('plsql')
-  assert plsql.metadata['sqKey'] == 'PlSql.PackageNaming'
-  java = rule.get_language('java')
-  assert java.metadata['sqKey'] == 'S120'
+    """Check that language metadata are correctly overriden."""
+    rule = RulesRepository(rules_path=mockrules).get_rule("S120")
+    plsql = rule.get_language("plsql")
+    assert plsql.metadata["sqKey"] == "PlSql.PackageNaming"
+    java = rule.get_language("java")
+    assert java.metadata["sqKey"] == "S120"
 
 
 def test_nonexisting_rule(mockrules: Path):
-  '''Check that a nonexisting rule is reported.'''
-  with pytest.raises(RuleNotFoundError, match=fr'^Cannot find rule S299'):
-    RulesRepository(rules_path=mockrules).get_rule('S299')
+    """Check that a nonexisting rule is reported."""
+    with pytest.raises(RuleNotFoundError, match=rf"^Cannot find rule S299"):
+        RulesRepository(rules_path=mockrules).get_rule("S299")

--- a/rspec-tools/tests/test_utils.py
+++ b/rspec-tools/tests/test_utils.py
@@ -1,60 +1,71 @@
 import pytest
 from rspec_tools.errors import InvalidArgumentError
-from rspec_tools.utils import (get_label_for_language,
-                               get_labels_for_languages, get_mapped_languages,
-                               load_valid_languages,
-                               parse_and_validate_language_list, resolve_rule)
+from rspec_tools.utils import (
+    get_label_for_language,
+    get_labels_for_languages,
+    get_mapped_languages,
+    load_valid_languages,
+    parse_and_validate_language_list,
+    resolve_rule,
+)
 
 
 def test_fails_when_no_languages_listed():
-  '''Test that language validation fails on empty list.'''
-  with pytest.raises(InvalidArgumentError):
-      parse_and_validate_language_list('')
-  with pytest.raises(InvalidArgumentError):
-      parse_and_validate_language_list('     ')
+    """Test that language validation fails on empty list."""
+    with pytest.raises(InvalidArgumentError):
+        parse_and_validate_language_list("")
+    with pytest.raises(InvalidArgumentError):
+        parse_and_validate_language_list("     ")
+
 
 def test_fails_for_non_language():
-  '''Test that language validation fails on unexpected langauge.'''
-  with pytest.raises(InvalidArgumentError):
-    parse_and_validate_language_list('abracadabra')
-  with pytest.raises(InvalidArgumentError):
-    parse_and_validate_language_list('java,abra,cadabra')
+    """Test that language validation fails on unexpected langauge."""
+    with pytest.raises(InvalidArgumentError):
+        parse_and_validate_language_list("abracadabra")
+    with pytest.raises(InvalidArgumentError):
+        parse_and_validate_language_list("java,abra,cadabra")
+
 
 def test_parses_the_language_list():
-  lang_list = ['php', 'javascript', 'cfamily']
-  lang_str = '  php,javascript, cfamily'
-  assert parse_and_validate_language_list(lang_str) == lang_list
+    lang_list = ["php", "javascript", "cfamily"]
+    lang_str = "  php,javascript, cfamily"
+    assert parse_and_validate_language_list(lang_str) == lang_list
+
 
 def test_valid_languages_contains_java():
-  assert 'java' in load_valid_languages()
+    assert "java" in load_valid_languages()
+
 
 def test_valid_and_mapped_languages_equivalent():
-  assert set(get_mapped_languages()) == set(load_valid_languages())
+    assert set(get_mapped_languages()) == set(load_valid_languages())
+
 
 def test_labels_for_languages():
-  lang_list = ['java', 'apex', 'cfamily', 'ruby']
-  labels = ['java', 'slang', 'cfamily']
-  assert set(get_labels_for_languages(lang_list)) == set(labels)
+    lang_list = ["java", "apex", "cfamily", "ruby"]
+    labels = ["java", "slang", "cfamily"]
+    assert set(get_labels_for_languages(lang_list)) == set(labels)
+
 
 def test_resolve_rule():
-  assert resolve_rule('S100') == 100
-  assert resolve_rule('S1234') == 1234
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('S12')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('12')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('SS13')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('RSPEC-1343')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule(' S1343 ')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('SXXXX')
-  with pytest.raises(InvalidArgumentError):
-    resolve_rule('S90000')
+    assert resolve_rule("S100") == 100
+    assert resolve_rule("S1234") == 1234
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("S12")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("12")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("SS13")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("RSPEC-1343")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule(" S1343 ")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("SXXXX")
+    with pytest.raises(InvalidArgumentError):
+        resolve_rule("S90000")
+
 
 def test_label_for_language():
-  assert get_label_for_language('java') == 'java'
-  with pytest.raises(InvalidArgumentError):
-    get_label_for_language('russian')
+    assert get_label_for_language("java") == "java"
+    with pytest.raises(InvalidArgumentError):
+        get_label_for_language("russian")

--- a/rspec-tools/tests/validation/test_description_validation.py
+++ b/rspec-tools/tests/validation/test_description_validation.py
@@ -16,189 +16,299 @@ from rspec_tools.validation.description import (
 
 @pytest.fixture
 def rule_language(mockrules: Path):
-  def _rule_language(rule_id, language):
-    rule = RulesRepository(rules_path=mockrules).get_rule(rule_id)
-    return rule.get_language(language)
-  return _rule_language
+    def _rule_language(rule_id, language):
+        rule = RulesRepository(rules_path=mockrules).get_rule(rule_id)
+        return rule.get_language(language)
+
+    return _rule_language
+
 
 @pytest.fixture
 def invalid_rule(mockinvalidrules: Path):
-  def _invalid_rule(rule_id, language):
-    rule = RulesRepository(rules_path=mockinvalidrules).get_rule(rule_id)
-    return rule.get_language(language)
-  return _invalid_rule
+    def _invalid_rule(rule_id, language):
+        rule = RulesRepository(rules_path=mockinvalidrules).get_rule(rule_id)
+        return rule.get_language(language)
+
+    return _invalid_rule
+
 
 def test_legacy_sections_fails_validation(rule_language):
-  '''Check that description with standard sections are no longer considered valid.'''
-  rule = rule_language('S100', 'cfamily')
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} has an unconventional header "Noncompliant Code Example"'):
-    validate_section_names(rule)
+    """Check that description with standard sections are no longer considered valid."""
+    rule = rule_language("S100", "cfamily")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf'^Rule {rule.id} has an unconventional header "Noncompliant Code Example"',
+    ):
+        validate_section_names(rule)
+
 
 def test_unexpected_section_fails_validation(invalid_rule):
-  rule = invalid_rule('S100', 'cfamily')
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} has an unconventional header "Invalid header"'):
-    validate_section_names(rule)
+    rule = invalid_rule("S100", "cfamily")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf'^Rule {rule.id} has an unconventional header "Invalid header"',
+    ):
+        validate_section_names(rule)
+
 
 def test_sections_with_wrong_level_fails_validation(invalid_rule):
-  rule = invalid_rule('S100', 'php')
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} has some sections misclassified. Ensure there are not too many `=` in the asciidoc file for: How to fix it, Resources'):
-    validate_section_names(rule)
+    rule = invalid_rule("S100", "php")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule.id} has some sections misclassified. Ensure there are not too many `=` in the asciidoc file for: How to fix it, Resources",
+    ):
+        validate_section_names(rule)
+
 
 def test_valid_section_levels_passes_validation(rule_language):
-  '''Check that description with correct formatting is considered valid.'''
-  validate_section_levels(rule_language('S100', 'cfamily'))
+    """Check that description with correct formatting is considered valid."""
+    validate_section_levels(rule_language("S100", "cfamily"))
+
 
 def test_level_0_section_fails_validation(invalid_rule):
-  rule = invalid_rule('S100', 'cfamily')
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} has level-0 header "Invalid header level"'):
-    validate_section_levels(rule)
+    rule = invalid_rule("S100", "cfamily")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf'^Rule {rule.id} has level-0 header "Invalid header level"',
+    ):
+        validate_section_levels(rule)
+
 
 def test_parameters_passes_validation(rule_language):
-  '''Check that correctly formed parameters are considered valid.'''
-  validate_parameters(rule_language('S100', 'cfamily'))
+    """Check that correctly formed parameters are considered valid."""
+    validate_parameters(rule_language("S100", "cfamily"))
+
 
 def test_parameters_fails_validation_missing_block(invalid_rule):
-  '''Check that description with unexpected tag breaks validation.'''
-  rule = invalid_rule('S100', 'cfamily')
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} should use `\*\*\*\*` blocks for each parameter'):
-    validate_parameters(rule)
+    """Check that description with unexpected tag breaks validation."""
+    rule = invalid_rule("S100", "cfamily")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule.id} should use `\*\*\*\*` blocks for each parameter",
+    ):
+        validate_parameters(rule)
+
 
 def test_parameters_fails_validation_missing_title(invalid_rule):
-  rule = invalid_rule('S100', 'csharp')
-  '''Check that parameters without key as title breaks validation.'''
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} should have a parameter name declared with `.name` before the bock, for each parameter'):
-    validate_parameters(rule)
+    rule = invalid_rule("S100", "csharp")
+    """Check that parameters without key as title breaks validation."""
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule.id} should have a parameter name declared with `.name` before the bock, for each parameter",
+    ):
+        validate_parameters(rule)
+
 
 def test_parameters_fails_validation_missing_description(invalid_rule):
-  rule = invalid_rule('S100', 'java')
-  '''Check that parameters without any description break validation.'''
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule.id} should have a description for each parameter'):
-    validate_parameters(rule)
+    rule = invalid_rule("S100", "java")
+    """Check that parameters without any description break validation."""
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule.id} should have a description for each parameter",
+    ):
+        validate_parameters(rule)
+
 
 def test_valid_source_declaration_validation(rule_language):
-  '''Check that declaring a language for sources is considered valid.'''
-  # cpp and text
-  validate_source_language(rule_language('S100', 'cfamily'))
-  # javascript and no source
-  validate_source_language(rule_language('S100', 'csharp'))
+    """Check that declaring a language for sources is considered valid."""
+    # cpp and text
+    validate_source_language(rule_language("S100", "cfamily"))
+    # javascript and no source
+    validate_source_language(rule_language("S100", "csharp"))
+
 
 def test_missing_source_language_fails_validation(invalid_rule):
-  '''Check that forgetting the language for sources breaks validation'''
-  rule = invalid_rule('S100', 'cfamily')
-  with pytest.raises(RuleValidationError, match=re.escape(f'Rule {rule.id} has non highlighted code example in section "Noncompliant Code Example".\nUse [source,cpp] or [source,text] before the opening \'----\'.')):
-    validate_source_language(rule)
+    """Check that forgetting the language for sources breaks validation"""
+    rule = invalid_rule("S100", "cfamily")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            f"Rule {rule.id} has non highlighted code example in section \"Noncompliant Code Example\".\nUse [source,cpp] or [source,text] before the opening '----'."
+        ),
+    ):
+        validate_source_language(rule)
+
 
 def test_missing_source_language_on_second_block_fails_validation(invalid_rule):
-  '''Check that forgetting the language for sources breaks validation in case of multiple blocks too'''
-  rule = invalid_rule('S100', 'java')
-  with pytest.raises(RuleValidationError, match=re.escape(f'Rule {rule.id} has non highlighted code example in section "Noncompliant Code Example".\nUse [source,java] or [source,text] before the opening \'----\'.')):
-    validate_source_language(rule)
+    """Check that forgetting the language for sources breaks validation in case of multiple blocks too"""
+    rule = invalid_rule("S100", "java")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            f"Rule {rule.id} has non highlighted code example in section \"Noncompliant Code Example\".\nUse [source,java] or [source,text] before the opening '----'."
+        ),
+    ):
+        validate_source_language(rule)
+
 
 def test_wrong_source_language_fails_validation(invalid_rule):
-  '''Check that forgetting the language for sources breaks validation'''
-  rule = invalid_rule('S100', 'csharp')
-  with pytest.raises(RuleValidationError, match=re.escape(f'Rule {rule.id} has unknown language "unknown" in code example in section "Noncompliant Code Example".\nAre you looking for "csharp"?')):
-    validate_source_language(rule)
+    """Check that forgetting the language for sources breaks validation"""
+    rule = invalid_rule("S100", "csharp")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            f'Rule {rule.id} has unknown language "unknown" in code example in section "Noncompliant Code Example".\nAre you looking for "csharp"?'
+        ),
+    ):
+        validate_source_language(rule)
+
 
 def test_unsupported_framework_name_in_how_to_fix_it_section_validation(invalid_rule):
-  '''Check that having "How to fix it" subsections using framework names that are not inside the "allowed_framework_names.adoc" file breaks validation'''
-  rule = invalid_rule('S101', 'csharp')
-  with pytest.raises(RuleValidationError, match=f'Rule csharp:S101 has a "How to fix it" section for an unsupported framework: "Foo Bar Framework"'):
-    validate_section_names(rule)
+    """Check that having "How to fix it" subsections using framework names that are not inside the "allowed_framework_names.adoc" file breaks validation"""
+    rule = invalid_rule("S101", "csharp")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule csharp:S101 has a "How to fix it" section for an unsupported framework: "Foo Bar Framework"',
+    ):
+        validate_section_names(rule)
+
 
 def test_too_many_frameworks_in_how_to_fix_it_validation(invalid_rule):
-  '''Check that having more than the current hard limit (6) "How to fix it" subsections breaks validation'''
-  rule = invalid_rule('S101', 'javascript')
-  with pytest.raises(RuleValidationError, match=f'Rule javascript:S101 has more than 6 "How to fix it" sections. Please ensure this limit can be increased with PM/UX teams'):
-    validate_section_names(rule)
+    """Check that having more than the current hard limit (6) "How to fix it" subsections breaks validation"""
+    rule = invalid_rule("S101", "javascript")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule javascript:S101 has more than 6 "How to fix it" sections. Please ensure this limit can be increased with PM/UX teams',
+    ):
+        validate_section_names(rule)
+
 
 def test_single_how_to_fix_it_allowed_validation(invalid_rule):
-  '''Check that mixing "How to fix it" and "How to fix it in FRAMEWORK" sections breaks validation'''
-  rule = invalid_rule('S200', 'abap')
-  with pytest.raises(RuleValidationError, match=f'Rule abap:S200 is mixing "How to fix it" with "How to fix it in FRAMEWORK NAME" sections. Either use a single "How to fix it" or one or more "How to fix it in FRAMEWORK"'):
-    validate_section_names(rule)
+    """Check that mixing "How to fix it" and "How to fix it in FRAMEWORK" sections breaks validation"""
+    rule = invalid_rule("S200", "abap")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule abap:S200 is mixing "How to fix it" with "How to fix it in FRAMEWORK NAME" sections. Either use a single "How to fix it" or one or more "How to fix it in FRAMEWORK"',
+    ):
+        validate_section_names(rule)
+
 
 def test_duplicate_h2_sections_validation(invalid_rule):
-  '''Check that duplicate H2 sections breaks validation'''
-  rule = invalid_rule('S200', 'javascript')
-  with pytest.raises(RuleValidationError, match='Rule javascript:S200 has duplicated {\'How to fix it in Razor\'} sections'):
-    validate_section_names(rule)
+    """Check that duplicate H2 sections breaks validation"""
+    rule = invalid_rule("S200", "javascript")
+    with pytest.raises(
+        RuleValidationError,
+        match="Rule javascript:S200 has duplicated {'How to fix it in Razor'} sections",
+    ):
+        validate_section_names(rule)
+
 
 def test_wrong_format_how_to_fix_it_section_validation(invalid_rule):
-  '''Check that "How to fix it" sections with a weird format breaks validation'''
-  rule = invalid_rule('S200', 'typescript')
-  with pytest.raises(RuleValidationError, match=f'Rule typescript:S200 has a "How to fix it" section with an unsupported format: "How to fix it wrong format". Either use "How to fix it" or "How to fix it in FRAMEWORK NAME"'):
-    validate_section_names(rule)
+    """Check that "How to fix it" sections with a weird format breaks validation"""
+    rule = invalid_rule("S200", "typescript")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule typescript:S200 has a "How to fix it" section with an unsupported format: "How to fix it wrong format". Either use "How to fix it" or "How to fix it in FRAMEWORK NAME"',
+    ):
+        validate_section_names(rule)
+
 
 def test_duplicate_subsections_in_how_to_fix_it_validation(invalid_rule):
-  '''Check that having duplicate "How to fix it" subsections breaks validation'''
-  rule = invalid_rule('S200', 'csharp')
-  with pytest.raises(RuleValidationError, match=f'Rule csharp:S200 has duplicate "How to fix it" subsections. There are 2 occurences of "Pitfalls"'):
-    validate_subsections(rule)
+    """Check that having duplicate "How to fix it" subsections breaks validation"""
+    rule = invalid_rule("S200", "csharp")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule csharp:S200 has duplicate "How to fix it" subsections. There are 2 occurences of "Pitfalls"',
+    ):
+        validate_subsections(rule)
+
 
 def test_unallowed_subsections_in_resources_validation(invalid_rule):
-  '''Check that having "Resources" subsections with unallowed names breaks validation'''
-  rule = invalid_rule('S200', 'cpp')
-  with pytest.raises(RuleValidationError, match=f'Rule cpp:S200 has a "Resources" subsection with an unallowed name: "Yolo"'):
-    validate_subsections(rule)
+    """Check that having "Resources" subsections with unallowed names breaks validation"""
+    rule = invalid_rule("S200", "cpp")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule cpp:S200 has a "Resources" subsection with an unallowed name: "Yolo"',
+    ):
+        validate_subsections(rule)
+
 
 def test_duplicate_subsections_in_resources_validation(invalid_rule):
-  '''Check that having duplicate "Resources" subsections breaks validation'''
-  rule = invalid_rule('S200', 'scala')
-  with pytest.raises(RuleValidationError, match=f'Rule scala:S200 has duplicate "Resources" subsections. There are 2 occurences of "Documentation"'):
-    validate_subsections(rule)
+    """Check that having duplicate "Resources" subsections breaks validation"""
+    rule = invalid_rule("S200", "scala")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule scala:S200 has duplicate "Resources" subsections. There are 2 occurences of "Documentation"',
+    ):
+        validate_subsections(rule)
+
 
 def test_education_format_missing_mandatory_sections_validation(invalid_rule):
-  '''Check that not having all the required sections in the education format breaks validation'''
-  rule = invalid_rule('S200', 'common')
-  with pytest.raises(RuleValidationError, match=f'Rule common:S200 is missing the "Why is this an issue\\?" section'):
-    validate_section_names(rule)
+    """Check that not having all the required sections in the education format breaks validation"""
+    rule = invalid_rule("S200", "common")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule common:S200 is missing the "Why is this an issue\\?" section',
+    ):
+        validate_section_names(rule)
+
 
 def test_noncompliant_examples_with_typo_validation(invalid_rule):
-  '''Check that the "Non-compliant examples" sub-subsection with a typo in the education format breaks validation'''
-  rule = invalid_rule('S200', 'apex')
-  with pytest.raises(RuleValidationError, match=f'Rule apex:S200 has a "Code examples" subsection with an unallowed name: "Non-compliant example"'):
-    validate_subsections(rule)
+    """Check that the "Non-compliant examples" sub-subsection with a typo in the education format breaks validation"""
+    rule = invalid_rule("S200", "apex")
+    with pytest.raises(
+        RuleValidationError,
+        match=f'Rule apex:S200 has a "Code examples" subsection with an unallowed name: "Non-compliant example"',
+    ):
+        validate_subsections(rule)
+
 
 def test_valid_optional_how_to_fix_it_section_validation(rule_language):
-  '''Check that missing the "How to fix it" section in the education format is considered valid'''
-  rule = rule_language('S200', 'php')
-  validate_section_names(rule)
+    """Check that missing the "How to fix it" section in the education format is considered valid"""
+    rule = rule_language("S200", "php")
+    validate_section_names(rule)
+
 
 def test_valid_how_to_fix_it_subsections_validation(rule_language):
-  '''Check that expected format is considered valid'''
-  rule = rule_language('S101', 'csharp')
-  validate_subsections(rule)
+    """Check that expected format is considered valid"""
+    rule = rule_language("S101", "csharp")
+    validate_subsections(rule)
+
 
 def test_valid_optional_resources(rule_language):
-  '''Check that the "Resources" section is optional'''
-  rule = rule_language('S200', 'csharp')
-  validate_subsections(rule)
-  validate_section_names(rule)
+    """Check that the "Resources" section is optional"""
+    rule = rule_language("S200", "csharp")
+    validate_subsections(rule)
+    validate_section_names(rule)
+
 
 def test_subsections_without_a_framework_in_how_to_fix_it_validation(rule_language):
-  '''Check that having subsections without a framework in "How to fix it" is considered valid'''
-  rule = rule_language('S200', 'cobol')
-  validate_subsections(rule)
+    """Check that having subsections without a framework in "How to fix it" is considered valid"""
+    rule = rule_language("S200", "cobol")
+    validate_subsections(rule)
+
 
 def test_valid_why_is_this_an_issue_subsections_validation(rule_language):
-  '''Check that any substitle is considered valid in the "why is this an issue?" section'''
-  rule = rule_language('S200', 'java')
-  validate_subsections(rule)
+    """Check that any substitle is considered valid in the "why is this an issue?" section"""
+    rule = rule_language("S200", "java")
+    validate_subsections(rule)
+
 
 def test_valid_security_standard_links(rule_language):
-  '''Check that the security standards links match what is define in th rule metadata'''
-  rule = rule_language('S200', 'python')
-  validate_security_standard_links(rule)
+    """Check that the security standards links match what is define in th rule metadata"""
+    rule = rule_language("S200", "python")
+    validate_security_standard_links(rule)
+
 
 def test_missing_security_standard_links_fails_validation(rule_language):
-  '''Check that the security standards links match what is define in th rule metadata'''
-  rule = rule_language('S200', 'docker')
-  with pytest.raises(RuleValidationError, match=re.escape('Rule docker:S200 has a mismatch for the OWASP security standards. Add links to the Resources/See section ([\'A10\']) or fix the rule metadata')):
-    validate_security_standard_links(rule)
+    """Check that the security standards links match what is define in th rule metadata"""
+    rule = rule_language("S200", "docker")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule docker:S200 has a mismatch for the OWASP security standards. Add links to the Resources/See section (['A10']) or fix the rule metadata"
+        ),
+    ):
+        validate_security_standard_links(rule)
+
 
 def test_extra_security_standard_links_fails_validation(rule_language):
-  '''Check that the security standards links match what is define in th rule metadata'''
-  rule = rule_language('S200', 'terraform')
-  with pytest.raises(RuleValidationError, match=re.escape('Rule terraform:S200 has a mismatch for the OWASP security standards. Remove links from the Resources/See section ([\'A10\']) or fix the rule metadata')):
-    validate_security_standard_links(rule)
+    """Check that the security standards links match what is define in th rule metadata"""
+    rule = rule_language("S200", "terraform")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule terraform:S200 has a mismatch for the OWASP security standards. Remove links from the Resources/See section (['A10']) or fix the rule metadata"
+        ),
+    ):
+        validate_security_standard_links(rule)

--- a/rspec-tools/tests/validation/test_metadata_validation.py
+++ b/rspec-tools/tests/validation/test_metadata_validation.py
@@ -1,188 +1,279 @@
+import re
+from copy import deepcopy
 from pathlib import Path
 
 from unittest.mock import patch, PropertyMock
+
 import pytest
-import re
 from rspec_tools.errors import RuleValidationError
-from copy import deepcopy
 
 from rspec_tools.rules import LanguageSpecificRule, RulesRepository
-from rspec_tools.validation.metadata import validate_rule_specialization_metadata, validate_rule_metadata
+from rspec_tools.validation.metadata import (
+    validate_rule_metadata,
+    validate_rule_specialization_metadata,
+)
+
 
 @pytest.fixture
 def rule_language(mockrules: Path):
-  rule = RulesRepository(rules_path=mockrules).get_rule('S100')
-  return rule.get_language('kotlin')
+    rule = RulesRepository(rules_path=mockrules).get_rule("S100")
+    return rule.get_language("kotlin")
 
 
 @pytest.fixture
 def invalid_rules():
-  invalid_rules_path = Path(__file__).parent.parent.joinpath('resources', 'invalid-rules')
-  return RulesRepository(rules_path=invalid_rules_path)
+    invalid_rules_path = Path(__file__).parent.parent.joinpath(
+        "resources", "invalid-rules"
+    )
+    return RulesRepository(rules_path=invalid_rules_path)
 
 
 def test_valid_metadata_passes_validation(rule_language: LanguageSpecificRule):
-  '''Check that language metadata are correctly overridden.'''
-  validate_rule_specialization_metadata(rule_language)
+    """Check that language metadata are correctly overridden."""
+    validate_rule_specialization_metadata(rule_language)
 
 
-@patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', [])
+@patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", [])
 def test_rule_with_no_language(invalid_rules: RulesRepository):
-  s501 = invalid_rules.get_rule('S501')
-  with pytest.raises(RuleValidationError, match=fr'^Rule S501 has no language-specific data'):
-    validate_rule_metadata(s501)
+    s501 = invalid_rules.get_rule("S501")
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule S501 has no language-specific data"
+    ):
+        validate_rule_metadata(s501)
 
 
-@patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', ['S501'])
+@patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", ["S501"])
 def test_rule_with_no_language_in_exception_list(invalid_rules: RulesRepository):
-  s501 = invalid_rules.get_rule('S501')
-  validate_rule_metadata(s501)
-  with patch.dict(s501.generic_metadata, [('status', 'deprecated')]):
+    s501 = invalid_rules.get_rule("S501")
     validate_rule_metadata(s501)
+    with patch.dict(s501.generic_metadata, [("status", "deprecated")]):
+        validate_rule_metadata(s501)
 
 
-@patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', ['S501'])
+@patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", ["S501"])
 def test_open_rule_with_no_language_in_exception_list(invalid_rules: RulesRepository):
-  s501 = invalid_rules.get_rule('S501')
-  with pytest.raises(RuleValidationError, match=fr'^Rule S501 should be closed or deprecated'):
-    with patch.dict(s501.generic_metadata, [('status', 'ready')]):
-      validate_rule_metadata(s501)
+    s501 = invalid_rules.get_rule("S501")
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule S501 should be closed or deprecated"
+    ):
+        with patch.dict(s501.generic_metadata, [("status", "ready")]):
+            validate_rule_metadata(s501)
 
 
-@patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', ['S120'])
+@patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", ["S120"])
 def test_rule_expected_to_have_no_language(mockrules: Path):
-  valid_rule = RulesRepository(rules_path=mockrules).get_rule('S120')
-  with pytest.raises(RuleValidationError, match=fr'^Rule S120 should have no specializations'):
-    validate_rule_metadata(valid_rule)
+    valid_rule = RulesRepository(rules_path=mockrules).get_rule("S120")
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule S120 should have no specializations"
+    ):
+        validate_rule_metadata(valid_rule)
 
 
-@patch('rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES', [])
+@patch("rspec_tools.validation.metadata.RULES_WITH_NO_LANGUAGES", [])
 def test_rule_with_invalid_language(invalid_rules: RulesRepository):
-  s502 = invalid_rules.get_rule('S502')
-  with pytest.raises(RuleValidationError, match=fr'^Rule S502 failed validation for these reasons:\n - Rule scala:S502 has invalid metadata'):
-    validate_rule_metadata(s502)
+    s502 = invalid_rules.get_rule("S502")
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule S502 failed validation for these reasons:\n - Rule scala:S502 has invalid metadata",
+    ):
+        validate_rule_metadata(s502)
+
 
 def test_rule_with_invalid_education_principles(invalid_rules: RulesRepository):
-  s503 = invalid_rules.get_rule('S503')
-  with pytest.raises(RuleValidationError, match=re.escape("Rule S503 failed validation for these reasons:\n - Rule scala:S503 has invalid metadata in 0: 'invalid' is not one of ['defense_in_depth', 'never_trust_user_input']")):
-    validate_rule_metadata(s503)
+    s503 = invalid_rules.get_rule("S503")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule S503 failed validation for these reasons:\n - Rule scala:S503 has invalid metadata in 0: 'invalid' is not one of ['defense_in_depth', 'never_trust_user_input']"
+        ),
+    ):
+        validate_rule_metadata(s503)
 
 
 def test_rule_with_no_impacts(invalid_rules: RulesRepository):
-  s504 = invalid_rules.get_rule('S504')
-  with pytest.raises(RuleValidationError, match=re.escape("Rule S504 failed validation for these reasons:\n - Rule scala:S504 has invalid metadata in impacts: {} should be non-empty")):
-    validate_rule_metadata(s504)
+    s504 = invalid_rules.get_rule("S504")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule S504 failed validation for these reasons:\n - Rule scala:S504 has invalid metadata in impacts: {} should be non-empty"
+        ),
+    ):
+        validate_rule_metadata(s504)
 
 
 def test_rule_with_invalid_impacts(invalid_rules: RulesRepository):
-  s505 = invalid_rules.get_rule('S505')
-  with pytest.raises(RuleValidationError, match=re.escape("Rule S505 failed validation for these reasons:\n - Rule scala:S505 has invalid metadata in impacts: Additional properties are not allowed ('INVALID' was unexpected)")):
-    validate_rule_metadata(s505)
+    s505 = invalid_rules.get_rule("S505")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule S505 failed validation for these reasons:\n - Rule scala:S505 has invalid metadata in impacts: Additional properties are not allowed ('INVALID' was unexpected)"
+        ),
+    ):
+        validate_rule_metadata(s505)
 
 
 def test_rule_with_invalid_impact_level(invalid_rules: RulesRepository):
-  s506 = invalid_rules.get_rule('S506')
-  with pytest.raises(RuleValidationError, match=re.escape("Rule S506 failed validation for these reasons:\n - Rule scala:S506 has invalid metadata in MAINTAINABILITY: 'INVALID' is not one of ['INFO', 'LOW', 'MEDIUM', 'HIGH', 'BLOCKER']")):
-    validate_rule_metadata(s506)
+    s506 = invalid_rules.get_rule("S506")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule S506 failed validation for these reasons:\n - Rule scala:S506 has invalid metadata in MAINTAINABILITY: 'INVALID' is not one of ['INFO', 'LOW', 'MEDIUM', 'HIGH', 'BLOCKER']"
+        ),
+    ):
+        validate_rule_metadata(s506)
 
 
 def test_rule_with_invalid_attribute(invalid_rules: RulesRepository):
-  s507 = invalid_rules.get_rule('S507')
-  with pytest.raises(RuleValidationError, match=re.escape("Rule S507 failed validation for these reasons:\n - Rule scala:S507 has invalid metadata in attribute: 'INVALID' is not one of ['FORMATTED', 'CONVENTIONAL', 'IDENTIFIABLE', 'CLEAR', 'LOGICAL', 'COMPLETE', 'EFFICIENT', 'FOCUSED', 'DISTINCT', 'MODULAR', 'TESTED', 'LAWFUL', 'TRUSTWORTHY', 'RESPECTFUL']")):
-    validate_rule_metadata(s507)
+    s507 = invalid_rules.get_rule("S507")
+    with pytest.raises(
+        RuleValidationError,
+        match=re.escape(
+            "Rule S507 failed validation for these reasons:\n - Rule scala:S507 has invalid metadata in attribute: 'INVALID' is not one of ['FORMATTED', 'CONVENTIONAL', 'IDENTIFIABLE', 'CLEAR', 'LOGICAL', 'COMPLETE', 'EFFICIENT', 'FOCUSED', 'DISTINCT', 'MODULAR', 'TESTED', 'LAWFUL', 'TRUSTWORTHY', 'RESPECTFUL']"
+        ),
+    ):
+        validate_rule_metadata(s507)
 
 
 def test_rule_with_unicode_in_metadata(invalid_rules: RulesRepository):
-  s4225 = invalid_rules.get_rule('S4225')
-  with pytest.raises(UnicodeDecodeError, match=fr'ascii'):
-    validate_rule_metadata(s4225)
+    s4225 = invalid_rules.get_rule("S4225")
+    with pytest.raises(UnicodeDecodeError, match=rf"ascii"):
+        validate_rule_metadata(s4225)
+
 
 def test_rule_that_is_fully_valid(mockrules: Path):
-  valid_rule = RulesRepository(rules_path=mockrules).get_rule('S120')
-  validate_rule_metadata(valid_rule)
+    valid_rule = RulesRepository(rules_path=mockrules).get_rule("S120")
+    validate_rule_metadata(valid_rule)
 
 
-def test_missing_required_property_fails_validation(rule_language: LanguageSpecificRule):
-  invalid_metadata = deepcopy(rule_language.metadata)
-  del invalid_metadata['title']
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata'):
-    with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-      mock.return_value = invalid_metadata
-      validate_rule_specialization_metadata(rule_language)
+def test_missing_required_property_fails_validation(
+    rule_language: LanguageSpecificRule,
+):
+    invalid_metadata = deepcopy(rule_language.metadata)
+    del invalid_metadata["title"]
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule {rule_language.id} has invalid metadata"
+    ):
+        with patch.object(
+            LanguageSpecificRule, "metadata", new_callable=PropertyMock
+        ) as mock:
+            mock.return_value = invalid_metadata
+            validate_rule_specialization_metadata(rule_language)
 
 
 def test_invalid_remediation_fails_validation(rule_language: LanguageSpecificRule):
-  invalid_metadata = deepcopy(rule_language.metadata)
-  invalid_metadata['remediation']["func"] = 42
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata'):
-    with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-      mock.return_value = invalid_metadata
-      validate_rule_specialization_metadata(rule_language)
+    invalid_metadata = deepcopy(rule_language.metadata)
+    invalid_metadata["remediation"]["func"] = 42
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule {rule_language.id} has invalid metadata"
+    ):
+        with patch.object(
+            LanguageSpecificRule, "metadata", new_callable=PropertyMock
+        ) as mock:
+            mock.return_value = invalid_metadata
+            validate_rule_specialization_metadata(rule_language)
 
 
 def test_adding_properties_fails_validation(rule_language: LanguageSpecificRule):
-  metadata = deepcopy(rule_language.metadata)
-  metadata['unknown'] = 42
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata'):
-    with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-      mock.return_value = metadata
-      validate_rule_specialization_metadata(rule_language)
+    metadata = deepcopy(rule_language.metadata)
+    metadata["unknown"] = 42
+    with pytest.raises(
+        RuleValidationError, match=rf"^Rule {rule_language.id} has invalid metadata"
+    ):
+        with patch.object(
+            LanguageSpecificRule, "metadata", new_callable=PropertyMock
+        ) as mock:
+            mock.return_value = metadata
+            validate_rule_specialization_metadata(rule_language)
 
 
-def test_ready_rule_with_replacement_fails_validation(rule_language: LanguageSpecificRule):
-  invalid_metadata = deepcopy(rule_language.metadata)
-  invalid_metadata['extra'] = { 'replacementRules': [ 'RSPEC-1234', 'RSPEC-5678' ]}
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata: status'):
-    with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-      mock.return_value = invalid_metadata
-      validate_rule_specialization_metadata(rule_language)
+def test_ready_rule_with_replacement_fails_validation(
+    rule_language: LanguageSpecificRule,
+):
+    invalid_metadata = deepcopy(rule_language.metadata)
+    invalid_metadata["extra"] = {"replacementRules": ["RSPEC-1234", "RSPEC-5678"]}
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule_language.id} has invalid metadata: status",
+    ):
+        with patch.object(
+            LanguageSpecificRule, "metadata", new_callable=PropertyMock
+        ) as mock:
+            mock.return_value = invalid_metadata
+            validate_rule_specialization_metadata(rule_language)
 
 
-def test_deprecated_rule_with_replacement_passes_validation(rule_language: LanguageSpecificRule):
-  metadata = deepcopy(rule_language.metadata)
-  metadata['extra'] = { 'replacementRules': [ 'RSPEC-1234' ]}
-  metadata['status'] = 'deprecated'
-  with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-    mock.return_value = metadata
-    validate_rule_specialization_metadata(rule_language)
+def test_deprecated_rule_with_replacement_passes_validation(
+    rule_language: LanguageSpecificRule,
+):
+    metadata = deepcopy(rule_language.metadata)
+    metadata["extra"] = {"replacementRules": ["RSPEC-1234"]}
+    metadata["status"] = "deprecated"
+    with patch.object(
+        LanguageSpecificRule, "metadata", new_callable=PropertyMock
+    ) as mock:
+        mock.return_value = metadata
+        validate_rule_specialization_metadata(rule_language)
 
 
-def test_rule_with_incomplete_list_of_security_standard_fails_validation(rule_language: LanguageSpecificRule):
-  invalid_metadata = deepcopy(rule_language.metadata)
-  # "OWASP Top 10 2021", defined in the generic metadata is missing
-  invalid_metadata['securityStandards'] = {'ASVS 4.0': [], 'OWASP': [], 'CERT': []}
-  with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata: securityStandard'):
-    with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-      mock.return_value = invalid_metadata
-      validate_rule_specialization_metadata(rule_language)
+def test_rule_with_incomplete_list_of_security_standard_fails_validation(
+    rule_language: LanguageSpecificRule,
+):
+    invalid_metadata = deepcopy(rule_language.metadata)
+    # "OWASP Top 10 2021", defined in the generic metadata is missing
+    invalid_metadata["securityStandards"] = {"ASVS 4.0": [], "OWASP": [], "CERT": []}
+    with pytest.raises(
+        RuleValidationError,
+        match=rf"^Rule {rule_language.id} has invalid metadata: securityStandard",
+    ):
+        with patch.object(
+            LanguageSpecificRule, "metadata", new_callable=PropertyMock
+        ) as mock:
+            mock.return_value = invalid_metadata
+            validate_rule_specialization_metadata(rule_language)
 
 
-def test_rule_with_complete_list_of_security_standard_passes_validation(rule_language: LanguageSpecificRule):
-  metadata = deepcopy(rule_language.metadata)
-  metadata['securityStandards'] = {'ASVS 4.0': [], 'OWASP': [], "OWASP Top 10 2021": []}
-  with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-    mock.return_value = metadata
-    validate_rule_specialization_metadata(rule_language)
+def test_rule_with_complete_list_of_security_standard_passes_validation(
+    rule_language: LanguageSpecificRule,
+):
+    metadata = deepcopy(rule_language.metadata)
+    metadata["securityStandards"] = {
+        "ASVS 4.0": [],
+        "OWASP": [],
+        "OWASP Top 10 2021": [],
+    }
+    with patch.object(
+        LanguageSpecificRule, "metadata", new_callable=PropertyMock
+    ) as mock:
+        mock.return_value = metadata
+        validate_rule_specialization_metadata(rule_language)
 
-def test_rule_with_invalid_format_for_security_standard_items_fails_validation(rule_language: LanguageSpecificRule):
-  invalid_security_standards_items = {
-    'OWASP': ['B1', 'AAA123', 'A0', ' A1', 'Not covered', ''],
-    'OWASP Top 10 2021': ['B1', 'AAA123', 'A0',  ' A1', 'Not covered', ''],
-    'OWASP Mobile': ['B1', 'MMM123', 'M0', ' M1', 'Not covered', ''],
-    'PCI DSS 3.2': ['2.1.A', '2.1.1 ', 'Not covered', ''],
-    'PCI DSS 4.0': ['2.1.A', '2.1.1 ', 'Not covered', ''],
-    'CIS': ['2.1.A', '"2.1.1 ', 'Not covered', ''],
-    'HIPAA': ['Not covered', ''],
-    'CERT': ['MSC13-C', 'MSC13-C. ', 'Not covered', ''],
-    'MASVS': ['MSTG-CRYPTO-A', 'MSTG-CRYPTO-6 ', 'Not covered', ''],
-    'ASVS 4.0': ['A.1.2', ' 1.1.1', 'Not covered', '']
-  }
 
-  for security_standard in invalid_security_standards_items:
-    for item in invalid_security_standards_items[security_standard]:
-      invalid_metadata = deepcopy(rule_language.metadata)
-      invalid_metadata['securityStandards'] = { security_standard: [item] }
-      with pytest.raises(RuleValidationError, match=fr'^Rule {rule_language.id} has invalid metadata in 0: \'{item}\' does not match'):
-        with patch.object(LanguageSpecificRule, 'metadata', new_callable=PropertyMock) as mock:
-          mock.return_value = invalid_metadata
-          validate_rule_specialization_metadata(rule_language)
+def test_rule_with_invalid_format_for_security_standard_items_fails_validation(
+    rule_language: LanguageSpecificRule,
+):
+    invalid_security_standards_items = {
+        "OWASP": ["B1", "AAA123", "A0", " A1", "Not covered", ""],
+        "OWASP Top 10 2021": ["B1", "AAA123", "A0", " A1", "Not covered", ""],
+        "OWASP Mobile": ["B1", "MMM123", "M0", " M1", "Not covered", ""],
+        "PCI DSS 3.2": ["2.1.A", "2.1.1 ", "Not covered", ""],
+        "PCI DSS 4.0": ["2.1.A", "2.1.1 ", "Not covered", ""],
+        "CIS": ["2.1.A", '"2.1.1 ', "Not covered", ""],
+        "HIPAA": ["Not covered", ""],
+        "CERT": ["MSC13-C", "MSC13-C. ", "Not covered", ""],
+        "MASVS": ["MSTG-CRYPTO-A", "MSTG-CRYPTO-6 ", "Not covered", ""],
+        "ASVS 4.0": ["A.1.2", " 1.1.1", "Not covered", ""],
+    }
+
+    for security_standard in invalid_security_standards_items:
+        for item in invalid_security_standards_items[security_standard]:
+            invalid_metadata = deepcopy(rule_language.metadata)
+            invalid_metadata["securityStandards"] = {security_standard: [item]}
+            with pytest.raises(
+                RuleValidationError,
+                match=rf"^Rule {rule_language.id} has invalid metadata in 0: \'{item}\' does not match",
+            ):
+                with patch.object(
+                    LanguageSpecificRule, "metadata", new_callable=PropertyMock
+                ) as mock:
+                    mock.return_value = invalid_metadata
+                    validate_rule_specialization_metadata(rule_language)

--- a/rspec-tools/tox.ini
+++ b/rspec-tools/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+# recommended options for compatibility with black
+max-line-length = 88
+extend-ignore = E203,E701


### PR DESCRIPTION
Add the default python codestyle tools: Black and usort and reformat code to enforce the consistent coding style.
The PR features massive changes due to batch reformatting. You can validate the changes by running the tools yourself:
```
cd rspec-tools
pipenv run black rspec_tools tests/
pipenv run usort format rspec_tools tests
```
Once merged, we should add .git-blame-ignore-revs file to exclude it from git blame.