### PR TITLE
Modify rules S5131,S7039,S7080: fix broken link with archive.org version

### DIFF
--- a/rules/S5131/common/resources/standards.adoc
+++ b/rules/S5131/common/resources/standards.adoc
@@ -3,6 +3,6 @@
 * OWASP - https://owasp.org/Top10/A03_2021-Injection/[Top 10 2021 Category A3 - Injection]
 * OWASP - https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)[Top 10 2017 Category A7 - Cross-Site Scripting (XSS)]
 * CWE - https://cwe.mitre.org/data/definitions/79[CWE-79 - Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')]
-* STIG Viewer - https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
+* STIG Viewer - https://web.archive.org/web/https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
 * STIG Viewer - https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222609[Application Security and Development: V-222609] - The application must not be subject to input handling vulnerabilities.
 

--- a/rules/S7039/common/resources/standards.adoc
+++ b/rules/S7039/common/resources/standards.adoc
@@ -3,5 +3,5 @@
 * OWASP - https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[Top 10 2021 Category A5 - Security Misconfiguration]
 * OWASP - https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[Top 10 2017 Category A6 - Security Misconfiguration]
 * CWE - https://cwe.mitre.org/data/definitions/693[CWE-693 - Protection Mechanism Failure]
-* STIG Viewer - https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
+* STIG Viewer - https://web.archive.org/web/https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
 

--- a/rules/S7080/javascript/rule.adoc
+++ b/rules/S7080/javascript/rule.adoc
@@ -157,7 +157,7 @@ content. Be sure to validate and sanitize all user content.
 * OWASP - https://owasp.org/Top10/A05_2021-Security_Misconfiguration/[Top 10 2021 Category A5 - Security Misconfiguration]
 * OWASP - https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html[Top 10 2017 Category A6 - Security Misconfiguration]
 * CWE - https://cwe.mitre.org/data/definitions/693[CWE-693 - Protection Mechanism Failure]
-* STIG Viewer - https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
+* STIG Viewer - https://web.archive.org/web/https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602[Application Security and Development: V-222602] - The application must protect from Cross-Site Scripting (XSS) vulnerabilities.
 
 === External coding guidelines
 


### PR DESCRIPTION
Replace broken link with archived version

Original link: https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602
Archived link: https://web.archive.org/web/https://stigviewer.com/stig/application_security_and_development/2023-06-08/finding/V-222602

This automated PR was created because the link was no longer accessible. Using the Internet Archive's Wayback Machine ensures that readers can still access the referenced content.

Files containing this link:
- /home/arseniy/proj/rspec/rspec-tools/../rules/S7080/javascript/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S5131/javascript/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S5131/python/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S5131/java/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S5131/csharp/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S5131/php/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S7039/html/rule.adoc
- /home/arseniy/proj/rspec/rspec-tools/../rules/S7039/csharp/rule.adoc
