### PR TITLE
Modify rule S6912: fix broken link with archive.org version

### DIFF
--- a/rules/S6912/java/rule.adoc
+++ b/rules/S6912/java/rule.adoc
@@ -64,5 +64,5 @@ public void execute(Connection connection) {
 
 === Articles & blog posts
 
-* https://www.baeldung.com/jdbc-batch-processing[Baeldung - JDBC Batch Processing]
+* https://web.archive.org/web/https://www.baeldung.com/jdbc-batch-processing[Baeldung - JDBC Batch Processing]
 


### PR DESCRIPTION
Replace broken link with archived version

Original link: https://www.baeldung.com/jdbc-batch-processing
Archived link: https://web.archive.org/web/https://www.baeldung.com/jdbc-batch-processing

This automated PR was created because the link was no longer accessible. Using the Internet Archive's Wayback Machine ensures that readers can still access the referenced content.

Files containing this link:
- /home/arseniy/proj/rspec/rspec-tools/../rules/S6912/java/rule.adoc
