### PR TITLE
SONARKT-659 Deprecate rule S6291 and S6300

### DIFF
--- a/rules/S6291/metadata.json
+++ b/rules/S6291/metadata.json
@@ -7,15 +7,11 @@
     },
     "attribute": "TRUSTWORTHY"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-    "cwe",
-    "android"
-  ],
   "extra": {
     "replacementRules": [
 
@@ -64,8 +60,6 @@
       "6.1.3"
     ]
   },
-  "defaultQualityProfiles": [
-    "Sonar way"
-  ],
+  "defaultQualityProfiles": [],
   "quickfix": "unknown"
 }

--- a/rules/S6291/metadata.json
+++ b/rules/S6291/metadata.json
@@ -12,6 +12,7 @@
     "func": "Constant\/Issue",
     "constantCost": "10min"
   },
+  "tags": [],
   "extra": {
     "replacementRules": [
 

--- a/rules/S6300/metadata.json
+++ b/rules/S6300/metadata.json
@@ -7,15 +7,12 @@
     },
     "attribute": "TRUSTWORTHY"
   },
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "10min"
   },
-  "tags": [
-    "cwe",
-    "android"
-  ],
+  "tags": [],
   "extra": {
     "replacementRules": [
 
@@ -61,7 +58,6 @@
     ]
   },
   "defaultQualityProfiles": [
-    "Sonar way"
   ],
   "quickfix": "unknown"
 }


### PR DESCRIPTION
[SONARKT-659](https://sonarsource.atlassian.net/browse/SONARKT-659)

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)



[SONARKT-654]: https://sonarsource.atlassian.net/browse/SONARKT-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONARJAVA-5544]: https://sonarsource.atlassian.net/browse/SONARJAVA-5544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SONARKT-657]: https://sonarsource.atlassian.net/browse/SONARKT-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SONARKT-659]: https://sonarsource.atlassian.net/browse/SONARKT-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ