### PR TITLE
S817 Remove diff highlighting from example

### DIFF
--- a/rules/S817/cfamily/rule.adoc
+++ b/rules/S817/cfamily/rule.adoc
@@ -7,7 +7,7 @@ Therefore, only string literals with the same prefix should be concatenated toge
 
 === Noncompliant code example
 
-[source,cpp,diff-id=1,diff-type=noncompliant]
+[source,cpp]
 ----
 wchar_t n_array[] = "Hello" L"World";     // Noncompliant
 wchar_t w_array[] = L"Hello" "World";     // Noncompliant
@@ -23,7 +23,7 @@ auto mixed3 = u8"Hello" u"World";         // Noncompliant
 
 === Compliant solution
 
-[source,cpp,diff-id=1,diff-type=compliant]
+[source,cpp]
 ----
 char n_array[] = "Hello" "World";         // Compliant
 wchar_t w_array[] = L"Hello" L"World";    // Compliant


### PR DESCRIPTION
The highlighting was introduced in #5138, but it looked noisy to me on peach (because it highlights the whole example).