### PR TITLE
SONARJAVA-5476 Modify rule S6363: Disable a url not meant to be a documentation link

### DIFF
--- a/rules/S6363/kotlin/rule.adoc
+++ b/rules/S6363/kotlin/rule.adoc
@@ -61,7 +61,7 @@ AndroidView(
 ----
 
 The compliant solution uses `WebViewAssetLoader` to load local files instead of directly accessing them via `file://`
-URLs. This approach serves assets over a secure `https://appassets.androidplatform.net` URL, effectively isolating the
+URLs. This approach serves assets over a secure `\https://appassets.androidplatform.net` URL, effectively isolating the
 WebView from the local file system.
 
 The file access settings are disabled by default in modern Android versions. To prevent possible security issues in


### PR DESCRIPTION
[SONARJAVA-5476](https://sonarsource.atlassian.net/browse/SONARJAVA-5476)



[SONARJAVA-5476]: https://sonarsource.atlassian.net/browse/SONARJAVA-5476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ