### PR TITLE
Add dogfood approach to publish `update-coverage` to `dogfood-automerge` and then to `gh-pages`

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-coverage token | dogfood_token;
-            development/kv/data/slack token | slack_token;
+            development/kv/data/slack webhook | slack_webhook;
       - name: git octopus step
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).dogfood_token }}

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,46 @@
+name: dogfood merge
+# This workflow is triggered on pushes to master and dogfood branches
+on:
+  pull_request:
+  push:
+  delete:
+    # There is no 'branch:' filter for the delete action,
+    # so we are using 'if:' inside the job instead.
+  workflow_dispatch:
+    # This allows to run the workflow manually from the Actions tab (can be useful for testing purposes)
+
+jobs:
+  dogfood_merge:
+    if: >-
+      (github.event_name == 'push' && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/dogfood/')))
+      || (github.event_name == 'delete' && startsWith(github.event.ref, 'dogfood/'))
+    runs-on: ubuntu-latest-large
+    name: Update dogfood branch
+    permissions:
+      id-token: write # required for SonarSource/vault-action-wrapper
+    steps:
+      - name: get secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@d1c1ab4ca5ad07fd9cdfe1eff038a39673dfca64  # tag=2.4.2-1
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-coverage token | dogfood_token;
+            development/kv/data/slack token | slack_token;
+      - name: git octopus step
+        env:
+          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).dogfood_token }}
+        id: dogfood
+        uses: SonarSource/gh-action_dogfood_merge@8ae16f1dc3c9687d5910016ba9f059d18286b308 # 1.0.2
+        with:
+          dogfood-branch: 'dogfood-automerge'
+      # Use the output from the `dogfood` step
+      - name: Get the name of the dogfood branch and its HEAD SHA1
+        run: echo "The dogfood branch was ${{ steps.dogfood.outputs.dogfood-branch }} and its HEAD SHA1 was ${{ steps.dogfood.outputs.sha1 }}"
+      - name: Notify failures on Slack
+        uses: Ilshidur/action-slack@fb92a78a305a399cd6d8ede99d641f2b9224daf3 # 2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_WEBHOOK }}
+          SLACK_CHANNEL: team-analysis-rspec
+        if: failure()
+        with:
+          args: "Dogfood merge failed by {{ GITHUB_ACTOR }}, see {{ GITHUB_SERVER_URL }}/{{ GITHUB_REPOSITORY }}/actions/runs/{{ GITHUB_RUN_ID }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - dogfood-automerge
       - rule/**
   workflow_dispatch:
     # This allows to run the workflow manually from the Actions tab (can be useful for testing purposes)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,13 +4,15 @@ on:
     branches:
       - master
       - rule/**
+  workflow_dispatch:
+    # This allows to run the workflow manually from the Actions tab (can be useful for testing purposes)
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest-large
     permissions:
       pull-requests: read # Get the list and metadata of open new-rule PRs
-      contents: write # Get the contents of open new-rule PRs, the 'master'; write to 'gh-pages' branch
+      contents: write # Get the contents of open new-rule PRs, the 'master' with updated-coverage from 'dogfood-automerge'; write to 'gh-pages' branch
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4 # If you're using actions/checkout you must set persist-credentials to false in most cases for the deployment to work correctly.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4 # If you're using actions/checkout you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
           persist-credentials: false
-          ref: 'master'
+          ref: 'dogfood-automerge'
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         working-directory: frontend

--- a/.github/workflows/update_coverage.yml
+++ b/.github/workflows/update_coverage.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       actions: write # required by andymckay/cancel-action
     env:
-      TMP_BRANCH: temporary/coverage_update
+      TMP_BRANCH: coverage-update
 
     steps:
     - name: 'get secrets'
@@ -61,8 +61,8 @@ jobs:
       if: steps.gen-coverage.outputs.new_coverage != 'true'
       uses: andymckay/cancel-action@0.2
 
-    - name: 'Push the updated coverage file to a new branch'
-      id: create-temp-branch
+    - name: 'Push the updated coverage file to the coverage branch'
+      id: push-to-branch
       if: steps.gen-coverage.outputs.new_coverage == 'true'
       working-directory: 'rspec'
       run: |
@@ -71,64 +71,8 @@ jobs:
         git checkout -b $TMP_BRANCH
         git add frontend/public/covered_rules.json
         git commit -m "update coverage information"
-        git push --force-with-lease origin $TMP_BRANCH
-
-    - name: 'Create a PR'
-      id: create-github-pr
-      working-directory: 'rspec'
-      env:
-        GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).coverage_github_token }}
-      run: |
-        PR_URL=$(gh pr create --head ${{ env.TMP_BRANCH }} --title "Update coverage information" --body "" --label "rspec system")
-        gh pr merge $PR_URL
-
-    - name: 'Wait until the PR is merged'
-      id: wait-for-pr-to-merge
-      env:
-        GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).coverage_github_token }}
-      working-directory: 'rspec'
-      run: |
-        set -ueo pipefail
-
-        # Implicitly referring to the PR corresponding to current branch
-
-        # Set timeout (20 minutes in seconds)
-        TIMEOUT=1200 # seconds
-        START_TIME=$(date +%s)
-        INTERVAL=20 # seconds
-
-        while true; do
-          # Check if the PR is merged
-          PR_STATE=$(gh pr view --json state,mergedAt -q '.state')
-          MERGED_AT=$(gh pr view --json state,mergedAt -q '.mergedAt')
-
-          if [[ "${PR_STATE}" == "MERGED" ]]; then
-            echo "PR merged at: $MERGED_AT"
-            exit 0
-          fi
-          echo "PR state is ${PR_STATE}"
-
-          # Check for timeout
-          CURRENT_TIME=$(date +%s)
-          ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
-
-          if [[ "${ELAPSED_TIME}" -gt "${TIMEOUT}" ]]; then
-            echo "Timeout waiting for PR to merge."
-            exit 1
-          fi
-
-          # Wait for $INTERVAL seconds before checking again
-          sleep "$INTERVAL"
-        done
-
-    - name: 'Close PR and delete branch upon failure to merge'
-      if: ${{ failure() }}
-      env:
-        GH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).coverage_github_token }}
-      working-directory: 'rspec'
-      run: |
-        PR_URL=$(gh pr view --json url --jq '.url')
-        gh pr close "$PR_URL" --delete-branch
+        git push --force-with-lease origin $TMP_BRANCH:$TMP_BRANCH
+        git push --force-with-lease origin $TMP_BRANCH:dogfood/$TMP_BRANCH
 
     - name: 'Notify on slack about the failure'
       if: ${{ failure() }}


### PR DESCRIPTION
* trigger of `update-coverage` run: https://github.com/SonarSource/rspec/actions/runs/15142120153
* trigger of `dogfood` octopus: https://github.com/SonarSource/rspec/actions/runs/15142249897
* deploy of `dogfood-automerge`: https://github.com/SonarSource/rspec/actions/runs/15142223258/job/42569016997