### PR TITLE
APPSEC-2665 S6380/S6382: Replace deprecated terraform azurerm_function_app references

### DIFF
--- a/rules/S6380/terraform/rule.adoc
+++ b/rules/S6380/terraform/rule.adoc
@@ -10,7 +10,7 @@ For https://azure.microsoft.com/en-us/services/app-service/[App Services and equ
 
 [source,terraform,diff-id=1,diff-type=noncompliant]
 ----
-resource "azurerm_function_app" "example" {
+resource "azurerm_linux_function_app" "example" {
   name = "example"
 
   auth_settings {
@@ -80,7 +80,7 @@ For https://azure.microsoft.com/en-us/services/app-service/[App Services and equ
 
 [source,terraform,diff-id=1,diff-type=compliant]
 ----
-resource "azurerm_function_app" "example" {
+resource "azurerm_linux_function_app" "example" {
   name = "example"
 
   auth_settings {
@@ -183,6 +183,10 @@ Note: App Service and equivalents resources:
 * ``app_service_slot``
 * ``function_app``
 * ``function_app_slot``
+* ``linux_function_app``
+* ``linux_function_app_slot``
+* ``windows_function_app``
+* ``windows_function_app_slot``
 * ``linux_web_app``
 * ``windows_web_app``
 === Highlighting

--- a/rules/S6382/terraform/rule.adoc
+++ b/rules/S6382/terraform/rule.adoc
@@ -23,7 +23,7 @@ For https://azure.microsoft.com/en-us/services/logic-apps/[Logic App Standards] 
 
 [source,terraform,diff-id=2,diff-type=noncompliant]
 ----
-resource "azurerm_function_app" "example" {
+resource "azurerm_linux_function_app" "example" {
   client_cert_mode = "Optional" # Sensitive
 }
 ----
@@ -72,7 +72,7 @@ For https://azure.microsoft.com/en-us/services/logic-apps/[Logic App Standards] 
 
 [source,terraform,diff-id=2,diff-type=compliant]
 ----
-resource "azurerm_function_app" "example" {
+resource "azurerm_linux_function_app" "example" {
   client_cert_mode = "Required"
 }
 ----


### PR DESCRIPTION
[APPSEC-2665](https://sonarsource.atlassian.net/browse/APPSEC-2665)

Part of APPSEC-2395
<!--
Jira Automation:

* Mention existing issue in the PR title to move it around automatically.
* Mention existing issue in the PR description and a sub-task will be created for you to track this rspec PR separately.

No issue is created by default.
-->

## Review

A dedicated reviewer checked the rule description successfully for:

- [ ] logical errors and incorrect information
- [ ] information gaps and missing content
- [ ] text style and tone
- [ ] PR summary and labels follow [the guidelines](https://github.com/SonarSource/rspec/#to-modify-an-existing-rule)



[APPSEC-2665]: https://sonarsource.atlassian.net/browse/APPSEC-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ