### PR TITLE
Remove some react dependencies

### DIFF
--- a/rules/S1534/javascript/metadata.json
+++ b/rules/S1534/javascript/metadata.json
@@ -19,9 +19,6 @@
     "replacementRules": [],
     "legacyKeys": [
       "DuplicatePropertyName"
-    ],
-    "requiredDependency": [
-      "react"
     ]
   },
   "defaultSeverity": "Major",

--- a/rules/S6479/javascript/metadata.json
+++ b/rules/S6479/javascript/metadata.json
@@ -17,11 +17,6 @@
     "jsx",
     "performance"
   ],
-  "extra": {
-    "requiredDependency": [
-      "react"
-    ]
-  },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6479",
   "sqKey": "S6479",

--- a/rules/S6480/javascript/metadata.json
+++ b/rules/S6480/javascript/metadata.json
@@ -17,11 +17,6 @@
     "jsx",
     "performance"
   ],
-  "extra": {
-    "requiredDependency": [
-      "react"
-    ]
-  },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6480",
   "sqKey": "S6480",

--- a/rules/S6749/javascript/metadata.json
+++ b/rules/S6749/javascript/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Redundant React fragments should be removed",
+  "title": "Redundant JSX fragments should be removed",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/rules/S6749/javascript/rule.adoc
+++ b/rules/S6749/javascript/rule.adoc
@@ -1,6 +1,6 @@
 == Why is this an issue?
 
-React fragments are a feature in React that allows you to group multiple elements together without adding an extra DOM element. They are a way to return multiple elements from a component's render method without requiring a wrapping parent element.
+JSX fragments is a feature that allows you to group multiple elements together without adding an extra DOM element. They are a way to return multiple elements from a component's render method without requiring a wrapping parent element.
 
 However, a fragment is redundant if it contains only one child, or if it is the child of an HTML element.
 

--- a/rules/S6770/javascript/metadata.json
+++ b/rules/S6770/javascript/metadata.json
@@ -9,11 +9,6 @@
   "tags": [
     "react"
   ],
-  "extra": {
-    "requiredDependency": [
-      "react"
-    ]
-  },
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-6770",
   "sqKey": "S6770",

--- a/rules/S6772/javascript/metadata.json
+++ b/rules/S6772/javascript/metadata.json
@@ -9,11 +9,6 @@
   "tags": [
     "react"
   ],
-  "extra": {
-    "requiredDependency": [
-      "react"
-    ]
-  },
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6772",
   "sqKey": "S6772",


### PR DESCRIPTION
While going through the ruling, sometimes the react rules are only pertaining to jsx. In those cases, we shouldn't require react to be a dependency.