### PR TITLE
Run update_coverage on a hosted runner to remain within the IP allowlist

### DIFF
--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_coverage:
-    runs-on: ubuntu-latest
+    runs-on: sonar-runner-large
     permissions:
       id-token: write # required by SonarSource/vault-action-wrapper
       contents: write


### PR DESCRIPTION
This is a temporary solution to keep the action going as we implement IP allow-list to access private Sonar repositories.