### PR TITLE
Modify rules S5308,S6183: Fix section level

### DIFF
--- a/rules/S5308/cfamily/rule.adoc
+++ b/rules/S5308/cfamily/rule.adoc
@@ -17,7 +17,7 @@ If the program fails to acquire more privileges to execute a privileged operatio
 However, if the program silently fails to drop its privileges, it will continue to run the subsequent operations with more privileges than expected, which poses a _serious_ security risk.
 
 
-== Example program that changes between privileged and unprivileged mode
+=== Example program that changes between privileged and unprivileged mode
 
 A brief example on how ``++setuid++`` can be used and how to correctly check its return value is given in what follows.
 

--- a/rules/S6183/cfamily/rule.adoc
+++ b/rules/S6183/cfamily/rule.adoc
@@ -127,7 +127,7 @@ bool fun(int x, std::vector<int> const& v) {
 ----
 
 
-== Interactions with associated rule S6214
+=== Interactions with associated rule S6214
 
 Note that this rule (S6183) deliberately avoids intersection with S6214.
 


### PR DESCRIPTION
See the discussion on Slack:
https://sonarsource.slack.com/archives/CFTDKT6RW/p1748421280851259

Fixing this: ![image](https://github.com/user-attachments/assets/d677a8e9-1d88-4392-b994-4b2fceb9c6c9)

https://rules.sonarsource.com/cpp/RSPEC-6183/
https://rules.sonarsource.com/cpp/RSPEC-5308/


