### PR TITLE
Modify rule S2384: improve sentence to fix typo

### DIFF
--- a/rules/S2384/java/rule.adoc
+++ b/rules/S2384/java/rule.adoc
@@ -12,8 +12,7 @@ This rule checks that private arrays, collections and Dates are not stored or re
 
 The rule violation is not reported for mutable values stored in private methods if no non-private methods directly passes a mutable parameter to them.
 
-Similarly, the rule violation is not reported for mutable values returned by a private getter, when the getter's value is not returned directly by a non-proviate method.
-
+Similarly, rule violations are not reported for mutable values returned by a private getter if that getter's value is not directly exposed by a non-private method.
 
 === Noncompliant code example
 


### PR DESCRIPTION
There was a typo in the word "private".

<!--
Jira Automation:

* Mention existing issue in the PR title to move it around automatically.
* Mention existing issue in the PR description and a sub-task will be created for you to track this rspec PR separately.

No issue is created by default.
-->

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

