### PR TITLE
JS-676 Resore js mapping on rspec website

### DIFF
--- a/frontend/src/utils/useRuleCoverage.ts
+++ b/frontend/src/utils/useRuleCoverage.ts
@@ -20,7 +20,7 @@ const languageToSonarpedia = new Map<string, string[]>(Object.entries({
   'ruby': ['RUBY'],
   'go': ['GO'],
   'java': ['JAVA'],
-  'javascript': ['JAVASCRIPT', 'JS', 'TYPESCRIPT'],
+  'javascript': ['js', 'ts'],
   'jcl': ['JCL'],
   'php': ['PHP'],
   'pli': ['PLI'],


### PR DESCRIPTION
[JS-676](https://sonarsource.atlassian.net/browse/JS-676)

I don't know how to test this, as npm install fails. However, running with a debugger showed that these keys were used to access the downloaded "coverage_rules.json" blob and they had incorrect possible keys.