### PR TITLE
Modify rule S2122: fix broken link with archive.org version

### DIFF
--- a/rules/S2122/java/rule.adoc
+++ b/rules/S2122/java/rule.adoc
@@ -34,7 +34,7 @@ public void do(){
 
 === Articles & blog posts
 * https://engineering.zalando.com/posts/2019/04/how-to-set-an-ideal-thread-pool-size.html[Zalando - How to set an ideal thread pool size]
-* https://www.baeldung.com/java-threadpooltaskexecutor-core-vs-max-poolsize[Baeldung - ThreadPoolTaskExecutor corePoolSize vs. maxPoolSize]
+* https://web.archive.org/web/https://www.baeldung.com/java-threadpooltaskexecutor-core-vs-max-poolsize[Baeldung - ThreadPoolTaskExecutor corePoolSize vs. maxPoolSize]
 
 
 ifdef::env-github,rspecator-view[]


### PR DESCRIPTION
Replace broken link with archived version

Original link: https://www.baeldung.com/java-threadpooltaskexecutor-core-vs-max-poolsize
Archived link: https://web.archive.org/web/https://www.baeldung.com/java-threadpooltaskexecutor-core-vs-max-poolsize

This automated PR was created because the link was no longer accessible. Using the Internet Archive's Wayback Machine ensures that readers can still access the referenced content.

Files containing this link:
- /home/arseniy/proj/rspec/rspec-tools/../rules/S2122/java/rule.adoc
