### PR TITLE
Extract common github action impacts into shared content

### DIFF
--- a/rules/S7630/githubactions/rule.adoc
+++ b/rules/S7630/githubactions/rule.adoc
@@ -15,39 +15,13 @@ For instance, if a pull request title contains shell metacharacters like `$(whoa
 
 The consequences of successful script injection attacks in GitHub Actions can be severe and far-reaching:
 
-==== Information disclosure
+include::../../../shared_content/githubactions/impact/information_disclosure.adoc[]
 
-Attackers can extract sensitive information from the runner environment, including:
+include::../../../shared_content/githubactions/impact/system_compromise.adoc[]
 
-* Repository secrets and environment variables
-* Authentication tokens and API keys
-* Build artifacts and deployment credentials
+include::../../../shared_content/githubactions/impact/supply_chain_attacks.adoc[]
 
-==== System compromise
-
-Successful command injection allows attackers to:
-
-* Execute arbitrary commands on the runner
-* Install malware or backdoors
-* Access other resources available to the runner
-
-==== Supply chain attacks
-
-Compromised workflows can be used to:
-
-* Inject malicious code into build artifacts
-* Modify dependencies or packages being published
-* Compromise downstream systems that consume the artifacts
-
-==== Repository manipulation
-
-Attackers may be able to:
-
-* Modify repository contents or history
-* Create unauthorized releases or tags
-* Access or modify other repositories the workflow has access to
-
-The impact is particularly severe because GitHub Actions runners often have elevated privileges and access to sensitive resources, making them attractive targets for attackers.
+include::../../../shared_content/githubactions/impact/repository_manipulation.adoc[]
 
 == How to fix it
 

--- a/shared_content/githubactions/impact/information_disclosure.adoc
+++ b/shared_content/githubactions/impact/information_disclosure.adoc
@@ -1,0 +1,7 @@
+==== Information disclosure
+
+Attackers can extract sensitive information from the runner environment, including:
+
+* Repository secrets and environment variables
+* Authentication tokens and API keys
+* Build artifacts and deployment credentials

--- a/shared_content/githubactions/impact/repository_manipulation.adoc
+++ b/shared_content/githubactions/impact/repository_manipulation.adoc
@@ -1,0 +1,9 @@
+==== Repository manipulation
+
+Attackers may be able to:
+
+* Modify repository contents or history
+* Create unauthorized releases or tags
+* Access or modify other repositories the workflow has access to
+
+The impact is particularly severe because GitHub Actions runners often have elevated privileges and access to sensitive resources, making them attractive targets for attackers.

--- a/shared_content/githubactions/impact/supply_chain_attacks.adoc
+++ b/shared_content/githubactions/impact/supply_chain_attacks.adoc
@@ -1,0 +1,7 @@
+==== Supply chain attacks
+
+Compromised workflows can be used to:
+
+* Inject malicious code into build artifacts
+* Modify dependencies or packages being published
+* Compromise downstream systems that consume the artifacts

--- a/shared_content/githubactions/impact/system_compromise.adoc
+++ b/shared_content/githubactions/impact/system_compromise.adoc
@@ -1,0 +1,7 @@
+==== System compromise
+
+Successful command injection allows attackers to:
+
+* Execute arbitrary commands on the runner
+* Install malware or backdoors
+* Access other resources available to the runner


### PR DESCRIPTION
<!--
Jira Automation:

* Mention existing issue in the PR title to move it around automatically.
* Mention existing issue in the PR description and a sub-task will be created for you to track this rspec PR separately.

No issue is created by default.
-->
This PR moves the impacts from S7630 under github actions shared content as they will likely be useful for other rules, too.
Done as part of APPSEC-2536, wanted to have this separated as we might not use these for it, but the work was already done.


## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)

