### PR TITLE
SONARGO-468 Adapt S2053 rule description for Argon2

### DIFF
--- a/rules/S2053/go/rule.adoc
+++ b/rules/S2053/go/rule.adoc
@@ -61,6 +61,7 @@ uses a cryptographically secure pseudo-random number generator.
 == Resources
 
 include::../common/resources/standards.adoc[]
+
 * Argon2 RFC - https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice[RFC 9106
 Argon2 Memory-Hard Function for Password Hashing and Proof-of-Work Applications - 4. Parameter Choice]
 

--- a/rules/S2053/go/rule.adoc
+++ b/rules/S2053/go/rule.adoc
@@ -51,7 +51,7 @@ func example(password []byte) {
 
 include::../common/fix/salt.adoc[]
 
-For Argon2, the recommended minimum from the RFC is 16 bytes.
+For Argon2, the recommended minimum from the RFC is 16 bytes (128 bits).
 
 Here, the compliant code example ensures the salt is random and has a sufficient
 length by calling the `crypto.rand.Read` function. This function internally
@@ -62,6 +62,9 @@ uses a cryptographically secure pseudo-random number generator.
 
 include::../common/resources/standards.adoc[]
 
+* PBKDF2 RFC - https://www.rfc-editor.org/rfc/rfc2898.html[RFC 2898 PKCS #5: Password-Based Cryptography Specification Version 2.0]
+* Scrypt RFC - https://www.rfc-editor.org/rfc/rfc7914.html[RFC 7914 The scrypt Password-Based Key Derivation Function]
+* Bcrypt reference - https://www.usenix.org/legacy/events/usenix99/provos/provos.pdf[Provos, N. and D. Mazieres, "A Future-Adaptable Password Scheme", USENIX 1999, June 1999]
 * Argon2 RFC - https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice[RFC 9106
 Argon2 Memory-Hard Function for Password Hashing and Proof-of-Work Applications - 4. Parameter Choice]
 

--- a/rules/S2053/go/rule.adoc
+++ b/rules/S2053/go/rule.adoc
@@ -51,6 +51,8 @@ func example(password []byte) {
 
 include::../common/fix/salt.adoc[]
 
+For Argon2, the recommended minimum from the RFC is 16 bytes.
+
 Here, the compliant code example ensures the salt is random and has a sufficient
 length by calling the `crypto.rand.Read` function. This function internally
 uses a cryptographically secure pseudo-random number generator.
@@ -59,6 +61,8 @@ uses a cryptographically secure pseudo-random number generator.
 == Resources
 
 include::../common/resources/standards.adoc[]
+* Argon2 RFC - https://www.rfc-editor.org/rfc/rfc9106.html#name-parameter-choice[RFC 9106
+Argon2 Memory-Hard Function for Password Hashing and Proof-of-Work Applications - 4. Parameter Choice]
 
 ifdef::env-github,rspecator-view[]
 


### PR DESCRIPTION
[SONARGO-468](https://sonarsource.atlassian.net/browse/SONARGO-468)



[SONARGO-468]: https://sonarsource.atlassian.net/browse/SONARGO-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ