### PR TITLE
Modify rule S6804: fix broken link with archive.org version

### DIFF
--- a/rules/S6804/java/rule.adoc
+++ b/rules/S6804/java/rule.adoc
@@ -75,5 +75,5 @@ String greeting = "Hello, world!"; // Compliant
 
 === Articles & blog posts
 
-- https://www.baeldung.com/spring-value-annotation[Baeldung - A Quick Guide to Spring @Value]
+- https://web.archive.org/web/https://www.baeldung.com/spring-value-annotation[Baeldung - A Quick Guide to Spring @Value]
 - https://www.digitalocean.com/community/tutorials/spring-value-annotation[DigitalOcean - Spring @Value Annotation]


### PR DESCRIPTION
Replace broken link with archived version

Original link: https://www.baeldung.com/spring-value-annotation
Archived link: https://web.archive.org/web/https://www.baeldung.com/spring-value-annotation

This automated PR was created because the link was no longer accessible. Using the Internet Archive's Wayback Machine ensures that readers can still access the referenced content.

Files containing this link:
- /home/arseniy/proj/rspec/rspec-tools/../rules/S6804/java/rule.adoc
